### PR TITLE
Fully thread-safe AST

### DIFF
--- a/src/main/scala-2.12/parsley/XCompat.scala
+++ b/src/main/scala-2.12/parsley/XCompat.scala
@@ -4,15 +4,15 @@ import scala.collection.mutable
 import scala.language.higherKinds
 
 private [parsley] object XCompat {
-  def isIdentityWrap[A, B](f: A => B): Boolean = f eq $conforms[A]
+    def isIdentityWrap[A, B](f: A => B): Boolean = f eq $conforms[A]
 
-  def refl[A]: A =:= A = implicitly[A =:= A]
+    def refl[A]: A =:= A = implicitly[A =:= A]
 
-  implicit class Subtitution[A, B](ev: A =:= B) {
-    def substituteCo[F[_]](fa: F[A]): F[B] = fa.asInstanceOf[F[B]]
-  }
+    implicit class Subtitution[A, B](ev: A =:= B) {
+        def substituteCo[F[_]](fa: F[A]): F[B] = fa.asInstanceOf[F[B]]
+    }
 
-  implicit class MapValuesInPlace[K, V](m: mutable.Map[K, V]) {
-    def mapValuesInPlace(f: (K, V) => V): mutable.Map[K, V] = m.transform(f)
-  }
+    implicit class MapValuesInPlace[K, V](m: mutable.Map[K, V]) {
+        def mapValuesInPlace(f: (K, V) => V): mutable.Map[K, V] = m.transform(f)
+    }
 }

--- a/src/main/scala/parsley/expr/Fixity.scala
+++ b/src/main/scala/parsley/expr/Fixity.scala
@@ -1,5 +1,7 @@
 package parsley.expr
 
+import scala.language.higherKinds
+
 /**
   * Denotes the fixity and associativity of an operator. Importantly, it also specifies the type of the
   * of the operations themselves. For non-monolithic structures this is described by `fixity.GOp` and

--- a/src/main/scala/parsley/internal/deepembedding/GeneralisedEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/GeneralisedEmbedding.scala
@@ -7,10 +7,10 @@ import scala.language.higherKinds
 
 // Core Embedding
 private [parsley] abstract class Singleton[A](pretty: String, instr: =>instructions.Instr) extends Parsley[A] {
-    final override def preprocess[Cont[_, +_]: ContOps, A_ >: A](implicit seen: Set[Parsley[_]], sub: SubMap,
-                                                                 label: UnsafeOption[String]): Cont[Unit, Parsley[A_]] = result(this)
     final override def findLetsAux[Cont[_, +_]: ContOps]
         (implicit seen: Set[Parsley[_]], state: LetFinderState, label: UnsafeOption[String]): Cont[Unit, Unit] = result(())
+    final override def preprocess[Cont[_, +_]: ContOps, A_ >: A](implicit seen: Set[Parsley[_]], sub: SubMap,
+                                                                 label: UnsafeOption[String]): Cont[Unit, Parsley[A_]] = result(this)
     final override def codeGen[Cont[_, +_]: ContOps](implicit instrs: InstrBuffer, state: CodeGenState): Cont[Unit, Unit] = {
         result(instrs += instr)
     }
@@ -21,13 +21,13 @@ private [parsley] abstract class Singleton[A](pretty: String, instr: =>instructi
 
 private [deepembedding] abstract class SingletonExpect[A](pretty: String, builder: UnsafeOption[String] => SingletonExpect[A], instr: instructions.Instr)
     extends Parsley[A] {
+    final override def findLetsAux[Cont[_, +_]: ContOps]
+        (implicit seen: Set[Parsley[_]], state: LetFinderState, label: UnsafeOption[String]): Cont[Unit, Unit] = result(())
     final override def preprocess[Cont[_, +_]: ContOps, A_ >: A](implicit seen: Set[Parsley[_]], sub: SubMap,
                                                                  label: UnsafeOption[String]): Cont[Unit, Parsley[A]] = {
         if (label == null) result(this)
         else result(builder(label))
     }
-    final override def findLetsAux[Cont[_, +_]: ContOps]
-        (implicit seen: Set[Parsley[_]], state: LetFinderState, label: UnsafeOption[String]): Cont[Unit, Unit] = result(())
     final override def codeGen[Cont[_, +_]: ContOps](implicit instrs: InstrBuffer, state: CodeGenState): Cont[Unit, Unit] = {
         result(instrs += instr)
     }
@@ -36,18 +36,16 @@ private [deepembedding] abstract class SingletonExpect[A](pretty: String, builde
     // $COVERAGE-ON$
 }
 
-private [deepembedding] abstract class Unary[A, B](_p: =>Parsley[A])(pretty: String => String, empty: String => Unary[A, B]) extends Parsley[B] {
+private [deepembedding] abstract class Unary[A, B](__p: =>Parsley[A])(pretty: String => String, empty: String => Unary[A, B]) extends Parsley[B] {
+    private lazy val _p = __p
     private [deepembedding] var p: Parsley[A] = _
     protected val childRepeats: Int = 1
     protected val numInstrs: Int
     final override def findLetsAux[Cont[_, +_]: ContOps]
-        (implicit seen: Set[Parsley[_]], state: LetFinderState, label: UnsafeOption[String]): Cont[Unit,Unit] = this.synchronized {
-        p = _p
-        p.findLets
-    }
+        (implicit seen: Set[Parsley[_]], state: LetFinderState, label: UnsafeOption[String]): Cont[Unit,Unit] = _p.findLets
     override def preprocess[Cont[_, +_]: ContOps, B_ >: B](implicit seen: Set[Parsley[_]], sub: SubMap,
                                                            label: UnsafeOption[String]): Cont[Unit, Parsley[B_]] =
-        for (p <- this.p.optimised) yield empty(label).ready(p)
+        for (p <- _p.optimised) yield empty(label).ready(p)
     private [deepembedding] def ready(p: Parsley[A]): this.type = {
         processed = true
         this.p = p
@@ -59,22 +57,20 @@ private [deepembedding] abstract class Unary[A, B](_p: =>Parsley[A])(pretty: Str
     // $COVERAGE-ON$
 }
 
-private [deepembedding] abstract class Binary[A, B, C](_left: =>Parsley[A], _right: =>Parsley[B])(pretty: (String, String) => String, empty: =>Binary[A, B, C])
+private [deepembedding] abstract class Binary[A, B, C](__left: =>Parsley[A], __right: =>Parsley[B])(pretty: (String, String) => String, empty: =>Binary[A, B, C])
     extends Parsley[C] {
+    private lazy val _left = __left
+    private lazy val _right = __right
     private [deepembedding] var left: Parsley[A] = _
     private [deepembedding] var right: Parsley[B] = _
     protected val numInstrs: Int
     protected val leftRepeats: Int = 1
     protected val rightRepeats: Int = 1
     final override def findLetsAux[Cont[_, +_]: ContOps]
-        (implicit seen: Set[Parsley[_]], state: LetFinderState, label: UnsafeOption[String]): Cont[Unit,Unit] = this.synchronized {
-        left = _left
-        right = _right
-        left.findLets >> right.findLets
-    }
+        (implicit seen: Set[Parsley[_]], state: LetFinderState, label: UnsafeOption[String]): Cont[Unit,Unit] = _left.findLets >> _right.findLets
     final override def preprocess[Cont[_, +_]: ContOps, C_ >: C](implicit seen: Set[Parsley[_]], sub: SubMap,
                                                    label: UnsafeOption[String]): Cont[Unit, Parsley[C_]] =
-        for (left <- this.left.optimised; right <- this.right.optimised) yield {
+        for (left <- _left.optimised; right <- _right.optimised) yield {
             empty.ready(left, right)
         }
     private [deepembedding] def ready(left: Parsley[A], right: Parsley[B]): this.type = {
@@ -91,22 +87,22 @@ private [deepembedding] abstract class Binary[A, B, C](_left: =>Parsley[A], _rig
     // $COVERAGE-ON$
 }
 
-private [deepembedding] abstract class Ternary[A, B, C, D](_first: =>Parsley[A], _second: =>Parsley[B], _third: =>Parsley[C])
+private [deepembedding] abstract class Ternary[A, B, C, D](__first: =>Parsley[A], __second: =>Parsley[B], __third: =>Parsley[C])
                                                           (pretty: (String, String, String) => String, empty: =>Ternary[A, B, C, D]) extends Parsley[D] {
+    private lazy val _first: Parsley[A] = __first
+    private lazy val _second: Parsley[B] = __second
+    private lazy val _third: Parsley[C] = __third
     private [deepembedding] var first: Parsley[A] = _
     private [deepembedding] var second: Parsley[B] = _
     private [deepembedding] var third: Parsley[C] = _
     protected val numInstrs: Int
     final override def findLetsAux[Cont[_, +_]: ContOps]
-        (implicit seen: Set[Parsley[_]], state: LetFinderState, label: UnsafeOption[String]): Cont[Unit, Unit] = this.synchronized {
-        first = _first
-        second = _second
-        third = _third
-        first.findLets >> second.findLets >> third.findLets
+        (implicit seen: Set[Parsley[_]], state: LetFinderState, label: UnsafeOption[String]): Cont[Unit, Unit] = {
+        _first.findLets >> _second.findLets >> _third.findLets
     }
     final override def preprocess[Cont[_, +_]: ContOps, D_ >: D](implicit seen: Set[Parsley[_]], sub: SubMap,
                                                            label: UnsafeOption[String]): Cont[Unit, Parsley[D_]] =
-        for (first <- this.first.optimised; second <- this.second.optimised; third <- this.third.optimised) yield {
+        for (first <- _first.optimised; second <- _second.optimised; third <- _third.optimised) yield {
             empty.ready(first, second, third)
         }
     private [deepembedding] def ready(first: Parsley[A], second: Parsley[B], third: Parsley[C]): this.type = {

--- a/src/main/scala/parsley/internal/deepembedding/GeneralisedEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/GeneralisedEmbedding.scala
@@ -57,8 +57,8 @@ private [deepembedding] abstract class Unary[A, B](__p: =>Parsley[A])(pretty: St
     // $COVERAGE-ON$
 }
 
-private [deepembedding] abstract class Binary[A, B, C](__left: =>Parsley[A], __right: =>Parsley[B])(pretty: (String, String) => String, empty: =>Binary[A, B, C])
-    extends Parsley[C] {
+private [deepembedding] abstract class Binary[A, B, C](__left: =>Parsley[A], __right: =>Parsley[B])
+                                                      (pretty: (String, String) => String, empty: =>Binary[A, B, C]) extends Parsley[C] {
     private lazy val _left = __left
     private lazy val _right = __right
     private [deepembedding] var left: Parsley[A] = _

--- a/src/main/scala/parsley/internal/deepembedding/Parsley.scala
+++ b/src/main/scala/parsley/internal/deepembedding/Parsley.scala
@@ -244,6 +244,9 @@ private [parsley] class SubMap(subs: Iterable[((UnsafeOption[String], Parsley[_]
     }.toSeq: _*)
 
     def apply[A](label: UnsafeOption[String], p: Parsley[A]): Parsley[A] = subMap.getOrElse((label, p), p).asInstanceOf[Parsley[A]]
+    def update(oldSub: Subroutine[_], newSub: Subroutine[_]) = {
+        subMap((oldSub.expected, oldSub.p)) = newSub
+    }
     // $COVERAGE-OFF$
     override def toString: String = subMap.toString
     // $COVERAGE-ON$

--- a/src/main/scala/parsley/internal/deepembedding/Parsley.scala
+++ b/src/main/scala/parsley/internal/deepembedding/Parsley.scala
@@ -9,6 +9,7 @@ import parsley.internal.instructions, instructions.{Instr, JumpTable, JumpInstr,
 import parsley.internal.{UnsafeOption, ResizableArray}
 import Parsley.allocateRegisters
 import ContOps.{safeCall, GenOps, perform, result, ContAdapter}
+import parsley.XCompat._
 
 /**
   * This is the class that encapsulates the act of parsing and running an object of this class with `runParser` will
@@ -228,7 +229,7 @@ private [parsley] class LetFinderState {
     def addReg(reg: Reg[_]): Unit = _usedRegs += reg
     def notProcessedBefore(p: Parsley[_], label: UnsafeOption[String]): Boolean = _preds((label, p)) == 1
 
-    def lets: Iterable[((UnsafeOption[String], Parsley[_]), Int)] = _preds.collect[(UnsafeOption[String], Parsley[_])] {
+    def lets: Iterable[((UnsafeOption[String], Parsley[_]), Int)] = _preds.toSeq.collect {
         case (k@(label, p), refs) if refs >= 2 && !_recs(p) => k
     }.zipWithIndex
 
@@ -238,9 +239,9 @@ private [parsley] class LetFinderState {
 
 private [parsley] class SubMap(subs: Iterable[((UnsafeOption[String], Parsley[_]), Int)]) {
     println(subs)
-    private val subMap: Map[(UnsafeOption[String], Parsley[_]), Subroutine[_]] = subs.map {
+    private val subMap: mutable.Map[(UnsafeOption[String], Parsley[_]), Subroutine[_]] = mutable.Map(subs.map {
         case (k@(label, p), id) => k -> Subroutine(id)(p, label, false)
-    }.toMap
+    }.toSeq: _*)
 
     def apply[A](label: UnsafeOption[String], p: Parsley[A]): Parsley[A] = subMap.getOrElse((label, p), p).asInstanceOf[Parsley[A]]
     // $COVERAGE-OFF$

--- a/src/main/scala/parsley/internal/deepembedding/Parsley.scala
+++ b/src/main/scala/parsley/internal/deepembedding/Parsley.scala
@@ -9,7 +9,6 @@ import parsley.internal.instructions, instructions.{Instr, JumpTable, JumpInstr,
 import parsley.internal.{UnsafeOption, ResizableArray}
 import Parsley.allocateRegisters
 import ContOps.{safeCall, GenOps, perform, result, ContAdapter}
-import parsley.XCompat._
 
 /**
   * This is the class that encapsulates the act of parsing and running an object of this class with `runParser` will

--- a/src/main/scala/parsley/internal/deepembedding/PrimitiveEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/PrimitiveEmbedding.scala
@@ -52,9 +52,9 @@ private [parsley] final class Subroutine[A](var p: Parsley[A], val expected: Uns
                                                            label: UnsafeOption[String]): Cont[Unit, Parsley[A_]] = {
         // The idea here is that the label itself was already established by letFinding, so we just use expected which should be equal to label
         assert(expected == label)
-        for (p <- this.p.optimised) yield this.update(p)
+        for (p <- this.p.optimised) yield this.ready(p)
     }
-    private def update(p: Parsley[A]): this.type = {
+    private def ready(p: Parsley[A]): this.type = {
         this.p = p
         processed = true
         this

--- a/src/main/scala/parsley/internal/deepembedding/PrimitiveEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/PrimitiveEmbedding.scala
@@ -54,7 +54,11 @@ private [parsley] final case class Subroutine[A](id: Int)(val p: Parsley[A], val
         if (!processed) {
             // The idea here is that the label itself was already established by letFinding, so we just use expected which should be equal to label
             assert(expected == label)
-            for (p <- this.p.optimised) yield Subroutine(id)(p, expected, true)
+            for (p <- this.p.optimised) yield {
+                val newSub = Subroutine(id)(p, expected, true)
+                sub(this) = newSub
+                newSub
+            }
         }
         else result(this)
     }

--- a/src/main/scala/parsley/internal/deepembedding/PrimitiveEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/PrimitiveEmbedding.scala
@@ -81,7 +81,10 @@ private [parsley] final class ErrorRelabel[+A](_p: =>Parsley[A], msg: String) ex
         if (label == null) p.optimised(implicitly[ContOps[Cont]], seen, sub, msg)
         else p.optimised
     }
-    override def findLetsAux[Cont[_, +_]: ContOps](implicit seen: Set[Parsley[_]], state: LetFinderState): Cont[Unit, Unit] = p.findLets
+    override def findLetsAux[Cont[_, +_]: ContOps](implicit seen: Set[Parsley[_]], state: LetFinderState, label: UnsafeOption[String]): Cont[Unit, Unit] = {
+        if (label == null) p.findLets(implicitly[ContOps[Cont]], seen, state, msg)
+        else p.findLets
+    }
     // $COVERAGE-OFF$
     override def optimise: Parsley[A] = throw new Exception("Error relabelling should not be in optimisation!")
     override def codeGen[Cont[_, +_]: ContOps](implicit instrs: InstrBuffer, state: CodeGenState): Cont[Unit, Unit] = {

--- a/src/main/scala/parsley/internal/deepembedding/PrimitiveEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/PrimitiveEmbedding.scala
@@ -44,20 +44,21 @@ private [parsley] final class Unexpected(private [Unexpected] val msg: String, v
 private [parsley] final class Rec[A](val p: Parsley[A], val expected: UnsafeOption[String] = null)
     extends SingletonExpect[A](s"rec $p", new Rec(p, _), new instructions.Call(p.instrs, expected))
 
-private [parsley] final class Subroutine[A](val p: Parsley[A], val expected: UnsafeOption[String] = null) extends Parsley[A] {//Unary[A, A](_p)(c => s"+$c", Subroutine.empty) {
+private [parsley] final case class Subroutine[A](id: Int)(val p: Parsley[A], val expected: UnsafeOption[String], processed: Boolean) extends Parsley[A] {
     size = 1
     override def findLetsAux[Cont[_, +_]: ContOps](implicit seen: Set[Parsley[_]], state: LetFinderState, label: UnsafeOption[String]): Cont[Unit, Unit] = {
         throw new Exception("Subroutines cannot exist during let detection")
     }
     override def preprocess[Cont[_, +_]: ContOps, A_ >: A](implicit seen: Set[Parsley[_]], sub: SubMap,
                                                            label: UnsafeOption[String]): Cont[Unit, Parsley[A_]] = {
-        // something is horribly off here!
-        val self = /*if (label == null)*/ this/* else Subroutine(p, label)*/
-        //if (!processed) for (p <- this.p.optimised(implicitly[ContOps[Cont]], seen, sub, null)) yield self.ready(p)
-        /*else*/ result(self)
+        if (!processed) {
+            // The idea here is that the label itself was already established by letFinding, so we just use expected which should be equal to label
+            assert(expected == label)
+            for (p <- this.p.optimised) yield Subroutine(id)(p, expected, true)
+        }
+        else result(this)
     }
-    // Well this is frankly going to be painful... We'll need an inlining phase shortly after this is merged!
-    //override def optimise: Parsley[A] = if (p.size <= 1) p else this // This threshold might need tuning?
+    override def optimise: Parsley[A] = if (p.size <= 1) p else this // This threshold might need tuning?
     override def codeGen[Cont[_, +_]: ContOps](implicit instrs: InstrBuffer, state: CodeGenState): Cont[Unit, Unit] = {
         result(instrs += new instructions.GoSub(state.getSubLabel(this), expected))
     }
@@ -123,9 +124,6 @@ private [deepembedding] object Look {
 private [deepembedding] object NotFollowedBy {
     def empty[A](expected: UnsafeOption[String]): NotFollowedBy[A] = new NotFollowedBy(null, expected)
     def apply[A](p: Parsley[A], expected: UnsafeOption[String]): NotFollowedBy[A] = empty(expected).ready(p)
-}
-private [parsley] object Subroutine {
-    def unapply[A](self: Subroutine[A]): Option[Parsley[A]] = Some(self.p)
 }
 private [deepembedding] object Put {
     def empty[S](r: Reg[S]): Put[S] = new Put(r, null)

--- a/src/main/scala/parsley/internal/instructions/CoreInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/CoreInstrs.scala
@@ -70,8 +70,8 @@ private [internal] final class Call(_instrs: =>Array[Instr], expected: UnsafeOpt
     // $COVERAGE-ON$
 }
 
-private [internal] final class GoSub(var label: Int, expected: UnsafeOption[String]) extends JumpInstr {
-    override def apply(ctx: Context): Unit = ctx.call(ctx.instrs, label, expected)
+private [internal] final class GoSub(var label: Int) extends JumpInstr {
+    override def apply(ctx: Context): Unit = ctx.call(ctx.instrs, label, null)
     // $COVERAGE-OFF$
     override def toString: String = s"GoSub($label)"
     // $COVERAGE-ON$

--- a/src/test/scala/parsley/internal/InternalTests.scala
+++ b/src/test/scala/parsley/internal/InternalTests.scala
@@ -11,7 +11,29 @@ class InternalTests extends ParsleyTest {
     "subroutines" should "function correctly and be picked up" in {
         val p = satisfy(_ => true) *> satisfy(_ => true) *> satisfy(_ => true)
         val q = 'a' *> p <* 'b' <* p <* 'c'
+        q.internal.instrs.count(_ == instructions.Return) shouldBe 1
         q.internal.instrs.last should be (instructions.Return)
+        q.runParser("a123b123c") should be (Success('3'))
+    }
+
+    they should "function correctly under error messages" in {
+        val p = satisfy(_ => true) *> satisfy(_ => true) *> satisfy(_ => true)
+        val q = p ? "err1" *> 'a' *> p ? "err1" <* 'b' <* p ? "err2" <* 'c' <* p ? "err2" <* 'd'
+        q.internal.instrs.count(_ == instructions.Return) shouldBe 2
+        q.runParser("123a123b123c123d") should be (Success('3'))
+    }
+
+    they should "not appear when only referenced once with any given error message" in {
+        val p = satisfy(_ => true) *> satisfy(_ => true) *> satisfy(_ => true)
+        val q = 'a' *> p ? "err1" <* 'b' <* p ? "err2" <* 'c'
+        q.internal.instrs.count(_ == instructions.Return) shouldBe 0
+        q.runParser("a123b123c") should be (Success('3'))
+    }
+
+    they should "not duplicate subroutines when error label is the same" in {
+        val p = satisfy(_ => true) *> satisfy(_ => true) *> satisfy(_ => true)
+        val q = 'a' *> p ? "err1" <* 'b' <* p ? "err1" <* 'c'
+        q.internal.instrs.count(_ == instructions.Return) shouldBe 1
         q.runParser("a123b123c") should be (Success('3'))
     }
 }

--- a/src/test/scala/parsley/internal/InternalTests.scala
+++ b/src/test/scala/parsley/internal/InternalTests.scala
@@ -42,9 +42,15 @@ class InternalTests extends ParsleyTest {
     they should "function properly when a recursion boundary is inside" in {
         lazy val q: Parsley[Unit] = (p *> p) <|> unit
         lazy val p: Parsley[Unit] = '(' *> q <* ')'
-        //println(instructions.pretty(q.internal.instrs))
         q.internal.instrs.count(_ == instructions.Return) shouldBe 1
         q.runParser("(()())()") shouldBe a [Success[_]]
+    }
+
+    they should "work in the precedence parser with one op" in {
+        val atom = some(digit).map(_.mkString.toInt)
+        val expr = precedence[Int](atom,
+            Ops(InfixL)('+' #> (_ + _)))
+        expr.internal.instrs.count(_ == instructions.Return) shouldBe 1
     }
 
     they should "appear frequently inside expression parsers" in {


### PR DESCRIPTION
This PR properly addresses the thread-safety bug with multiple threads processing a shared sub-parser. This removes the hot patches implemented in #57 and properly repairs the issue by disconnecting let-finding and preprocess passes. The let-finding no longer uses any mutability, instead thread-safe Scala lazy vals are used. The preprocess pass then creates an entirely new version of the AST where mutation is allowed again (this work is repeated for each thread).

In addition, this PR has improved let-binding analysis to allow for factoring out of parsers with common bodies _and_ common error messages and also ensures that parsers that appear multiple times but don't share error messages are not factored out in the first place. This improves performance in general, potentially by _substantial_ amounts