### PR TITLE
Reduce

### DIFF
--- a/src/main/scala-2.12/parsley/XCompat.scala
+++ b/src/main/scala-2.12/parsley/XCompat.scala
@@ -3,7 +3,9 @@ package parsley
 import scala.collection.mutable
 import scala.language.higherKinds
 
-private[parsley] object XCompat {
+private [parsley] object XCompat {
+  def isIdentityWrap[A, B](f: A => B): Boolean = f eq $conforms[A]
+
   def refl[A]: A =:= A = implicitly[A =:= A]
 
   implicit class Subtitution[A, B](ev: A =:= B) {

--- a/src/main/scala-2.13+/parsley/XCompat.scala
+++ b/src/main/scala-2.13+/parsley/XCompat.scala
@@ -4,4 +4,5 @@ import scala.collection.mutable
 
 private[parsley] object XCompat {
   def refl[A]: A =:= A = <:<.refl
+  def isIdentityWrap[A, B](f: A => B): Boolean = f eq refl
 }

--- a/src/main/scala/parsley/Parsley.scala
+++ b/src/main/scala/parsley/Parsley.scala
@@ -250,7 +250,7 @@ object Parsley
           * @param f combining function
           * @return the result of folding the results of `p` with `f` and `k`
           */
-        def foldLeft[B](k: B)(f: (B, A) => B): Parsley[B] = chain.postfix(pure(k), this.map(x => (y: B) => f(y, x)))
+        def foldLeft[B](k: B)(f: (B, A) => B): Parsley[B] = new Parsley(new deepembedding.Chainl(pure(k).internal, p.internal, pure(f).internal))
         /**
           * A fold for a parser: `p.foldRight1(k)(f)` will try executing `p` many times until it fails, combining the
           * results with right-associative application of `f` with a `k` at the right-most position. It must parse `p`
@@ -279,7 +279,7 @@ object Parsley
           */
         def foldLeft1[B](k: B)(f: (B, A) => B): Parsley[B] = {
             lazy val q: Parsley[A] = p
-            chain.postfix(q.map(f(k, _)), q.map(x => (y: B) => f(y, x)))
+            new Parsley(new deepembedding.Chainl(q.map(f(k, _)).internal, q.internal, pure(f).internal))
         }
         /**
           * A reduction for a parser: `p.reduceRight(op)` will try executing `p` many times until it fails, combining the

--- a/src/main/scala/parsley/combinator.scala
+++ b/src/main/scala/parsley/combinator.scala
@@ -92,8 +92,7 @@ object combinator {
       *  of values returned by `p`.*/
     def sepBy1[A, B](p: =>Parsley[A], sep: =>Parsley[B]): Parsley[List[A]] = {
         lazy val _p = p
-        lazy val _sep = sep
-        _p <::> many(_sep *> _p)
+        _p <::> many(sep *> _p)
     }
 
     /**`sepEndBy(p, sep)` parses *zero* or more occurrences of `p`, separated and optionally ended

--- a/src/main/scala/parsley/internal/instructions/IterativeInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/IterativeInstrs.scala
@@ -101,8 +101,7 @@ private [internal] final class ChainPre(var label: Int) extends JumpInstr with S
     // $COVERAGE-ON$
     override def copy: ChainPre = new ChainPre(label)
 }
-private [internal] final class Chainl[A, B](var label: Int, _wrap: A => B) extends JumpInstr with Stateful {
-    private [this] val wrap: Any => B = _wrap.asInstanceOf[Any => B]
+private [internal] final class Chainl(var label: Int) extends JumpInstr with Stateful {
     private [this] var acc: Any = _
     override def apply(ctx: Context): Unit = {
         if (ctx.status eq Good) {
@@ -112,7 +111,7 @@ private [internal] final class Chainl[A, B](var label: Int, _wrap: A => B) exten
             if (acc == null) {
                 // after this point, the inputCheck will roll back one too many items on the stack, because this item
                 // was consumed. It should be adjusted
-                acc = op(wrap(ctx.stack.upop()), y)
+                acc = op(ctx.stack.upop(), y)
                 ctx.handlers.head.stacksz -= 1
             }
             else acc = op(acc, y)
@@ -125,7 +124,7 @@ private [internal] final class Chainl[A, B](var label: Int, _wrap: A => B) exten
                 // if acc is null this is first entry, p already on the stack!
                 if (acc != null) ctx.pushAndContinue(acc)
                 // but p does need to be wrapped
-                else ctx.exchangeAndContinue(wrap(ctx.stack.upeek))
+                else ctx.exchangeAndContinue(ctx.stack.upeek)
             }
             acc = null
         }
@@ -133,7 +132,7 @@ private [internal] final class Chainl[A, B](var label: Int, _wrap: A => B) exten
     // $COVERAGE-OFF$
     override def toString: String = s"Chainl($label)"
     // $COVERAGE-ON$
-    override def copy: Chainl[A, B] = new Chainl(label, wrap)
+    override def copy: Chainl = new Chainl(label)
 }
 
 private [instructions] sealed trait DualHandler {

--- a/src/test/scala/parsley/CoreTests.scala
+++ b/src/test/scala/parsley/CoreTests.scala
@@ -4,7 +4,7 @@ import parsley.{Reg => _}
 import parsley.Parsley.{lift2 => _, lift1 => _, lift3 => _, get => _, gets => _, modify => _, put => _, local => _, rollback => _, many => _, _}
 import parsley.combinator.many
 import parsley.lift._
-import parsley.character.{char, satisfy, digit, anyChar}
+import parsley.character.{char, satisfy, digit, anyChar, string}
 import parsley.implicits.{charLift, stringLift}
 import parsley.registers._
 
@@ -296,6 +296,22 @@ class CoreTests extends ParsleyTest {
         val p = digit.foldLeft1(0)((x, d) => x * 10 + d.asDigit)
         p.runParser("") shouldBe a [Failure]
         p.runParser("123") should be (Success(123))
+    }
+    "reduceRightOption" should "return Some on success" in {
+        val p = string("a").reduceRightOption((s1, s2) => s"$s1($s2)")
+        p.runParser("aaaaa") shouldBe Success(Some("a(a(a(a(a))))"))
+    }
+    it should "return None if there is no p" in {
+        val p = string("a").reduceRightOption((s1, s2) => s"$s1($s2)")
+        p.runParser("") shouldBe Success(None)
+    }
+    "reduceLeftOption" should "return Some on success" in {
+        val p = string("a").reduceLeftOption((s1, s2) => s"($s1)$s2")
+        p.runParser("aaaaa") shouldBe Success(Some("((((a)a)a)a)a"))
+    }
+    it should "return None if there is no p" in {
+        val p = string("a").reduceLeftOption((s1, s2) => s"($s1)$s2")
+        p.runParser("") shouldBe Success(None)
     }
 
     "stack overflows" should "not occur" in {


### PR DESCRIPTION
Added the `reduceLeft`, `reduceLeftOption`, `reduceRight` and `reduceRightOption` combinators.

In addition, I've managed to improve the performance of `foldLeft` and `foldLeft1` substantially, as well as a minor increase to the performance of `chain.left1` and `chain.left` when `A =:= B`.