### PR TITLE
Added lazy annotations to lifts, but not maps

### DIFF
--- a/src/main/scala/parsley/implicits.scala
+++ b/src/main/scala/parsley/implicits.scala
@@ -24,144 +24,144 @@ object implicits
     }
     implicit class Lift1[T1, R]
         (private val f: T1 => R) extends AnyVal {
-        def lift(p1: Parsley[T1]): Parsley[R] = lift1(f, p1)
+        def lift(p1: =>Parsley[T1]): Parsley[R] = lift1(f, p1)
     }
     implicit class Lift2[T1, T2, R]
         (private val f: (T1, T2) => R) extends AnyVal {
-        def lift(p1: Parsley[T1], p2: Parsley[T2]): Parsley[R] = lift2(f, p1, p2)
+        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2]): Parsley[R] = lift2(f, p1, p2)
     }
     implicit class Lift3[T1, T2, T3, R]
         (private val f: (T1, T2, T3) => R) extends AnyVal {
-        def lift(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3]): Parsley[R] = lift3(f, p1, p2, p3)
+        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3]): Parsley[R] = lift3(f, p1, p2, p3)
     }
     implicit class Lift4[T1, T2, T3, T4, R]
         (private val f: (T1, T2, T3, T4) => R) extends AnyVal {
-        def lift(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4]): Parsley[R] = lift4(f, p1, p2, p3, p4)
+        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4]): Parsley[R] = lift4(f, p1, p2, p3, p4)
     }
     implicit class Lift5[T1, T2, T3, T4, T5, R]
         (private val f: (T1, T2, T3, T4, T5) => R) extends AnyVal {
-        def lift(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5]): Parsley[R] = lift5(f, p1, p2, p3, p4, p5)
+        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5]): Parsley[R] = lift5(f, p1, p2, p3, p4, p5)
     }
     implicit class Lift6[T1, T2, T3, T4, T5, T6, R]
         (private val f: (T1, T2, T3, T4, T5, T6) => R) extends AnyVal {
-        def lift(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4],
-                 p5: Parsley[T5], p6: Parsley[T6]): Parsley[R] = lift6(f, p1, p2, p3, p4, p5, p6)
+        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4],
+                 p5: =>Parsley[T5], p6: =>Parsley[T6]): Parsley[R] = lift6(f, p1, p2, p3, p4, p5, p6)
     }
     implicit class Lift7[T1, T2, T3, T4, T5, T6, T7, R]
         (private val f: (T1, T2, T3, T4, T5, T6, T7) => R) extends AnyVal {
-        def lift(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4],
-                 p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7]): Parsley[R] = lift7(f, p1, p2, p3, p4, p5, p6, p7)
+        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4],
+                 p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7]): Parsley[R] = lift7(f, p1, p2, p3, p4, p5, p6, p7)
     }
     implicit class Lift8[T1, T2, T3, T4, T5, T6, T7, T8, R]
         (private val f: (T1, T2, T3, T4, T5, T6, T7, T8) => R) extends AnyVal {
-        def lift(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4],
-                 p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8]): Parsley[R] = lift8(f, p1, p2, p3, p4, p5, p6, p7, p8)
+        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4],
+                 p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8]): Parsley[R] = lift8(f, p1, p2, p3, p4, p5, p6, p7, p8)
     }
     implicit class Lift9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R]
         (private val f: (T1, T2, T3, T4, T5, T6, T7, T8, T9) => R) extends AnyVal {
-        def lift(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4],
-                 p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-                 p9: Parsley[T9]): Parsley[R] = lift9(f, p1, p2, p3, p4, p5, p6, p7, p8, p9)
+        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4],
+                 p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+                 p9: =>Parsley[T9]): Parsley[R] = lift9(f, p1, p2, p3, p4, p5, p6, p7, p8, p9)
     }
     implicit class Lift10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R]
         (private val f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) => R) extends AnyVal {
-        def lift(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4],
-                 p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-                 p9: Parsley[T9], p10: Parsley[T10]): Parsley[R] = lift10(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10)
+        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4],
+                 p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+                 p9: =>Parsley[T9], p10: =>Parsley[T10]): Parsley[R] = lift10(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10)
     }
     implicit class Lift11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R]
         (private val f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) => R) extends AnyVal {
-        def lift(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4],
-                 p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-                 p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11]): Parsley[R] = lift11(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11)
+        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4],
+                 p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+                 p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11]): Parsley[R] = lift11(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11)
     }
     implicit class Lift12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R]
         (private val f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) => R) extends AnyVal {
-        def lift(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4],
-                 p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-                 p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12]): Parsley[R] =
+        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4],
+                 p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+                 p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12]): Parsley[R] =
             lift12(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12)
     }
     implicit class Lift13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R]
         (private val f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) => R) extends AnyVal {
-        def lift(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4],
-                 p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-                 p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12],
-                 p13: Parsley[T13]): Parsley[R] = lift13(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13)
+        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4],
+                 p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+                 p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12],
+                 p13: =>Parsley[T13]): Parsley[R] = lift13(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13)
     }
     implicit class Lift14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R]
         (private val f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) => R) extends AnyVal {
-        def lift(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4],
-                 p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-                 p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12],
-                 p13: Parsley[T13], p14: Parsley[T14]): Parsley[R] = lift14(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14)
+        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4],
+                 p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+                 p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12],
+                 p13: =>Parsley[T13], p14: =>Parsley[T14]): Parsley[R] = lift14(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14)
     }
     implicit class Lift15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R]
         (private val f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) => R) extends AnyVal {
-        def lift(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4],
-                 p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-                 p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12],
-                 p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15]): Parsley[R] =
+        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4],
+                 p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+                 p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12],
+                 p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15]): Parsley[R] =
             lift15(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15)
     }
     implicit class Lift16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R]
         (private val f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) => R) extends AnyVal {
-        def lift(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4],
-                 p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-                 p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12],
-                 p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15], p16: Parsley[T16]): Parsley[R] =
+        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4],
+                 p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+                 p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12],
+                 p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15], p16: =>Parsley[T16]): Parsley[R] =
             lift16(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16)
     }
     implicit class Lift17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R]
         (private val f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) => R) extends AnyVal {
-        def lift(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4],
-                 p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-                 p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12],
-                 p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15], p16: Parsley[T16],
-                 p17: Parsley[T17]): Parsley[R] = lift17(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17)
+        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4],
+                 p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+                 p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12],
+                 p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15], p16: =>Parsley[T16],
+                 p17: =>Parsley[T17]): Parsley[R] = lift17(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17)
     }
     implicit class Lift18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R]
         (private val f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) => R) extends AnyVal {
-        def lift(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4],
-                 p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-                 p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12],
-                 p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15], p16: Parsley[T16],
-                 p17: Parsley[T17], p18: Parsley[T18]): Parsley[R] = lift18(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18)
+        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4],
+                 p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+                 p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12],
+                 p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15], p16: =>Parsley[T16],
+                 p17: =>Parsley[T17], p18: =>Parsley[T18]): Parsley[R] = lift18(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18)
     }
     implicit class Lift19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R]
         (private val f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) => R) extends AnyVal {
-        def lift(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4],
-                 p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-                 p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12],
-                 p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15], p16: Parsley[T16],
-                 p17: Parsley[T17], p18: Parsley[T18], p19: Parsley[T19]): Parsley[R] =
+        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4],
+                 p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+                 p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12],
+                 p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15], p16: =>Parsley[T16],
+                 p17: =>Parsley[T17], p18: =>Parsley[T18], p19: =>Parsley[T19]): Parsley[R] =
             lift19(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19)
     }
     implicit class Lift20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R]
         (private val f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) => R) extends AnyVal {
-        def lift(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4],
-                 p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-                 p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12],
-                 p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15], p16: Parsley[T16],
-                 p17: Parsley[T17], p18: Parsley[T18], p19: Parsley[T19], p20: Parsley[T20]): Parsley[R] =
+        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4],
+                 p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+                 p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12],
+                 p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15], p16: =>Parsley[T16],
+                 p17: =>Parsley[T17], p18: =>Parsley[T18], p19: =>Parsley[T19], p20: =>Parsley[T20]): Parsley[R] =
             lift20(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20)
     }
     implicit class Lift21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R]
         (private val f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21) => R) extends AnyVal {
-        def lift(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4],
-                 p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-                 p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12],
-                 p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15], p16: Parsley[T16],
-                 p17: Parsley[T17], p18: Parsley[T18], p19: Parsley[T19], p20: Parsley[T20],
-                 p21: Parsley[T21]): Parsley[R] = lift21(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21)
+        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4],
+                 p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+                 p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12],
+                 p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15], p16: =>Parsley[T16],
+                 p17: =>Parsley[T17], p18: =>Parsley[T18], p19: =>Parsley[T19], p20: =>Parsley[T20],
+                 p21: =>Parsley[T21]): Parsley[R] = lift21(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21)
     }
     implicit class Lift22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R]
         (private val f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22) => R) extends AnyVal {
-        def lift(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4],
-                 p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-                 p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12],
-                 p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15], p16: Parsley[T16],
-                 p17: Parsley[T17], p18: Parsley[T18], p19: Parsley[T19], p20: Parsley[T20], p21: Parsley[T21], p22: Parsley[T22]): Parsley[R] =
+        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4],
+                 p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+                 p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12],
+                 p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15], p16: =>Parsley[T16],
+                 p17: =>Parsley[T17], p18: =>Parsley[T18], p19: =>Parsley[T19], p20: =>Parsley[T20], p21: =>Parsley[T21], p22: =>Parsley[T22]): Parsley[R] =
             lift22(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22)
     }
 

--- a/src/main/scala/parsley/implicits.scala
+++ b/src/main/scala/parsley/implicits.scala
@@ -126,7 +126,8 @@ object implicits
                  p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
                  p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12],
                  p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15], p16: =>Parsley[T16],
-                 p17: =>Parsley[T17], p18: =>Parsley[T18]): Parsley[R] = lift18(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18)
+                 p17: =>Parsley[T17], p18: =>Parsley[T18]): Parsley[R] =
+            lift18(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18)
     }
     implicit class Lift19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R]
         (private val f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) => R) extends AnyVal {

--- a/src/main/scala/parsley/lift.scala
+++ b/src/main/scala/parsley/lift.scala
@@ -12,210 +12,218 @@ import parsley.internal.deepembedding
 object lift {
     def lift1[T1, R]
         (f: T1 => R,
-         p1: Parsley[T1]): Parsley[R] =
+         p1: =>Parsley[T1]): Parsley[R] =
         p1.map(f)
     def lift2[T1, T2, R]
         (f: (T1, T2) => R,
-         p1: Parsley[T1], p2: Parsley[T2]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2]): Parsley[R] =
         new Parsley(new deepembedding.Lift2(f, p1.internal, p2.internal))
     def lift3[T1, T2, T3, R]
         (f: (T1, T2, T3) => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3]): Parsley[R] =
         new Parsley(new deepembedding.Lift3(f, p1.internal, p2.internal, p3.internal))
     // $COVERAGE-OFF$
     def lift4[T1, T2, T3, T4, R]
         (f: (T1, T2, T3, T4) => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4]): Parsley[R] =
         lift4(f.curried, p1, p2, p3, p4)
     def lift5[T1, T2, T3, T4, T5, R]
         (f: (T1, T2, T3, T4, T5) => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5]): Parsley[R] =
         lift5(f.curried, p1, p2, p3, p4, p5)
     def lift6[T1, T2, T3, T4, T5, T6, R]
         (f: (T1, T2, T3, T4, T5, T6) => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6]): Parsley[R] =
         lift6(f.curried, p1, p2, p3, p4, p5, p6)
     def lift7[T1, T2, T3, T4, T5, T6, T7, R]
         (f: (T1, T2, T3, T4, T5, T6, T7) => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7]): Parsley[R] =
         lift7(f.curried, p1, p2, p3, p4, p5, p6, p7)
     def lift8[T1, T2, T3, T4, T5, T6, T7, T8, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8) => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7],
+         p8: =>Parsley[T8]): Parsley[R] =
         lift8(f.curried, p1, p2, p3, p4, p5, p6, p7, p8)
     def lift9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9) => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-         p9: Parsley[T9]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p9: =>Parsley[T9]): Parsley[R] =
         lift9(f.curried, p1, p2, p3, p4, p5, p6, p7, p8, p9)
     def lift10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-         p9: Parsley[T9], p10: Parsley[T10]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p9: =>Parsley[T9], p10: =>Parsley[T10]): Parsley[R] =
         lift10(f.curried, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10)
     def lift11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-         p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11]): Parsley[R] =
         lift11(f.curried, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11)
     def lift12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-         p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12]): Parsley[R] =
         lift12(f.curried, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12)
     def lift13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-         p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13]): Parsley[R] =
         lift13(f.curried, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13)
     def lift14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-         p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13], p14: Parsley[T14]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14]): Parsley[R] =
         lift14(f.curried, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14)
     def lift15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-         p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14],
+         p15: =>Parsley[T15]): Parsley[R] =
         lift15(f.curried, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15)
     def lift16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-         p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15], p16: Parsley[T16]):
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15],
+         p16: =>Parsley[T16]):
         Parsley[R] = lift16(f.curried, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16)
     def lift17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-         p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15], p16: Parsley[T16],
-         p17: Parsley[T17]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15],
+         p16: =>Parsley[T16], p17: =>Parsley[T17]): Parsley[R] =
         lift17(f.curried, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17)
     def lift18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-         p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15], p16: Parsley[T16],
-         p17: Parsley[T17], p18: Parsley[T18]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15],
+         p16: =>Parsley[T16], p17: =>Parsley[T17], p18: =>Parsley[T18]): Parsley[R] =
         lift18(f.curried, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18)
     def lift19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-         p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15], p16: Parsley[T16],
-         p17: Parsley[T17], p18: Parsley[T18], p19: Parsley[T19]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15],
+         p16: =>Parsley[T16], p17: =>Parsley[T17], p18: =>Parsley[T18], p19: =>Parsley[T19]): Parsley[R] =
         lift19(f.curried, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19)
     def lift20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-         p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15], p16: Parsley[T16],
-         p17: Parsley[T17], p18: Parsley[T18], p19: Parsley[T19], p20: Parsley[T20]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15],
+         p16: =>Parsley[T16], p17: =>Parsley[T17], p18: =>Parsley[T18], p19: =>Parsley[T19], p20: =>Parsley[T20]): Parsley[R] =
         lift20(f.curried, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20)
     def lift21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21) => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-         p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15], p16: Parsley[T16],
-         p17: Parsley[T17], p18: Parsley[T18], p19: Parsley[T19], p20: Parsley[T20], p21: Parsley[T21]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15],
+         p16: =>Parsley[T16], p17: =>Parsley[T17], p18: =>Parsley[T18], p19: =>Parsley[T19], p20: =>Parsley[T20], p21: =>Parsley[T21]): Parsley[R] =
         lift21(f.curried, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21)
     // $COVERAGE-ON$
     def lift22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22) => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-         p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15], p16: Parsley[T16],
-         p17: Parsley[T17], p18: Parsley[T18], p19: Parsley[T19], p20: Parsley[T20], p21: Parsley[T21], p22: Parsley[T22]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15],
+         p16: =>Parsley[T16], p17: =>Parsley[T17], p18: =>Parsley[T18], p19: =>Parsley[T19], p20: =>Parsley[T20], p21: =>Parsley[T21],
+         p22: =>Parsley[T22]): Parsley[R] =
         lift22(f.curried, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22)
 
     // INTERNAL HELPERS
     @inline private def lift4[T1, T2, T3, T4, R]
         (f: T1 => T2 => T3 => T4 => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4]): Parsley[R] =
         lift3((x1: T1, x2: T2, x3: T3) => f(x1)(x2)(x3), p1, p2, p3) <*> p4
     @inline private def lift5[T1, T2, T3, T4, T5, R]
         (f: T1 => T2 => T3 => T4 => T5 => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5]): Parsley[R] =
         lift4(f, p1, p2, p3, p4) <*> p5
     @inline private def lift6[T1, T2, T3, T4, T5, T6, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6]): Parsley[R] =
         lift5(f, p1, p2, p3, p4, p5) <*> p6
     @inline private def lift7[T1, T2, T3, T4, T5, T6, T7, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7]): Parsley[R] =
         lift6(f, p1, p2, p3, p4, p5, p6) <*> p7
     @inline private def lift8[T1, T2, T3, T4, T5, T6, T7, T8, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7],
+         p8: =>Parsley[T8]): Parsley[R] =
         lift7(f, p1, p2, p3, p4, p5, p6, p7) <*> p8
     @inline private def lift9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => T9 => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-         p9: Parsley[T9]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p9: =>Parsley[T9]): Parsley[R] =
         lift8(f, p1, p2, p3, p4, p5, p6, p7, p8) <*> p9
     @inline private def lift10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => T9 => T10 => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-         p9: Parsley[T9], p10: Parsley[T10]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p9: =>Parsley[T9], p10: =>Parsley[T10]): Parsley[R] =
         lift9(f, p1, p2, p3, p4, p5, p6, p7, p8, p9) <*> p10
     @inline private def lift11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => T9 => T10 => T11 => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-         p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11]): Parsley[R] =
         lift10(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10) <*> p11
     @inline private def lift12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => T9 => T10 => T11 => T12 => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-         p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12]): Parsley[R] =
         lift11(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11) <*> p12
     @inline private def lift13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => T9 => T10 => T11 => T12 => T13 => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-         p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13]): Parsley[R] =
         lift12(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12) <*> p13
     @inline private def lift14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => T9 => T10 => T11 => T12 => T13 => T14 => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-         p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13], p14: Parsley[T14]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14]): Parsley[R] =
         lift13(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13) <*> p14
     @inline private def lift15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => T9 => T10 => T11 => T12 => T13 => T14 => T15 => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-         p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14],
+         p15: =>Parsley[T15]): Parsley[R] =
         lift14(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14) <*> p15
     @inline private def lift16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => T9 => T10 => T11 => T12 => T13 => T14 => T15 => T16 => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-         p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15], p16: Parsley[T16]):
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15],
+         p16: =>Parsley[T16]):
         Parsley[R] = lift15(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15) <*> p16
     @inline private def lift17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => T9 => T10 => T11 => T12 => T13 => T14 => T15 => T16 => T17 => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-         p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15], p16: Parsley[T16],
-         p17: Parsley[T17]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15],
+         p16: =>Parsley[T16], p17: =>Parsley[T17]): Parsley[R] =
         lift16(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16) <*> p17
     @inline private def lift18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => T9 => T10 => T11 => T12 => T13 => T14 => T15 => T16 => T17 => T18 => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-         p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15], p16: Parsley[T16],
-         p17: Parsley[T17], p18: Parsley[T18]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15],
+         p16: =>Parsley[T16], p17: =>Parsley[T17], p18: =>Parsley[T18]): Parsley[R] =
         lift17(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17) <*> p18
     @inline private def lift19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => T9 => T10 => T11 => T12 => T13 => T14 => T15 => T16 => T17 => T18 => T19 => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-         p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15], p16: Parsley[T16],
-         p17: Parsley[T17], p18: Parsley[T18], p19: Parsley[T19]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15],
+         p16: =>Parsley[T16], p17: =>Parsley[T17], p18: =>Parsley[T18], p19: =>Parsley[T19]): Parsley[R] =
         lift18(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18) <*> p19
     @inline private def lift20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => T9 => T10 => T11 => T12 => T13 => T14 => T15 => T16 => T17 => T18 => T19 => T20 => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-         p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15], p16: Parsley[T16],
-         p17: Parsley[T17], p18: Parsley[T18], p19: Parsley[T19], p20: Parsley[T20]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15],
+         p16: =>Parsley[T16], p17: =>Parsley[T17], p18: =>Parsley[T18], p19: =>Parsley[T19], p20: =>Parsley[T20]): Parsley[R] =
         lift19(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19) <*> p20
     @inline private def lift21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => T9 => T10 => T11 => T12 => T13 => T14 => T15 => T16 => T17 => T18 => T19 => T20 => T21 => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-         p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15], p16: Parsley[T16],
-         p17: Parsley[T17], p18: Parsley[T18], p19: Parsley[T19], p20: Parsley[T20], p21: Parsley[T21]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15],
+         p16: =>Parsley[T16], p17: =>Parsley[T17], p18: =>Parsley[T18], p19: =>Parsley[T19], p20: =>Parsley[T20], p21: =>Parsley[T21]): Parsley[R] =
         lift20(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20) <*> p21
     @inline private def lift22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => T9 => T10 => T11 => T12 => T13 => T14 => T15 => T16 => T17 => T18 => T19 => T20 => T21 => T22 => R,
-         p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5], p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8],
-         p9: Parsley[T9], p10: Parsley[T10], p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15], p16: Parsley[T16],
-         p17: Parsley[T17], p18: Parsley[T18], p19: Parsley[T19], p20: Parsley[T20], p21: Parsley[T21], p22: Parsley[T22]): Parsley[R] =
+         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15],
+         p16: =>Parsley[T16], p17: =>Parsley[T17], p18: =>Parsley[T18], p19: =>Parsley[T19], p20: =>Parsley[T20], p21: =>Parsley[T21],
+         p22: =>Parsley[T22]): Parsley[R] =
         lift21(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21) <*> p22
 }


### PR DESCRIPTION
The lift functions all have `by-name` parameters, fixing #63. `map` family (to be called `zipWith`) does not, because they are strict tuples. If necessary this can be done, however, the `lift` family and `map` are in a one-to-one correspondence.