### PR TITLE
Added synchronisation to AST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /bin
 /wiki
 /inputs
+**/playground
 /.settings
 /.idea
 target/

--- a/src/main/scala/parsley/internal/instructions/Context.scala
+++ b/src/main/scala/parsley/internal/instructions/Context.scala
@@ -67,13 +67,6 @@ private [parsley] final class Context(private [instructions] var instrs: Array[I
     }
     // $COVERAGE-ON$
 
-    /*private [parsley] def pos: (Int, Int) = (startline, startcol)
-    private [parsley] def pos_=(pos: (Int, Int)): Unit = {
-        val (line, col) = pos
-        startline = line
-        startcol = col
-    }*/
-
     @tailrec @inline private [parsley] def runParser[A](): Result[A] = {
         //println(pretty)
         if (status eq Failed) Failure(errorMessage)
@@ -127,6 +120,8 @@ private [parsley] final class Context(private [instructions] var instrs: Array[I
     private def adjustErrors(e: UnsafeOption[String]): Unit = {
         if (offset > erroffset) {
             erroffset = offset
+            // FIXME: These get stuck at deepest error
+            // Regular parsec semantics, however says that an earlier error message may override this if it is "more meaningful"
             errcol = col
             errline = line
             unexpected = if (offset < inputsz) "\"" + nextChar + "\"" else s"end of $inputDescriptor"


### PR DESCRIPTION
When the same sub parser is used and compiled by two separate threads, it can result in a race condition involving the error relabeling mechanism. Marking the `letFinder` as synchronized appears to fix this (I've also marked `ready` as sychronized just in case). I suspect there is a more deep cause to this issue, and there is a better fix, but this will do for now. It's not even that expensive either.