### PR TITLE
Explain combinator

### DIFF
--- a/src/main/scala/parsley/Parsley.scala
+++ b/src/main/scala/parsley/Parsley.scala
@@ -251,10 +251,18 @@ object Parsley
         /**Alias for guard combinator, taking a dynamic message generator.*/
         def >?>(pred: A => Boolean, msggen: A => String): Parsley[A] = this.guard(pred, msggen)
         /**Alias for `label`*/
-        def ?(msg: String): Parsley[A] = /*new Parsley(new deepembedding.UnsafeErrorRelabel(p.internal, msg))*/this.label(msg)
+        def ?(msg: String): Parsley[A] = this.label(msg)
         /**Sets the expected message for a parser. If the parser fails then `expected msg` will added to the error
           * @since 2.6.0 */
         def label(msg: String): Parsley[A] = new Parsley(new deepembedding.ErrorLabel(p.internal, msg))
+        /** Similar to `label`, except instead of providing an expected message replacing the original tag, this combinator
+          * adds a ''reason'' that the error occurred. This is in complement to the label. The `reason` is only added when
+          * the parser fails, and will disappear if any further progress in the parser is made (unlike labels, which may
+          * reappear as "hints").
+          * @param reason The reason why a parser failed
+          * @since 2.7.0
+          */
+        def explain(reason: String): Parsley[A] = new Parsley(new deepembedding.ErrorExplain(p.internal, reason))
         /**Hides the "expected" error message for a parser.*/
         def hide: Parsley[A] = this.label("") //THIS MUST BE LABEL
         /** Same as `fail`, except allows for a message generated from the result of the failed parser. In essence, this

--- a/src/main/scala/parsley/internal/instructions/Context.scala
+++ b/src/main/scala/parsley/internal/instructions/Context.scala
@@ -121,7 +121,7 @@ private [parsley] final class Context(private [instructions] var instrs: Array[I
     // $COVERAGE-ON$
 
     @tailrec @inline private [parsley] def runParser[A](): Result[A] = {
-        //println(pretty)
+        println(pretty)
         if (status eq Failed) {
             assert(!isEmpty(errs) && isEmpty(errs.tail), "there should be only one error on failure")
             assert(isEmpty(handlers), "there should be no handlers left on failure")

--- a/src/main/scala/parsley/internal/instructions/Context.scala
+++ b/src/main/scala/parsley/internal/instructions/Context.scala
@@ -121,7 +121,7 @@ private [parsley] final class Context(private [instructions] var instrs: Array[I
     // $COVERAGE-ON$
 
     @tailrec @inline private [parsley] def runParser[A](): Result[A] = {
-        println(pretty)
+        //println(pretty)
         if (status eq Failed) {
             assert(!isEmpty(errs) && isEmpty(errs.tail), "there should be only one error on failure")
             assert(isEmpty(handlers), "there should be no handlers left on failure")

--- a/src/main/scala/parsley/internal/instructions/ErrorInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/ErrorInstrs.scala
@@ -57,7 +57,24 @@ private [internal] object MergeErrors extends Instr {
     }
 
     // $COVERAGE-OFF$
-    override def toString: String = s"MergeErrors"
+    override def toString: String = "MergeErrors"
+    // $COVERAGE-ON$
+}
+
+private [internal] class ApplyReason(reason: String) extends Instr {
+    override def apply(ctx: Context): Unit = {
+        if (ctx.status eq Good) {
+            ctx.handlers = ctx.handlers.tail
+            ctx.inc()
+        }
+        else {
+            ctx.errs.head = ctx.errs.head.giveReason(reason)
+            ctx.fail()
+        }
+    }
+
+    // $COVERAGE-OFF$
+    override def toString: String = s"ApplyReason($reason)"
     // $COVERAGE-ON$
 }
 

--- a/src/main/scala/parsley/token/Lexer.scala
+++ b/src/main/scala/parsley/token/Lexer.scala
@@ -155,7 +155,7 @@ class Lexer(lang: LanguageDef)
     {
         '\\' *> (escapeGap #> None
              <|> escapeEmpty #> None
-             <|> (escapeCode <#> (Some(_))))
+             <|> (escapeCode <#> (Some(_))).explain("invalid escape sequence"))
     }
     private lazy val stringChar: Parsley[Option[Char]] = ((stringLetter <#> (Some(_))) <|> stringEscape).label("string character")
 

--- a/src/main/scala/parsley/token/Lexer.scala
+++ b/src/main/scala/parsley/token/Lexer.scala
@@ -116,7 +116,7 @@ class Lexer(lang: LanguageDef)
      * This parser deals correctly with escape sequences. The literal character is parsed according
      * to the grammar rules defined in the Haskell report (which matches most programming languages
      * quite closely).*/
-    lazy val charLiteral: Parsley[Char] = lexeme(between('\'', '\''.unsafeLabel("end of character"), characterChar).unsafeLabel("character"))
+    lazy val charLiteral: Parsley[Char] = lexeme(between('\''.unsafeLabel("character"), '\''.unsafeLabel("end of character"), characterChar))
 
     /**This lexeme parser parses a literal string. Returns the literal string value. This parser
      * deals correctly with escape sequences and gaps. The literal string is parsed according to


### PR DESCRIPTION
Added the explain combinator, which can be used to annotate an error with a reason that the error occured. Unlike labels, these reasons will not materialise as hints if the error was recovered from.