### PR TITLE
String vs array

### DIFF
--- a/src/main/scala/parsley/Parsley.scala
+++ b/src/main/scala/parsley/Parsley.scala
@@ -47,7 +47,8 @@ final class Parsley[+A] private [parsley] (private [parsley] val internal: deepe
       * @param input The input to run against
       * @return Either a success with a value of type `A` or a failure with error message
       */
-    //def runParser(input: String): Result[A] = runParser(input.toCharArray)
+    @deprecated("This method will be removed in Parsley 3.0 since Strings are now the underlying representation for Parsley", "2.8.4")
+    def runParser(input: Array[Char]): Result[A] = runParser(new String(input))
     /** This method is responsible for actually executing parsers. Given an input
       * array, will parse the string with the parser. The result is either a `Success` or a `Failure`.
       * @param input The input to run against

--- a/src/main/scala/parsley/Parsley.scala
+++ b/src/main/scala/parsley/Parsley.scala
@@ -47,20 +47,20 @@ final class Parsley[+A] private [parsley] (private [parsley] val internal: deepe
       * @param input The input to run against
       * @return Either a success with a value of type `A` or a failure with error message
       */
-    def runParser(input: String): Result[A] = runParser(input.toCharArray)
+    //def runParser(input: String): Result[A] = runParser(input.toCharArray)
     /** This method is responsible for actually executing parsers. Given an input
       * array, will parse the string with the parser. The result is either a `Success` or a `Failure`.
       * @param input The input to run against
       * @return Either a success with a value of type `A` or a failure with error message
       */
-    def runParser(input: Array[Char]): Result[A] = new Context(internal.threadSafeInstrs, input).runParser()
+    def runParser(input: String): Result[A] = new Context(internal.threadSafeInstrs, input).runParser()
     /** This method executes a parser, but collects the input to the parser from the given file.
       * The file name is used to annotate any error messages.
       * @param file The file to load and run against
       * @return Either a success with a value of type `A` or a failure with error message
       * @since 2.3.0
       */
-    def parseFromFile(file: File): Result[A] = new Context(internal.threadSafeInstrs, Source.fromFile(file).toArray, Some(file.getName)).runParser()
+    def parseFromFile(file: File): Result[A] = new Context(internal.threadSafeInstrs, Source.fromFile(file).toString, Some(file.getName)).runParser()
 }
 /** This object contains the core "function-style" combinators as well as the implicit classes which provide
   * the "method-style" combinators. All parsers will likely require something from within! */

--- a/src/main/scala/parsley/internal/instructions/Context.scala
+++ b/src/main/scala/parsley/internal/instructions/Context.scala
@@ -238,7 +238,7 @@ private [parsley] final class Context(private [instructions] var instrs: Array[I
         inc()
     }
     private [instructions] def inc(): Unit = pc += 1
-    private [instructions] def nextChar: Char = input(offset)
+    private [instructions] def nextChar: Char = input.charAt(offset)
     private [instructions] def moreInput: Boolean = offset < inputsz
     private [instructions] def updatePos(c: Char) = c match {
         case '\n' => line += 1; col = 1
@@ -303,7 +303,7 @@ private [parsley] final class Context(private [instructions] var instrs: Array[I
             if (idx == -1) Context.this.inputsz else idx
         }
         def segmentBetween(start: Int, end: Int): String = {
-            Context.this.input.slice(start, end).mkString
+            Context.this.input.substring(start, end)
         }
     }
 }

--- a/src/main/scala/parsley/internal/instructions/Context.scala
+++ b/src/main/scala/parsley/internal/instructions/Context.scala
@@ -19,7 +19,7 @@ private [instructions] final class State(val offset: Int, val line: Int, val col
 }
 
 private [parsley] final class Context(private [instructions] var instrs: Array[Instr],
-                                      private [instructions] var input: Array[Char],
+                                      private [instructions] var input: String,
                                       private [instructions] val sourceName: Option[String] = None) {
     /** This is the operand stack, where results go to live  */
     private [instructions] val stack: ArrayStack[Any] = new ArrayStack()
@@ -274,7 +274,7 @@ private [parsley] final class Context(private [instructions] var instrs: Array[I
     }
 
     // Allows us to reuse a context, helpful for benchmarking and potentially user applications
-    private [parsley] def apply(_instrs: Array[Instr], _input: Array[Char]): Context = {
+    private [parsley] def apply(_instrs: Array[Instr], _input: String): Context = {
         instrs = _instrs
         input = _input
         stack.clear()
@@ -310,5 +310,5 @@ private [parsley] final class Context(private [instructions] var instrs: Array[I
 
 private [parsley] object Context {
     private [Context] val NumRegs = 4
-    def empty: Context = new Context(null, Array.emptyCharArray)
+    def empty: Context = new Context(null, "")
 }

--- a/src/main/scala/parsley/internal/instructions/Errors.scala
+++ b/src/main/scala/parsley/internal/instructions/Errors.scala
@@ -55,6 +55,7 @@ private [internal] sealed trait ParseError {
         val topStr = posStr(sourceName)
         val (line, caret) = getLineWithCaret(helper)
         val info = infoLines.filter(_.nonEmpty).mkString("\n  ")
+        // TODO: Add preamble of parse error?
         // Apparently, multi-line strings use whatever line endings the file has instead of platform-independent LIKE EVERYTHING ELSE
         // So we can't use them without breaking the error messages on Windows.
         /*s"""$topStr:

--- a/src/main/scala/parsley/internal/instructions/IntrinsicInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/IntrinsicInstrs.scala
@@ -70,7 +70,7 @@ private [internal] final class StringTok private [instructions] (s: String, x: A
     compute(cs)
 
     @tailrec private def go(ctx: Context, i: Int, j: Int, err: =>TrivialError): Unit = {
-        if (j < sz && i < ctx.inputsz && ctx.input(i) == cs(j)) go(ctx, i + 1, j + 1, err)
+        if (j < sz && i < ctx.inputsz && ctx.input.charAt(i) == cs(j)) go(ctx, i + 1, j + 1, err)
         else {
             val (colAdjust, lineAdjust) = adjustAtIndex(j)
             ctx.col = colAdjust(ctx.col)
@@ -87,7 +87,7 @@ private [internal] final class StringTok private [instructions] (s: String, x: A
         val origCol = ctx.col
         go(ctx, ctx.offset, 0,
             TrivialError(origOffset, origLine, origCol,
-                Some(if (ctx.inputsz > origOffset) Raw(ctx.input.slice(origOffset, Math.min(origOffset + sz, ctx.inputsz)).mkString) else EndOfInput),
+                Some(if (ctx.inputsz > origOffset) Raw(ctx.input.substring(origOffset, Math.min(origOffset + sz, ctx.inputsz))) else EndOfInput),
                 Set(errorItem), Set.empty
             ))
     }

--- a/src/main/scala/parsley/internal/instructions/TokenInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/TokenInstrs.scala
@@ -168,8 +168,8 @@ private [instructions] abstract class TokenSpecificAllowTrailing(_specific: Stri
     protected def postprocess(ctx: Context, i: Int): Unit
 
     val readCharCaseHandled = {
-        if (caseSensitive) (ctx: Context, i: Int) => ctx.input(i)
-        else (ctx: Context, i: Int) => ctx.input(i).toLower
+        if (caseSensitive) (ctx: Context, i: Int) => ctx.input.charAt(i)
+        else (ctx: Context, i: Int) => ctx.input.charAt(i).toLower
     }
 
     @tailrec final private def readSpecific(ctx: Context, i: Int, j: Int): Unit = {
@@ -191,7 +191,7 @@ private [instructions] abstract class TokenSpecificAllowTrailing(_specific: Stri
 private [internal] final class TokenSpecific(_specific: String, letter: TokenSet, caseSensitive: Boolean, expected: UnsafeOption[String])
     extends TokenSpecificAllowTrailing(_specific, caseSensitive, expected) {
     override def postprocess(ctx: Context, i: Int): Unit = {
-        if (i < ctx.inputsz && letter(ctx.input(i))) {
+        if (i < ctx.inputsz && letter(ctx.input.charAt(i))) {
             ctx.expectedFail(expectedEnd)
             ctx.restoreState()
         }
@@ -213,7 +213,7 @@ private [internal] final class TokenMaxOp(operator: String, _ops: Set[String], e
     })
 
     @tailrec private def go(ctx: Context, i: Int, ops: Radix[Unit]): Unit = {
-        lazy val ops_ = ops.suffixes(ctx.input(i))
+        lazy val ops_ = ops.suffixes(ctx.input.charAt(i))
         val possibleOpsRemain = i < ctx.inputsz && ops.nonEmpty
         if (possibleOpsRemain && ops_.contains("")) {
             ctx.expectedFail(expectedEnd)

--- a/src/main/scala/parsley/internal/instructions/TokenInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/TokenInstrs.scala
@@ -127,10 +127,9 @@ private [internal] final class TokenNonSpecific(name: String, illegalName: Strin
 
     override def apply(ctx: Context): Unit = {
         if (ctx.moreInput && start(ctx.nextChar)) {
-            val name = new StringBuilder()
-            name += ctx.nextChar
+            val initialOffset = ctx.offset
             ctx.offset += 1
-            restOfToken(ctx, name)
+            restOfToken(ctx, initialOffset)
         }
         else ctx.expectedFail(expected)
     }
@@ -146,13 +145,12 @@ private [internal] final class TokenNonSpecific(name: String, illegalName: Strin
         }
     }
 
-    @tailrec private def restOfToken(ctx: Context, tok: StringBuilder): Unit = {
+    @tailrec private def restOfToken(ctx: Context, initialOffset: Int): Unit = {
         if (ctx.moreInput && letter(ctx.nextChar)) {
-            tok += ctx.nextChar
             ctx.offset += 1
-            restOfToken(ctx, tok)
+            restOfToken(ctx, initialOffset)
         }
-        else ensureLegal(ctx, tok.toString)
+        else ensureLegal(ctx, ctx.input.substring(initialOffset, ctx.offset))
     }
 
     // $COVERAGE-OFF$

--- a/src/main/scala/parsley/internal/instructions/TokenStringInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/TokenStringInstrs.scala
@@ -18,7 +18,7 @@ private [internal] class TokenEscape(_expected: UnsafeOption[String]) extends In
         new TokenEscape.EscapeChar(c)
     }
 
-    private final def lookAhead(ctx: Context, n: Int): Char = ctx.input(ctx.offset + n)
+    private final def lookAhead(ctx: Context, n: Int): Char = ctx.input.charAt(ctx.offset + n)
     private final def lookAhead(ctx: Context, n: Int, c: Char): Boolean = ctx.offset + n < ctx.inputsz && lookAhead(ctx, n) == c
 
     private final def numericEscape(ctx: Context, escapeCode: Int) = {

--- a/src/main/scala/parsley/unsafe.scala
+++ b/src/main/scala/parsley/unsafe.scala
@@ -31,7 +31,7 @@ object unsafe {
           * implicit for convenience.
           * @since 1.6.0
           */
-        def runParserFastUnsafe(input: String): Result[A] = runParserFastUnsafe(input.toCharArray)
+        //def runParserFastUnsafe(input: String): Result[A] = runParserFastUnsafe(input.toCharArray)
         /** This method allows you to run a parser with a cached context, which improves performance.
           * If no implicit context can be found, the parsley default context is used. This will
           * cause issues with multi-threaded execution of parsers. In order to mitigate these issues,
@@ -39,7 +39,7 @@ object unsafe {
           * implicit for convenience.
           * @since 1.6.0
           */
-        def runParserFastUnsafe(input: Array[Char]): Result[A] = ctx.internal(p.internal.instrs, input).runParser()
+        def runParserFastUnsafe(input: String): Result[A] = ctx.internal(p.internal.instrs, input).runParser()
     }
 
     final class Context private [parsley] (private [parsley] val internal: instructions.Context)

--- a/src/main/scala/parsley/unsafe.scala
+++ b/src/main/scala/parsley/unsafe.scala
@@ -31,7 +31,8 @@ object unsafe {
           * implicit for convenience.
           * @since 1.6.0
           */
-        //def runParserFastUnsafe(input: String): Result[A] = runParserFastUnsafe(input.toCharArray)
+        @deprecated("This method will be removed in Parsley 3.0 since Strings are now the underlying representation for Parsley", "2.8.4")
+        def runParserFastUnsafe(input: Array[Char]): Result[A] = runParserFastUnsafe(new String(input))
         /** This method allows you to run a parser with a cached context, which improves performance.
           * If no implicit context can be found, the parsley default context is used. This will
           * cause issues with multi-threaded execution of parsers. In order to mitigate these issues,


### PR DESCRIPTION
Changes the implementation for the input from `Array[Char]` to `String`. Any (negligible) performance gains once obtained are now dwarfed by the use of `Array.slice` (O(n)) as opposed to `String.substring` (O(1)). Also, this allows us to remove a couple of `StringBuilders` in the tokeniser, as now `substring` can be used. A definitely performance gain was obtained from this.