### PR TITLE
Cross build for Dotty-0.27.0-RC1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,3 @@
-val scala2Version = "2.13.3"
 val projectName = "parsley"
 val parsleyVersion = "1.5.0"
 
@@ -10,10 +9,20 @@ lazy val root = project.in(file("."))
     version := parsleyVersion,
     target in Compile in doc := baseDirectory.value / "docs",
 
-    libraryDependencies ++= Seq("org.scalactic" %% "scalactic" % "3.0.8" % "test",
-                                "org.scalatest" %% "scalatest" % "3.0.8" % "test"),
-    scalaVersion := scala2Version,
-    crossScalaVersions := List(scala2Version, "2.12.12"),
+    libraryDependencies ++= Seq(
+      "org.scalactic" %% "scalactic" % "3.2.2" % Test,
+      "org.scalatest" %% "scalatest" % "3.2.2" % Test
+    ),
+    scalaVersion := "2.13.3",
+    crossScalaVersions := (scalaVersion.value :: List("2.12.12", "0.27.0-RC1")),
 
     scalacOptions ++= Seq("-deprecation", "-unchecked"),
+    scalacOptions ++= {
+      if (isDotty.value)
+        Seq(
+          "-language:implicitConversions",
+          "-source:3.0-migration"
+        )
+      else Seq.empty
+    }
   )

--- a/src/main/scala-0.27/parsley/XCompat.scala
+++ b/src/main/scala-0.27/parsley/XCompat.scala
@@ -1,0 +1,13 @@
+package parsley
+
+import scala.collection.mutable
+
+private[parsley] object XCompat {
+  def refl[A]: A =:= A = <:<.refl
+
+  def substituteCo[F[_], A, B](fa: F[A])(implicit ev: A =:= B): F[B] =
+    ev.substituteCo[F](fa)
+
+  def mapValuesInPlace[A, B](m: mutable.Map[A, B])(f: (A, B) => B): m.type =
+    m.mapValuesInPlace(f)
+}

--- a/src/main/scala/parsley/Cont.scala
+++ b/src/main/scala/parsley/Cont.scala
@@ -59,7 +59,7 @@ private [parsley] object Cont
     }
 }
 
-private [parsley] class Id[_, A](var x: A)
+private [parsley] class Id[R, A](var x: A)
 private [parsley] object Id
 {
     implicit val ops: ContOps[Id] = new ContOps[Id]

--- a/src/main/scala/parsley/Parsley.scala
+++ b/src/main/scala/parsley/Parsley.scala
@@ -1032,7 +1032,7 @@ private [parsley] object DeepEmbedding
             }
         override def findLetsAux[Cont[_, _]](implicit seen: Set[Parsley[_]], state: LetFinderState, ops: ContOps[Cont]): Cont[Unit, Unit] =
             for (_ <- _p.findLets; _ <- _q.findLets) yield ()
-        @tailrec override def optimise: Parsley[B] = p match
+        /* @tailrec */ override def optimise: Parsley[B] = p match
         {
             // pure _ *> p = p
             case _: Pure[_] => q
@@ -1120,7 +1120,7 @@ private [parsley] object DeepEmbedding
             }
         override def findLetsAux[Cont[_, _]](implicit seen: Set[Parsley[_]], state: LetFinderState, ops: ContOps[Cont]): Cont[Unit, Unit] =
             for (_ <- _p.findLets; _ <- _q.findLets) yield ()
-        @tailrec override def optimise: Parsley[A] = q match
+        /* @tailrec */ override def optimise: Parsley[A] = q match
         {
             // p <* pure _ = p
             case _: Pure[_] => p

--- a/src/main/scala/parsley/package.scala
+++ b/src/main/scala/parsley/package.scala
@@ -166,7 +166,7 @@ package object parsley
 
         def setup(set: Set[Char]): (Int, Array[Int]) =
         {
-            val max = if (set.isEmpty) -1 else set.max
+            val max = if (set.isEmpty) -1 else set.max.toInt
             val arr = new Array[Int]((max >> 5) + 1)
 
             for (c <- set)

--- a/src/test/scala/parsley/CharTests.scala
+++ b/src/test/scala/parsley/CharTests.scala
@@ -1,3 +1,5 @@
+package parsley
+
 import parsley.Char._
 import parsley.{Failure, runParser}
 import parsley.Parsley._

--- a/src/test/scala/parsley/CombinatorTests.scala
+++ b/src/test/scala/parsley/CombinatorTests.scala
@@ -1,3 +1,5 @@
+package parsley
+
 import parsley.{Failure, Success, Var, runParser}
 import parsley.Combinator._
 import parsley.Parsley._

--- a/src/test/scala/parsley/CoreTests.scala
+++ b/src/test/scala/parsley/CoreTests.scala
@@ -1,3 +1,5 @@
+package parsley
+
 import parsley.{Failure, Parsley, Success, Var, runParser}
 import parsley.Parsley._
 import parsley.Char.{char, satisfy}

--- a/src/test/scala/parsley/ErrorMessageTests.scala
+++ b/src/test/scala/parsley/ErrorMessageTests.scala
@@ -1,3 +1,5 @@
+package parsley
+
 import parsley.Combinator.eof
 import parsley.Parsley._
 import parsley.{Failure, Parsley, runParser}

--- a/src/test/scala/parsley/ExpressionParserTests.scala
+++ b/src/test/scala/parsley/ExpressionParserTests.scala
@@ -1,3 +1,5 @@
+package parsley
+
 import parsley.Char.digit
 import parsley.Implicits.{charLift, stringLift}
 import parsley.Combinator.{chainPost, chainPre, chainl1, chainr1}
@@ -25,7 +27,7 @@ class ExpressionParserTests extends ParsleyTest
     }
     it must "not leave the stack in an inconsistent state on failure" in
     {
-        val p = chainPost[Int]('1' #> 1, (col #>[Int => Int] (_ + 1)) <* '+')
+        val p = chainPost[Int]('1' #> 1, (col.#>[Int => Int](_ + 1)) <* '+')
         val q = chainl1[Int, Int](p, '*' #> (_ * _))
         noException should be thrownBy runParser(q, "1+*1+")
     }
@@ -93,7 +95,7 @@ class ExpressionParserTests extends ParsleyTest
     }
     it must "not leave the stack in an inconsistent state on failure" in
     {
-        val p = chainl1[Int, Int]('1' #> 1, (col #>[(Int, Int) => Int] (_ + _)) <* '+')
+        val p = chainl1[Int, Int]('1' #> 1, (col.#>[(Int, Int) => Int](_ + _)) <* '+')
         val q = chainl1[Int, Int](p, '*' #> (_ * _))
         noException should be thrownBy runParser(q, "1+1*1+1")
     }

--- a/src/test/scala/parsley/ParsleyTest.scala
+++ b/src/test/scala/parsley/ParsleyTest.scala
@@ -1,3 +1,7 @@
-import org.scalatest.{Assertions, Matchers, FlatSpec}
+package parsley
 
-abstract class ParsleyTest extends FlatSpec with Matchers with Assertions
+import org.scalatest.Assertions
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+abstract class ParsleyTest extends AnyFlatSpec with Matchers with Assertions

--- a/src/test/scala/parsley/TokeniserTests.scala
+++ b/src/test/scala/parsley/TokeniserTests.scala
@@ -1,3 +1,5 @@
+package parsley
+
 import parsley._
 import parsley.Char.{alphaNum, letter, whitespace, oneOf => inSet}
 import parsley.Implicits.charLift


### PR DESCRIPTION
We use `-source:3.0-migration` in order to cross build between Scala 2 and Dotty.