### PR TITLE
`filterOut` should not pop stack after failure

### DIFF
--- a/src/main/scala/parsley/internal/instructions/IntrinsicInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/IntrinsicInstrs.scala
@@ -110,7 +110,7 @@ private [internal] final class Filter[A](_pred: A=>Boolean, expected: UnsafeOpti
     private [this] val pred = _pred.asInstanceOf[Any=>Boolean]
     override def apply(ctx: Context): Unit = {
         if (pred(ctx.stack.upeek)) ctx.inc()
-        else ctx.expectedFail(expected)
+        else ctx.fail(TrivialError(ctx.offset, ctx.line, ctx.col, None, if (expected == null) Set.empty else Set(Desc(expected)), Set.empty))
     }
     // $COVERAGE-OFF$
     override def toString: String = "Filter(?)"
@@ -121,8 +121,8 @@ private [internal] final class FilterOut[A](_pred: PartialFunction[A, String], e
     private [this] val pred = _pred.asInstanceOf[PartialFunction[Any, String]]
     override def apply(ctx: Context): Unit = {
         if (pred.isDefinedAt(ctx.stack.upeek)) {
-            ctx.expectedFail(expected)
-            ctx.errs.head = ctx.errs.head.giveReason(pred(ctx.stack.upop()))
+            val reason = pred(ctx.stack.upop())
+            ctx.fail(TrivialError(ctx.offset, ctx.line, ctx.col, None, if (expected == null) Set.empty else Set(Desc(expected)), Set(reason)))
         }
         else ctx.inc()
     }

--- a/src/test/scala/parsley/CombinatorTests.scala
+++ b/src/test/scala/parsley/CombinatorTests.scala
@@ -57,8 +57,10 @@ class CombinatorTests extends ParsleyTest {
     }
     it must "compose with option to become identity" in {
         decide(option(pure(7))).runParser("") should be (pure(7).runParser(""))
-        decide(option('a')).runParser("") should be ('a'.runParser(""))
-        decide(option("ab")).runParser("a") should be ("ab".runParser("a"))
+        decide(option('a')).runParser("") shouldBe a [Failure]
+        'a'.runParser("") shouldBe a [Failure]
+        decide(option("ab")).runParser("a") shouldBe a [Failure]
+        "ab".runParser("a") shouldBe a [Failure]
     }
 
     "optional" must "succeed if p succeeds" in {

--- a/src/test/scala/parsley/CoreTests.scala
+++ b/src/test/scala/parsley/CoreTests.scala
@@ -241,7 +241,7 @@ class CoreTests extends ParsleyTest {
         val q = anyChar.filterOut {
             case c if c.isLower => s"'$c' should have been uppercase"
         }
-        q.runParser("a") shouldBe Failure("(line 1, column 2):\n  unexpected end of input\n  'a' should have been uppercase\n  >a\n  > ^")
+        q.runParser("a") shouldBe Failure("(line 1, column 2):\n  'a' should have been uppercase\n  >a\n  > ^")
         q.runParser("A") shouldBe Success('A')
 
         val r = anyChar.guardAgainst {
@@ -257,6 +257,14 @@ class CoreTests extends ParsleyTest {
         val t = anyChar.guard(_.isUpper, c => s"'$c' is not uppercase")
         t.runParser("a") shouldBe Failure("(line 1, column 2):\n  'a' is not uppercase\n  >a\n  > ^")
         t.runParser("A") shouldBe Success('A')
+    }
+
+    // Issue #
+    "filterOut" should "not corrupt the stack under a handler" in {
+        val p = attempt(anyChar.filterOut {
+            case c if c.isLower => "no lowercase!"
+        })
+        p.runParser("a") shouldBe a [Failure]
     }
 
     "the collect combinator" should "act like a filter then a map" in {

--- a/src/test/scala/parsley/CoreTests.scala
+++ b/src/test/scala/parsley/CoreTests.scala
@@ -259,7 +259,7 @@ class CoreTests extends ParsleyTest {
         t.runParser("A") shouldBe Success('A')
     }
 
-    // Issue #
+    // Issue #70
     "filterOut" should "not corrupt the stack under a handler" in {
         val p = attempt(anyChar.filterOut {
             case c if c.isLower => "no lowercase!"


### PR DESCRIPTION
Fixes #70. Also correctly removes the unexpected message from filters to properly align with the expected behaviour of `empty`, which is the advertised semantics.