### PR TITLE
Error optimising

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ target/
 .jvmopts
 *.class
 *.log
+.vscode
+.metals
+.bloop
+project/project
+project/metals.sbt

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ val projectName = "parsley"
 inThisBuild(List(
   organization := "com.github.j-mie6",
   homepage := Some(url("https://github.com/j-mie6/parsley")),
-  licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
+  licenses := List("BSD 3-Clause" -> url("https://opensource.org/licenses/BSD-3-Clause")),
   developers := List(
     Developer(
       "j-mie6",

--- a/src/main/scala/parsley/Parsley.scala
+++ b/src/main/scala/parsley/Parsley.scala
@@ -41,7 +41,7 @@ final class Parsley[+A] private [parsley] (private [parsley] val internal: deepe
       */
     def overflows(): Unit = internal.overflows()
 
-    //TODO: we need a way to set source pos and filename
+    // $COVERAGE-OFF$
     /** This method is responsible for actually executing parsers. Given an input
       * string, will parse the string with the parser. The result is either a `Success` or a `Failure`.
       * @param input The input to run against
@@ -49,6 +49,7 @@ final class Parsley[+A] private [parsley] (private [parsley] val internal: deepe
       */
     @deprecated("This method will be removed in Parsley 3.0 since Strings are now the underlying representation for Parsley", "2.8.4")
     def runParser(input: Array[Char]): Result[A] = runParser(new String(input))
+    // $COVERAGE-ON$
     /** This method is responsible for actually executing parsers. Given an input
       * array, will parse the string with the parser. The result is either a `Success` or a `Failure`.
       * @param input The input to run against
@@ -61,7 +62,7 @@ final class Parsley[+A] private [parsley] (private [parsley] val internal: deepe
       * @return Either a success with a value of type `A` or a failure with error message
       * @since 2.3.0
       */
-    def parseFromFile(file: File): Result[A] = new Context(internal.threadSafeInstrs, Source.fromFile(file).toString, Some(file.getName)).runParser()
+    def parseFromFile(file: File): Result[A] = new Context(internal.threadSafeInstrs, Source.fromFile(file).mkString, Some(file.getName)).runParser()
 }
 /** This object contains the core "function-style" combinators as well as the implicit classes which provide
   * the "method-style" combinators. All parsers will likely require something from within! */
@@ -81,7 +82,10 @@ object Parsley
           */
         def map[B](f: A => B): Parsley[B] = pure(f) <*> p
         /**This combinator is an alias for `map`*/
+        @deprecated("This combinator will be removed in Parsley 3.0, use .map instead", "2.8.4")
+        // $COVERAGE-OFF$
         def <#>[B](f: A => B): Parsley[B] = this.map(f)
+        // $COVERAGE-ON$
         /**
           * This is the Applicative application parser. The type of `pf` is `Parsley[A => B]`. Then, given a
           * `Parsley[A]`, we can produce a `Parsley[B]` by parsing `pf` to retrieve `f: A => B`, then parse `px`
@@ -201,7 +205,10 @@ object Parsley
           * @since 2.8.0
           */
         def filterOut(pred: PartialFunction[A, String]): Parsley[A] = new Parsley(new deepembedding.FilterOut(p.internal, pred))
+        // $COVERAGE-OFF$
+        // This can be dropped when we stop supporting scala 2.12
         def withFilter(pred: A => Boolean): Parsley[A] = this.filter(pred)
+        // $COVERAGE-ON$
         /** Attempts to first filter the parser to ensure that `pf` is defined over it. If it is, then the function `pf`
           * is mapped over its result. Roughly the same as a `filter` then a `map`.
           * @param pf The partial function

--- a/src/main/scala/parsley/Result.scala
+++ b/src/main/scala/parsley/Result.scala
@@ -185,6 +185,7 @@ class Failure private [parsley] (_msg: =>String) extends Result[Nothing] with Pr
     override def isFailure: Boolean = true
     override def get: Nothing = throw new NoSuchElementException("get called on Failure")
     // We are normally given everything below, but ideally we want to make error generation lazy
+    // $COVERAGE-OFF$
     override def toString: String = s"Failure($msg)"
     override def hashCode: Int = MurmurHash3.productHash(this)
     override def canEqual(x: Any): Boolean = x.isInstanceOf[Failure]
@@ -197,10 +198,13 @@ class Failure private [parsley] (_msg: =>String) extends Result[Nothing] with Pr
         case x: Failure => x.msg == msg
     })
     def copy(msg: =>String = this.msg): Failure = new Failure(msg)
+    // $COVERAGE-ON$
 }
+// $COVERAGE-OFF$
 object Failure {
     def apply(msg: =>String): Failure = new Failure(msg)
     def unapply(x: Failure): Some[String] = Some(x.msg)
     def andThen[A](f: Failure => A): String => A = msg => f(Failure(msg))
     def compose[A](f: A => String): A => Failure = msg => Failure(f(msg))
 }
+// $COVERAGE-ON$

--- a/src/main/scala/parsley/Result.scala
+++ b/src/main/scala/parsley/Result.scala
@@ -193,16 +193,13 @@ class Failure private [parsley] (_msg: =>String) extends Result[Nothing] with Pr
     override def productElement(idx: Int): Any = {
         if (idx != 0) throw new IndexOutOfBoundsException("Failure only has arity 1") else msg
     }
-    override def productElementName(idx: Int): String = {
-        if (idx != 0) throw new IndexOutOfBoundsException("Failure only has arity 1") else "msg"
-    }
     override def equals(x: Any): Boolean = x != null && (x match {
         case x: Failure => x.msg == msg
     })
-    def copy(msg: =>String = this.msg) = new Failure(msg)
+    def copy(msg: =>String = this.msg): Failure = new Failure(msg)
 }
 object Failure {
-    def apply(msg: =>String) = new Failure(msg)
+    def apply(msg: =>String): Failure = new Failure(msg)
     def unapply(x: Failure): Some[String] = Some(x.msg)
     def andThen[A](f: Failure => A): String => A = msg => f(Failure(msg))
     def compose[A](f: A => String): A => Failure = msg => Failure(f(msg))

--- a/src/main/scala/parsley/internal/deepembedding/AlternativeEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/AlternativeEmbedding.scala
@@ -7,6 +7,7 @@ import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.language.higherKinds
 
+// Tablification is too aggressive. It appears that `optional` is being compiled to jumptable
 private [parsley] final class <|>[A, B](_p: =>Parsley[A], _q: =>Parsley[B]) extends Binary[A, B, B](_p, _q)((l, r) => s"($l <|> $r)", <|>.empty) {
     override val numInstrs = 3
 

--- a/src/main/scala/parsley/internal/deepembedding/AlternativeEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/AlternativeEmbedding.scala
@@ -206,7 +206,7 @@ private [parsley] class Empty(val expected: Option[String] = None)
     extends SingletonExpect[Nothing]("empty", new Empty(_), new instructions.Empty(expected)) with MZero
 
 private [deepembedding] object <|> {
-    def empty[A, B]: A <|> B = new <|>(null, null)
+    def empty[A, B]: A <|> B = new <|>(???, ???)
     def apply[A, B](left: Parsley[A], right: Parsley[B]): A <|> B = empty.ready(left, right)
     def unapply[A, B](self: A <|> B): Option[(Parsley[A], Parsley[B])] = Some((self.left, self.right))
 }

--- a/src/main/scala/parsley/internal/deepembedding/AlternativeEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/AlternativeEmbedding.scala
@@ -1,7 +1,8 @@
 package parsley.internal.deepembedding
 
 import ContOps.{result, ContAdapter}
-import parsley.internal.instructions, instructions.{ErrorItem, Raw, Desc}
+import parsley.internal.instructions
+import parsley.internal.errors.{ErrorItem, Raw, Desc}
 
 import scala.annotation.tailrec
 import scala.collection.mutable

--- a/src/main/scala/parsley/internal/deepembedding/AlternativeEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/AlternativeEmbedding.scala
@@ -7,7 +7,7 @@ import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.language.higherKinds
 
-// Tablification is too aggressive. It appears that `optional` is being compiled to jumptable
+// TODO: Tablification is too aggressive. It appears that `optional` is being compiled to jumptable
 private [parsley] final class <|>[A, B](_p: =>Parsley[A], _q: =>Parsley[B]) extends Binary[A, B, B](_p, _q)((l, r) => s"($l <|> $r)", <|>.empty) {
     override val numInstrs = 3
 
@@ -89,6 +89,7 @@ private [parsley] final class <|>[A, B](_p: =>Parsley[A], _q: =>Parsley[B]) exte
             val end = state.freshLabel()
             val default = state.freshLabel()
             val (roots, leads, ls, expecteds) = foldTablified(tablified, state, mutable.Map.empty, Nil, Nil, mutable.Map.empty)
+            //println(leads, tablified)
             instrs += new instructions.JumpTable(leads, ls, default, expecteds)
             codeGenRoots(roots, ls, end) >> {
                 instrs += instructions.Catch //This instruction is reachable as default - 1

--- a/src/main/scala/parsley/internal/deepembedding/AlternativeEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/AlternativeEmbedding.scala
@@ -1,7 +1,7 @@
 package parsley.internal.deepembedding
 
 import ContOps.{result, ContAdapter}
-import parsley.internal.{UnsafeOption, instructions}, instructions.{ErrorItem, Raw, Desc}
+import parsley.internal.instructions, instructions.{ErrorItem, Raw, Desc}
 
 import scala.annotation.tailrec
 import scala.collection.mutable
@@ -97,7 +97,7 @@ private [parsley] final class <|>[A, B](_p: =>Parsley[A], _q: =>Parsley[B]) exte
                 val merge = state.freshLabel()
                 instrs += new instructions.PushHandler(merge)
                 if (needsDefault) {
-                    instrs += new instructions.Empty(null)
+                    instrs += new instructions.Empty(None)
                     instrs += new instructions.Label(merge)
                     instrs += instructions.MergeErrors
                     result(instrs += new instructions.Label(end))
@@ -207,7 +207,7 @@ private [parsley] final class <|>[A, B](_p: =>Parsley[A], _q: =>Parsley[B]) exte
 }
 
 private [parsley] class Empty(val expected: UnsafeOption[String] = null)
-    extends SingletonExpect[Nothing]("empty", new Empty(_), new instructions.Empty(expected)) with MZero
+    extends SingletonExpect[Nothing]("empty", new Empty(_), new instructions.Empty(Option(expected))) with MZero
 
 private [deepembedding] object <|> {
     def empty[A, B]: A <|> B = new <|>(null, null)

--- a/src/main/scala/parsley/internal/deepembedding/AlternativeEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/AlternativeEmbedding.scala
@@ -40,12 +40,11 @@ private [parsley] final class <|>[A, B](_p: =>Parsley[A], _q: =>Parsley[B]) exte
                 case v =>
                     val handler = state.freshLabel()
                     val skip = state.freshLabel()
+                    val merge = state.freshLabel()
                     instrs += new instructions.PushHandlerAndState(handler, true, false)
                     u.codeGen >> {
                         instrs += new instructions.Label(handler)
-                        instrs += new instructions.JumpGoodAttempt(skip)
-                        val merge = state.freshLabel()
-                        instrs += new instructions.PushHandler(merge)
+                        instrs += new instructions.JumpGoodAttempt(skip, merge)
                         v.codeGen |> {
                             instrs += new instructions.Label(merge)
                             instrs += instructions.MergeErrors
@@ -125,12 +124,11 @@ private [parsley] final class <|>[A, B](_p: =>Parsley[A], _q: =>Parsley[B]) exte
         case Attempt(alt)::alts_ =>
             val handler = state.freshLabel()
             val skip = state.freshLabel()
+            val merge = state.freshLabel()
             instrs += new instructions.PushHandlerAndState(handler, true, false)
             alt.codeGen >> {
                 instrs += new instructions.Label(handler)
-                instrs += new instructions.JumpGoodAttempt(skip)
-                val merge = state.freshLabel()
-                instrs += new instructions.PushHandler(merge)
+                instrs += new instructions.JumpGoodAttempt(skip, merge)
                 codeGenAlternatives(alts_) |> {
                     instrs += new instructions.Label(merge)
                     instrs += instructions.MergeErrors

--- a/src/main/scala/parsley/internal/deepembedding/GeneralisedEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/GeneralisedEmbedding.scala
@@ -8,9 +8,9 @@ import scala.language.higherKinds
 // Core Embedding
 private [parsley] abstract class Singleton[A](pretty: String, instr: =>instructions.Instr) extends Parsley[A] {
     final override def findLetsAux[Cont[_, +_]: ContOps]
-        (implicit seen: Set[Parsley[_]], state: LetFinderState, label: UnsafeOption[String]): Cont[Unit, Unit] = result(())
+        (implicit seen: Set[Parsley[_]], state: LetFinderState, label: Option[String]): Cont[Unit, Unit] = result(())
     final override def preprocess[Cont[_, +_]: ContOps, A_ >: A](implicit seen: Set[Parsley[_]], sub: SubMap,
-                                                                 label: UnsafeOption[String]): Cont[Unit, Parsley[A_]] = result(this)
+                                                                 label: Option[String]): Cont[Unit, Parsley[A_]] = result(this)
     final override def codeGen[Cont[_, +_]: ContOps](implicit instrs: InstrBuffer, state: CodeGenState): Cont[Unit, Unit] = {
         result(instrs += instr)
     }
@@ -19,13 +19,13 @@ private [parsley] abstract class Singleton[A](pretty: String, instr: =>instructi
     // $COVERAGE-ON$
 }
 
-private [deepembedding] abstract class SingletonExpect[A](pretty: String, builder: UnsafeOption[String] => SingletonExpect[A], instr: instructions.Instr)
+private [deepembedding] abstract class SingletonExpect[A](pretty: String, builder: Option[String] => SingletonExpect[A], instr: instructions.Instr)
     extends Parsley[A] {
     final override def findLetsAux[Cont[_, +_]: ContOps]
-        (implicit seen: Set[Parsley[_]], state: LetFinderState, label: UnsafeOption[String]): Cont[Unit, Unit] = result(())
+        (implicit seen: Set[Parsley[_]], state: LetFinderState, label: Option[String]): Cont[Unit, Unit] = result(())
     final override def preprocess[Cont[_, +_]: ContOps, A_ >: A](implicit seen: Set[Parsley[_]], sub: SubMap,
-                                                                 label: UnsafeOption[String]): Cont[Unit, Parsley[A]] = {
-        if (label == null) result(this)
+                                                                 label: Option[String]): Cont[Unit, Parsley[A]] = {
+        if (label.isEmpty) result(this)
         else result(builder(label))
     }
     final override def codeGen[Cont[_, +_]: ContOps](implicit instrs: InstrBuffer, state: CodeGenState): Cont[Unit, Unit] = {
@@ -36,15 +36,15 @@ private [deepembedding] abstract class SingletonExpect[A](pretty: String, builde
     // $COVERAGE-ON$
 }
 
-private [deepembedding] abstract class Unary[A, B](__p: =>Parsley[A])(pretty: String => String, empty: String => Unary[A, B]) extends Parsley[B] {
+private [deepembedding] abstract class Unary[A, B](__p: =>Parsley[A])(pretty: String => String, empty: Option[String] => Unary[A, B]) extends Parsley[B] {
     private lazy val _p = __p
     private [deepembedding] var p: Parsley[A] = _
     protected val childRepeats: Int = 1
     protected val numInstrs: Int
     final override def findLetsAux[Cont[_, +_]: ContOps]
-        (implicit seen: Set[Parsley[_]], state: LetFinderState, label: UnsafeOption[String]): Cont[Unit,Unit] = _p.findLets
+        (implicit seen: Set[Parsley[_]], state: LetFinderState, label: Option[String]): Cont[Unit,Unit] = _p.findLets
     override def preprocess[Cont[_, +_]: ContOps, B_ >: B](implicit seen: Set[Parsley[_]], sub: SubMap,
-                                                           label: UnsafeOption[String]): Cont[Unit, Parsley[B_]] =
+                                                           label: Option[String]): Cont[Unit, Parsley[B_]] =
         for (p <- _p.optimised) yield empty(label).ready(p)
     private [deepembedding] def ready(p: Parsley[A]): this.type = {
         processed = true
@@ -67,9 +67,9 @@ private [deepembedding] abstract class Binary[A, B, C](__left: =>Parsley[A], __r
     protected val leftRepeats: Int = 1
     protected val rightRepeats: Int = 1
     final override def findLetsAux[Cont[_, +_]: ContOps]
-        (implicit seen: Set[Parsley[_]], state: LetFinderState, label: UnsafeOption[String]): Cont[Unit,Unit] = _left.findLets >> _right.findLets
+        (implicit seen: Set[Parsley[_]], state: LetFinderState, label: Option[String]): Cont[Unit,Unit] = _left.findLets >> _right.findLets
     final override def preprocess[Cont[_, +_]: ContOps, C_ >: C](implicit seen: Set[Parsley[_]], sub: SubMap,
-                                                   label: UnsafeOption[String]): Cont[Unit, Parsley[C_]] =
+                                                   label: Option[String]): Cont[Unit, Parsley[C_]] =
         for (left <- _left.optimised; right <- _right.optimised) yield {
             empty.ready(left, right)
         }
@@ -97,11 +97,11 @@ private [deepembedding] abstract class Ternary[A, B, C, D](__first: =>Parsley[A]
     private [deepembedding] var third: Parsley[C] = _
     protected val numInstrs: Int
     final override def findLetsAux[Cont[_, +_]: ContOps]
-        (implicit seen: Set[Parsley[_]], state: LetFinderState, label: UnsafeOption[String]): Cont[Unit, Unit] = {
+        (implicit seen: Set[Parsley[_]], state: LetFinderState, label: Option[String]): Cont[Unit, Unit] = {
         _first.findLets >> _second.findLets >> _third.findLets
     }
     final override def preprocess[Cont[_, +_]: ContOps, D_ >: D](implicit seen: Set[Parsley[_]], sub: SubMap,
-                                                           label: UnsafeOption[String]): Cont[Unit, Parsley[D_]] =
+                                                           label: Option[String]): Cont[Unit, Parsley[D_]] =
         for (first <- _first.optimised; second <- _second.optimised; third <- _third.optimised) yield {
             empty.ready(first, second, third)
         }

--- a/src/main/scala/parsley/internal/deepembedding/GeneralisedEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/GeneralisedEmbedding.scala
@@ -1,7 +1,7 @@
 package parsley.internal.deepembedding
 
 import ContOps.{result, ContAdapter}
-import parsley.internal.{UnsafeOption, instructions}
+import parsley.internal.instructions
 
 import scala.language.higherKinds
 

--- a/src/main/scala/parsley/internal/deepembedding/IntrinsicEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/IntrinsicEmbedding.scala
@@ -117,33 +117,33 @@ private [deepembedding] object StringTok {
     def unapply(self: StringTok): Option[String] = Some(self.s)
 }
 private [deepembedding] object Lift2 {
-    def empty[A, B, C](f: (A, B) => C): Lift2[A, B, C] = new Lift2(f, null, null)
+    def empty[A, B, C](f: (A, B) => C): Lift2[A, B, C] = new Lift2(f, ???, ???)
     def unapply[A, B, C](self: Lift2[A, B, C]): Option[((A, B) => C, Parsley[A], Parsley[B])] = Some((self.f, self.left, self.right))
 }
 private [deepembedding] object Lift3 {
-    def empty[A, B, C, D](f: (A, B, C) => D): Lift3[A, B, C, D] = new Lift3(f, null, null, null)
+    def empty[A, B, C, D](f: (A, B, C) => D): Lift3[A, B, C, D] = new Lift3(f, ???, ???, ???)
     def unapply[A, B, C, D](self: Lift3[A, B, C, D]): Option[((A, B, C) => D, Parsley[A], Parsley[B], Parsley[C])] = {
         Some((self.f, self.first, self.second, self.third))
     }
 }
 private [deepembedding] object FastFail {
-    def empty[A](msggen: A => String): FastFail[A] = new FastFail(null, msggen)
+    def empty[A](msggen: A => String): FastFail[A] = new FastFail(???, msggen)
 }
 private [deepembedding] object FastUnexpected {
-    def empty[A](msggen: A => String, expected: Option[String]): FastUnexpected[A] = new FastUnexpected(null, msggen, expected)
+    def empty[A](msggen: A => String, expected: Option[String]): FastUnexpected[A] = new FastUnexpected(???, msggen, expected)
 }
 private [deepembedding] object Filter {
-    def empty[A](pred: A => Boolean, expected: Option[String]): Filter[A] = new Filter(null, pred, expected)
+    def empty[A](pred: A => Boolean, expected: Option[String]): Filter[A] = new Filter(???, pred, expected)
 }
 private [deepembedding] object FilterOut {
-    def empty[A](pred: PartialFunction[A, String], expected: Option[String]): FilterOut[A] = new FilterOut(null, pred, expected)
+    def empty[A](pred: PartialFunction[A, String], expected: Option[String]): FilterOut[A] = new FilterOut(???, pred, expected)
 }
 private [deepembedding] object GuardAgainst {
-    def empty[A](pred: PartialFunction[A, String]): GuardAgainst[A] = new GuardAgainst(null, pred)
+    def empty[A](pred: PartialFunction[A, String]): GuardAgainst[A] = new GuardAgainst(???, pred)
 }
 private [deepembedding] object If {
-    def empty[A]: If[A] = new If(null, null, null)
+    def empty[A]: If[A] = new If(???, ???, ???)
 }
 private [deepembedding] object Local {
-    def empty[S, A](r: Reg[S]): Local[S, A] = new Local(r, null, null)
+    def empty[S, A](r: Reg[S]): Local[S, A] = new Local(r, ???, ???)
 }

--- a/src/main/scala/parsley/internal/deepembedding/IntrinsicEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/IntrinsicEmbedding.scala
@@ -54,7 +54,7 @@ private [parsley] final class FastFail[A](_p: =>Parsley[A], msggen: A => String)
     extends FilterLike[A, Nothing](_p, c => s"$c ! ?", _ => FastFail.empty(msggen),
                                    x => new Fail(msggen(x)), new instructions.FastFail(msggen), _ => true) with MZero
 private [parsley] final class FastUnexpected[A](_p: =>Parsley[A], msggen: A => String, expected: UnsafeOption[String] = null)
-    extends FilterLike[A, Nothing](_p, c => s"$c.unexpected(?)", _ => FastFail.empty(msggen),
+    extends FilterLike[A, Nothing](_p, c => s"$c.unexpected(?)", FastUnexpected.empty(msggen, _),
                                    x => new Unexpected(msggen(x), expected), new instructions.FastUnexpected(msggen, expected), _ => true) with MZero
 private [parsley] final class Filter[A](_p: =>Parsley[A], pred: A => Boolean, expected: UnsafeOption[String] = null)
     extends FilterLike[A, A](_p, c => s"$c.filter(?)", Filter.empty(pred, _),
@@ -118,41 +118,32 @@ private [deepembedding] object StringTok {
 }
 private [deepembedding] object Lift2 {
     def empty[A, B, C](f: (A, B) => C): Lift2[A, B, C] = new Lift2(f, null, null)
-    def apply[A, B, C](f: (A, B) => C, left: Parsley[A], right: Parsley[B]): Lift2[A, B, C] = empty(f).ready(left, right)
     def unapply[A, B, C](self: Lift2[A, B, C]): Option[((A, B) => C, Parsley[A], Parsley[B])] = Some((self.f, self.left, self.right))
 }
 private [deepembedding] object Lift3 {
     def empty[A, B, C, D](f: (A, B, C) => D): Lift3[A, B, C, D] = new Lift3(f, null, null, null)
-    def apply[A, B, C, D](f: (A, B, C) => D, p: Parsley[A], q: Parsley[B], r: Parsley[C]): Lift3[A, B, C, D] = empty(f).ready(p, q, r)
     def unapply[A, B, C, D](self: Lift3[A, B, C, D]): Option[((A, B, C) => D, Parsley[A], Parsley[B], Parsley[C])] = {
         Some((self.f, self.first, self.second, self.third))
     }
 }
 private [deepembedding] object FastFail {
     def empty[A](msggen: A => String): FastFail[A] = new FastFail(null, msggen)
-    def apply[A](p: Parsley[A], msggen: A => String): FastFail[A] = empty(msggen).ready(p)
 }
 private [deepembedding] object FastUnexpected {
     def empty[A](msggen: A => String, expected: UnsafeOption[String]): FastUnexpected[A] = new FastUnexpected(null, msggen, expected)
-    def apply[A](p: Parsley[A], msggen: A => String, expected: UnsafeOption[String]): FastUnexpected[A] = empty(msggen, expected).ready(p)
 }
 private [deepembedding] object Filter {
     def empty[A](pred: A => Boolean, expected: UnsafeOption[String]): Filter[A] = new Filter(null, pred, expected)
-    def apply[A](p: Parsley[A], pred: A => Boolean, expected: UnsafeOption[String]): Filter[A] = empty(pred, expected).ready(p)
 }
 private [deepembedding] object FilterOut {
     def empty[A](pred: PartialFunction[A, String], expected: UnsafeOption[String]): FilterOut[A] = new FilterOut(null, pred, expected)
-    def apply[A](p: Parsley[A], pred: PartialFunction[A, String], expected: UnsafeOption[String]): FilterOut[A] = empty(pred, expected).ready(p)
 }
 private [deepembedding] object GuardAgainst {
     def empty[A](pred: PartialFunction[A, String]): GuardAgainst[A] = new GuardAgainst(null, pred)
-    def apply[A](p: Parsley[A], pred: PartialFunction[A, String]): GuardAgainst[A] = empty(pred).ready(p)
 }
 private [deepembedding] object If {
     def empty[A]: If[A] = new If(null, null, null)
-    def apply[A](b: Parsley[Boolean], p: Parsley[A], q: Parsley[A]): If[A] = empty.ready(b, p, q)
 }
 private [deepembedding] object Local {
     def empty[S, A](r: Reg[S]): Local[S, A] = new Local(r, null, null)
-    def apply[S, A](r: Reg[S], left: Parsley[S], right: Parsley[A]): Local[S, A] = empty(r).ready(left, right)
 }

--- a/src/main/scala/parsley/internal/deepembedding/IterativeEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/IterativeEmbedding.scala
@@ -1,7 +1,7 @@
 package parsley.internal.deepembedding
 
 import ContOps.{result, ContAdapter}
-import parsley.internal.{UnsafeOption, instructions}
+import parsley.internal.instructions
 
 import scala.annotation.tailrec
 import scala.collection.mutable

--- a/src/main/scala/parsley/internal/deepembedding/IterativeEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/IterativeEmbedding.scala
@@ -119,7 +119,7 @@ private [parsley] final class SepEndBy1[A, B](_p: =>Parsley[A], _sep: =>Parsley[
         }
     }
 }
-private [parsley] final class ManyUntil[A](_body: Parsley[Any]) extends Unary[Any, List[A]](_body)(c => s"manyUntil($c)", _ => ManyUntil.empty) {
+private [parsley] final class ManyUntil[A](_body: =>Parsley[Any]) extends Unary[Any, List[A]](_body)(c => s"manyUntil($c)", _ => ManyUntil.empty) {
     override val numInstrs = 2
     override def codeGen[Cont[_, +_]: ContOps](implicit instrs: InstrBuffer, state: CodeGenState): Cont[Unit, Unit] = {
         val start = state.freshLabel()

--- a/src/main/scala/parsley/internal/deepembedding/IterativeEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/IterativeEmbedding.scala
@@ -135,34 +135,26 @@ private [parsley] final class ManyUntil[A](_body: Parsley[Any]) extends Unary[An
 
 private [deepembedding] object Many {
     def empty[A]: Many[A] = new Many(null)
-    def apply[A](p: Parsley[A]): Many[A] = empty.ready(p)
 }
 private [deepembedding] object SkipMany {
     def empty[A]: SkipMany[A] = new SkipMany(null)
-    def apply[A](p: Parsley[A]): SkipMany[A] = empty.ready(p)
 }
 private [deepembedding] object ChainPost {
     def empty[A]: ChainPost[A] = new ChainPost(null, null)
-    def apply[A](left: Parsley[A], right: Parsley[A => A]): ChainPost[A] = empty.ready(left, right)
 }
 private [deepembedding] object ChainPre {
     def empty[A]: ChainPre[A] = new ChainPre(null, null)
-    def apply[A](left: Parsley[A], right: Parsley[A => A]): ChainPre[A] = empty.ready(left, right)
 }
 private [deepembedding] object Chainl {
     def empty[A, B]: Chainl[A, B] = new Chainl(null, null, null)
-    def apply[A, B](first: Parsley[B], second: Parsley[A], third: Parsley[(B, A) => B]): Chainl[A, B] = empty.ready(first, second, third)
 }
 private [deepembedding] object Chainr {
     def empty[A, B](wrap: A => B): Chainr[A, B] = new Chainr(null, null, wrap)
-    def apply[A, B](left: Parsley[A], right: Parsley[(A, B) => B], wrap: A => B): Chainr[A, B] = empty(wrap).ready(left, right)
 }
 private [deepembedding] object SepEndBy1 {
     def empty[A, B]: SepEndBy1[A, B] = new SepEndBy1(null, null)
-    def apply[A, B](left: Parsley[A], right: Parsley[B]): SepEndBy1[A, B] = empty.ready(left, right)
 }
 private [parsley] object ManyUntil {
     object Stop
     def empty[A]: ManyUntil[A] = new ManyUntil(null)
-    def apply[A](p: Parsley[Any]): ManyUntil[A] = empty.ready(p)
 }

--- a/src/main/scala/parsley/internal/deepembedding/Parsley.scala
+++ b/src/main/scala/parsley/internal/deepembedding/Parsley.scala
@@ -231,7 +231,6 @@ private [parsley] class LetFinderState {
         case (k@(label, p), refs) if refs >= 2 && !_recs(p) => k
     }
 
-    def recs: Set[Parsley[_]] = _recs.toSet
     def usedRegs: Set[Reg[_]] = _usedRegs.toSet
 }
 

--- a/src/main/scala/parsley/internal/deepembedding/Parsley.scala
+++ b/src/main/scala/parsley/internal/deepembedding/Parsley.scala
@@ -40,7 +40,7 @@ private [parsley] abstract class Parsley[+A] private [deepembedding]
 
     // Internals
     final private [deepembedding] def findLets[Cont[_, +_]: ContOps]
-        (implicit seen: Set[Parsley[_]], state: LetFinderState, label: UnsafeOption[String]): Cont[Unit, Unit] = {
+        (implicit seen: Set[Parsley[_]], state: LetFinderState, label: Option[String]): Cont[Unit, Unit] = {
         state.addPred(this, label)
         if (seen(this)) result(state.addRec(this))
         else if (state.notProcessedBefore(this, label)) {
@@ -52,7 +52,7 @@ private [parsley] abstract class Parsley[+A] private [deepembedding]
         }
         else result(())
     }
-    final private def fix(implicit seen: Set[Parsley[_]], sub: SubMap, label: UnsafeOption[String]): Parsley[A] = {
+    final private def fix(implicit seen: Set[Parsley[_]], sub: SubMap, label: Option[String]): Parsley[A] = {
         // We use the seen set here to prevent cascading sub-routines
         val wasSeen = seen(this)
         val self = sub(label, this)
@@ -62,7 +62,7 @@ private [parsley] abstract class Parsley[+A] private [deepembedding]
     }
     final private [deepembedding] def optimised[Cont[_, +_]: ContOps, A_ >: A](implicit seen: Set[Parsley[_]],
                                                                                         sub: SubMap,
-                                                                                        label: UnsafeOption[String]): Cont[Unit, Parsley[A_]] = {
+                                                                                        label: Option[String]): Cont[Unit, Parsley[A_]] = {
         val fixed = this.fix
         if (fixed.processed) result(fixed.optimise)
         else for (p <- fixed.preprocess(implicitly[ContOps[Cont]], seen + this, sub, label)) yield p.optimise
@@ -91,7 +91,7 @@ private [parsley] abstract class Parsley[+A] private [deepembedding]
     final private def pipeline[Cont[_, +_]: ContOps](implicit instrs: InstrBuffer, state: CodeGenState): Unit = {
         perform {
             implicit val seenSet: Set[Parsley[_]] = Set.empty
-            implicit val label: UnsafeOption[String] = null
+            implicit val label: Option[String] = None
             implicit val letFinderState: LetFinderState = new LetFinderState
             implicit lazy val subMap: SubMap = new SubMap(letFinderState.lets)
             findLets >> {
@@ -151,9 +151,9 @@ private [parsley] abstract class Parsley[+A] private [deepembedding]
     // Sub-tree optimisation and Rec calculation - Bottom-up
     protected def preprocess[Cont[_, +_]: ContOps, A_ >: A](implicit seen: Set[Parsley[_]],
                                                             sub: SubMap,
-                                                            label: UnsafeOption[String]): Cont[Unit, Parsley[A_]]
+                                                            label: Option[String]): Cont[Unit, Parsley[A_]]
     // Let-finder recursion
-    protected def findLetsAux[Cont[_, +_]: ContOps](implicit seen: Set[Parsley[_]], state: LetFinderState, label: UnsafeOption[String]): Cont[Unit, Unit]
+    protected def findLetsAux[Cont[_, +_]: ContOps](implicit seen: Set[Parsley[_]], state: LetFinderState, label: Option[String]): Cont[Unit, Unit]
     // Optimisation - Bottom-up
     protected def optimise: Parsley[A] = this
     // Peephole optimisation and code generation - Top-down
@@ -219,27 +219,27 @@ private [parsley] class CodeGenState {
 
 private [parsley] class LetFinderState {
     private val _recs = mutable.Set.empty[Parsley[_]]
-    private val _preds = mutable.Map.empty[(UnsafeOption[String], Parsley[_]), Int]
+    private val _preds = mutable.Map.empty[(Option[String], Parsley[_]), Int]
     private val _usedRegs = mutable.Set.empty[Reg[_]]
 
-    def addPred(p: Parsley[_], label: UnsafeOption[String]): Unit = _preds += (label, p) -> (_preds.getOrElseUpdate((label, p), 0) + 1)
+    def addPred(p: Parsley[_], label: Option[String]): Unit = _preds += (label, p) -> (_preds.getOrElseUpdate((label, p), 0) + 1)
     def addRec(p: Parsley[_]): Unit = _recs += p
     def addReg(reg: Reg[_]): Unit = _usedRegs += reg
-    def notProcessedBefore(p: Parsley[_], label: UnsafeOption[String]): Boolean = _preds((label, p)) == 1
+    def notProcessedBefore(p: Parsley[_], label: Option[String]): Boolean = _preds((label, p)) == 1
 
-    def lets: Iterable[(UnsafeOption[String], Parsley[_])] = _preds.toSeq.collect {
+    def lets: Iterable[(Option[String], Parsley[_])] = _preds.toSeq.collect {
         case (k@(label, p), refs) if refs >= 2 && !_recs(p) => k
     }
 
     def usedRegs: Set[Reg[_]] = _usedRegs.toSet
 }
 
-private [parsley] class SubMap(subs: Iterable[(UnsafeOption[String], Parsley[_])]) {
-    private val subMap: Map[(UnsafeOption[String], Parsley[_]), Subroutine[_]] = subs.map {
+private [parsley] class SubMap(subs: Iterable[(Option[String], Parsley[_])]) {
+    private val subMap: Map[(Option[String], Parsley[_]), Subroutine[_]] = subs.map {
         case k@(label, p) => k -> new Subroutine(p, label)
     }.toMap
 
-    def apply[A](label: UnsafeOption[String], p: Parsley[A]): Parsley[A] = subMap.getOrElse((label, p), p).asInstanceOf[Parsley[A]]
+    def apply[A](label: Option[String], p: Parsley[A]): Parsley[A] = subMap.getOrElse((label, p), p).asInstanceOf[Parsley[A]]
     // $COVERAGE-OFF$
     override def toString: String = subMap.toString
     // $COVERAGE-ON$

--- a/src/main/scala/parsley/internal/deepembedding/Parsley.scala
+++ b/src/main/scala/parsley/internal/deepembedding/Parsley.scala
@@ -5,7 +5,7 @@ import scala.annotation.tailrec
 import scala.collection.mutable
 
 import parsley.registers.Reg
-import parsley.internal.instructions, instructions.{Instr, JumpTable, JumpInstr, Label}
+import parsley.internal.instructions, instructions.{Instr, JumpTable, Label}
 import parsley.internal.ResizableArray
 import Parsley.allocateRegisters
 import ContOps.{safeCall, GenOps, perform, result, ContAdapter}
@@ -128,8 +128,7 @@ private [parsley] abstract class Parsley[+A] private [deepembedding]
         @tailrec def applyLabels(srcs: Array[Instr], labels: Array[Int], dests: Array[Instr], n: Int, i: Int, off: Int): Unit = if (i < n) srcs(i + off) match {
             case null => applyLabels(srcs, labels, dests, n, i, off + 1)
             case instr =>
-                instr.relabel(labels)
-                dests(i) = instr
+                dests(i) = instr.relabel(labels)
                 applyLabels(srcs, labels, dests, n, i + 1, off)
         }
         val instrsOversize = instrs.toArray

--- a/src/main/scala/parsley/internal/deepembedding/Parsley.scala
+++ b/src/main/scala/parsley/internal/deepembedding/Parsley.scala
@@ -6,7 +6,7 @@ import scala.collection.mutable
 
 import parsley.registers.Reg
 import parsley.internal.instructions, instructions.{Instr, JumpTable, JumpInstr, Label}
-import parsley.internal.{UnsafeOption, ResizableArray}
+import parsley.internal.ResizableArray
 import Parsley.allocateRegisters
 import ContOps.{safeCall, GenOps, perform, result, ContAdapter}
 

--- a/src/main/scala/parsley/internal/deepembedding/PrimitiveEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/PrimitiveEmbedding.scala
@@ -150,28 +150,28 @@ private [deepembedding] object Satisfy {
     def unapply(self: Satisfy): Option[Char => Boolean] = Some(self.f)
 }
 private [deepembedding] object Attempt {
-    def empty[A]: Attempt[A] = new Attempt(null)
+    def empty[A]: Attempt[A] = new Attempt(???)
     def unapply[A](self: Attempt[A]): Option[Parsley[A]] = Some(self.p)
 }
 private [deepembedding] object Look {
-    def empty[A]: Look[A] = new Look(null)
+    def empty[A]: Look[A] = new Look(???)
 }
 private [deepembedding] object ErrorLabel {
-    def empty[A](label: String): ErrorLabel[A] = new ErrorLabel(null, label)
+    def empty[A](label: String): ErrorLabel[A] = new ErrorLabel(???, label)
     def apply[A](p: Parsley[A], label: String): ErrorLabel[A] = empty(label).ready(p)
 }
 private [deepembedding] object ErrorExplain {
-    def empty[A](reason: String): ErrorExplain[A] = new ErrorExplain(null, reason)
+    def empty[A](reason: String): ErrorExplain[A] = new ErrorExplain(???, reason)
     def apply[A](p: Parsley[A], reason: String): ErrorExplain[A] = empty(reason).ready(p)
 }
 private [deepembedding] object NotFollowedBy {
-    def empty[A](expected: Option[String]): NotFollowedBy[A] = new NotFollowedBy(null, expected)
+    def empty[A](expected: Option[String]): NotFollowedBy[A] = new NotFollowedBy(???, expected)
 }
 private [deepembedding] object Put {
-    def empty[S](r: Reg[S]): Put[S] = new Put(r, null)
+    def empty[S](r: Reg[S]): Put[S] = new Put(r, ???)
 }
 private [deepembedding] object Debug {
-    def empty[A](name: String, break: Breakpoint): Debug[A] = new Debug(null, name, break)
+    def empty[A](name: String, break: Breakpoint): Debug[A] = new Debug(???, name, break)
 }
 
 private [deepembedding] object Rec {

--- a/src/main/scala/parsley/internal/deepembedding/PrimitiveEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/PrimitiveEmbedding.scala
@@ -9,11 +9,11 @@ import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.language.higherKinds
 
-private [parsley] final class Satisfy(private [Satisfy] val f: Char => Boolean, val expected: UnsafeOption[String] = null)
-    extends SingletonExpect[Char]("satisfy(f)", new Satisfy(f, _), new instructions.Satisfies(f, Option(expected)))
+private [parsley] final class Satisfy(private [Satisfy] val f: Char => Boolean, val expected: Option[String] = None)
+    extends SingletonExpect[Char]("satisfy(f)", new Satisfy(f, _), new instructions.Satisfies(f, expected))
 
 private [deepembedding] sealed abstract class ScopedUnary[A, B](_p: =>Parsley[A], name: String, doesNotProduceHints: Boolean,
-                                                                empty: UnsafeOption[String] => ScopedUnary[A, B], instr: instructions.Instr)
+                                                                empty: Option[String] => ScopedUnary[A, B], instr: instructions.Instr)
     extends Unary[A, B](_p)(c => s"$name($c)", empty) {
     final override val numInstrs = 2
     final override def codeGen[Cont[_, +_]: ContOps](implicit instrs: InstrBuffer, state: CodeGenState): Cont[Unit, Unit] = {
@@ -27,8 +27,8 @@ private [deepembedding] sealed abstract class ScopedUnary[A, B](_p: =>Parsley[A]
 }
 private [parsley] final class Attempt[A](_p: =>Parsley[A]) extends ScopedUnary[A, A](_p, "attempt", false, _ => Attempt.empty, instructions.Attempt)
 private [parsley] final class Look[A](_p: =>Parsley[A]) extends ScopedUnary[A, A](_p, "lookAhead", true, _ => Look.empty, instructions.Look)
-private [parsley] final class NotFollowedBy[A](_p: =>Parsley[A], val expected: UnsafeOption[String] = null)
-    extends ScopedUnary[A, Unit](_p, "notFollowedBy", true, NotFollowedBy.empty, new instructions.NotFollowedBy(Some(expected))) {
+private [parsley] final class NotFollowedBy[A](_p: =>Parsley[A], val expected: Option[String] = None)
+    extends ScopedUnary[A, Unit](_p, "notFollowedBy", true, NotFollowedBy.empty, new instructions.NotFollowedBy(expected)) {
     override def optimise: Parsley[Unit] = p match {
         case z: MZero => new Pure(())
         case _ => this
@@ -38,20 +38,20 @@ private [parsley] final class NotFollowedBy[A](_p: =>Parsley[A], val expected: U
 private [parsley] final class Fail(private [Fail] val msg: String)
     extends SingletonExpect[Nothing](s"fail($msg)", _ => new Fail(msg), new instructions.Fail(msg)) with MZero
 
-private [parsley] final class Unexpected(private [Unexpected] val msg: String, val expected: UnsafeOption[String] = null)
-    extends SingletonExpect[Nothing](s"unexpected($msg)", new Unexpected(msg, _), new instructions.Unexpected(msg, Option(expected))) with MZero
+private [parsley] final class Unexpected(private [Unexpected] val msg: String, val expected: Option[String] = None)
+    extends SingletonExpect[Nothing](s"unexpected($msg)", new Unexpected(msg, _), new instructions.Unexpected(msg, expected)) with MZero
 
 private [parsley] final class Rec[A](val p: Parsley[A])
     extends SingletonExpect[A](s"rec $p", _ => new Rec(p), new instructions.Call(p.instrs))
 
-private [parsley] final class Subroutine[A](var p: Parsley[A], val expected: UnsafeOption[String]) extends Parsley[A] {
+private [parsley] final class Subroutine[A](var p: Parsley[A], val expected: Option[String]) extends Parsley[A] {
     // $COVERAGE-OFF$
-    override def findLetsAux[Cont[_, +_]: ContOps](implicit seen: Set[Parsley[_]], state: LetFinderState, label: UnsafeOption[String]): Cont[Unit, Unit] = {
+    override def findLetsAux[Cont[_, +_]: ContOps](implicit seen: Set[Parsley[_]], state: LetFinderState, label: Option[String]): Cont[Unit, Unit] = {
         throw new Exception("Subroutines cannot exist during let detection")
     }
     // $COVERAGE-ON$
     override def preprocess[Cont[_, +_]: ContOps, A_ >: A](implicit seen: Set[Parsley[_]], sub: SubMap,
-                                                           label: UnsafeOption[String]): Cont[Unit, Parsley[A_]] = {
+                                                           label: Option[String]): Cont[Unit, Parsley[A_]] = {
         // The idea here is that the label itself was already established by letFinding, so we just use expected which should be equal to label
         assert(expected == label, "letFinding should have already set the expected label for a subroutine")
         for (p <- this.p.optimised) yield this.ready(p)
@@ -84,10 +84,12 @@ private [parsley] final class Put[S](val reg: Reg[S], _p: =>Parsley[S])
 
 private [parsley] final class ErrorLabel[A](_p: =>Parsley[A], label: String)
     extends Unary[A, A](_p)(c => s"$c.label($label)", expected =>
-        ErrorLabel.empty(if (expected == null) label else {
-            println(s"""WARNING: a label "$label" has been forcibly overriden by an unsafeLabel "$expected" that encapsulates it.
-                       |This is likely a mistake: confirm your intent by removing this label!""".stripMargin)
-            expected
+        ErrorLabel.empty(expected match {
+            case None => label
+            case Some(e) =>
+                println(s"""WARNING: a label "$label" has been forcibly overriden by an unsafeLabel "$e" that encapsulates it.
+                        |This is likely a mistake: confirm your intent by removing this label!""".stripMargin)
+                e
         })) {
     final override val numInstrs = 2
     final override def codeGen[Cont[_, +_]: ContOps](implicit instrs: InstrBuffer, state: CodeGenState): Cont[Unit, Unit] = {
@@ -115,12 +117,12 @@ private [parsley] final class ErrorExplain[A](_p: =>Parsley[A], reason: String)
 private [parsley] final class UnsafeErrorRelabel[+A](_p: =>Parsley[A], msg: String) extends Parsley[A] {
     lazy val p = _p
     override def preprocess[Cont[_, +_]: ContOps, A_ >: A](implicit seen: Set[Parsley[_]], sub: SubMap,
-                                                           label: UnsafeOption[String]): Cont[Unit, Parsley[A_]] = {
-        if (label == null) p.optimised(implicitly[ContOps[Cont]], seen, sub, msg)
+                                                           label: Option[String]): Cont[Unit, Parsley[A_]] = {
+        if (label.isEmpty) p.optimised(implicitly[ContOps[Cont]], seen, sub, Some(msg))
         else p.optimised
     }
-    override def findLetsAux[Cont[_, +_]: ContOps](implicit seen: Set[Parsley[_]], state: LetFinderState, label: UnsafeOption[String]): Cont[Unit, Unit] = {
-        if (label == null) p.findLets(implicitly[ContOps[Cont]], seen, state, msg)
+    override def findLetsAux[Cont[_, +_]: ContOps](implicit seen: Set[Parsley[_]], state: LetFinderState, label: Option[String]): Cont[Unit, Unit] = {
+        if (label.isEmpty) p.findLets(implicitly[ContOps[Cont]], seen, state, Some(msg))
         else p.findLets
     }
     // $COVERAGE-OFF$
@@ -163,7 +165,7 @@ private [deepembedding] object ErrorExplain {
     def apply[A](p: Parsley[A], reason: String): ErrorExplain[A] = empty(reason).ready(p)
 }
 private [deepembedding] object NotFollowedBy {
-    def empty[A](expected: UnsafeOption[String]): NotFollowedBy[A] = new NotFollowedBy(null, expected)
+    def empty[A](expected: Option[String]): NotFollowedBy[A] = new NotFollowedBy(null, expected)
 }
 private [deepembedding] object Put {
     def empty[S](r: Reg[S]): Put[S] = new Put(r, null)
@@ -173,8 +175,8 @@ private [deepembedding] object Debug {
 }
 
 private [deepembedding] object Rec {
-    def apply[A](p: Parsley[A], expected: UnsafeOption[String]): Parsley[A] = {
-        if (expected == null) new Rec(p)
-        else ErrorLabel(new Rec(p), expected)
+    def apply[A](p: Parsley[A], expected: Option[String]): Parsley[A] = expected match {
+        case None => new Rec(p)
+        case Some(expected) => ErrorLabel(new Rec(p), expected)
     }
 }

--- a/src/main/scala/parsley/internal/deepembedding/PrimitiveEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/PrimitiveEmbedding.scala
@@ -106,7 +106,7 @@ private [parsley] final class ErrorExplain[A](_p: =>Parsley[A], reason: String)
     final override val numInstrs = 2
     final override def codeGen[Cont[_, +_]: ContOps](implicit instrs: InstrBuffer, state: CodeGenState): Cont[Unit, Unit] = {
         val handler = state.freshLabel()
-        instrs += new instructions.PushHandler(handler)
+        instrs += new instructions.InputCheck(handler)
         p.codeGen |> {
             instrs += new instructions.Label(handler)
             instrs += new instructions.ApplyReason(reason)

--- a/src/main/scala/parsley/internal/deepembedding/SequenceEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/SequenceEmbedding.scala
@@ -110,8 +110,6 @@ private [deepembedding] sealed abstract class Seq[A, B](_discard: =>Parsley[A], 
     final def discard_=(p: Parsley[A]): Unit = left = p
     final override val numInstrs = 1
     def copy[B_ >: B](prev: Parsley[A], next: Parsley[B_]): Seq[A, B_]
-    //TODO I don't think this optimisation is valid anymore, considering how strings error messages have changed. But perhaps we can adapt it somehow?
-    // An error message reflecting something then something would work...
     private def buildResult[R](make: (StringTok, Pure[B]) => Parsley[B])(s: String, r: R, ex1: UnsafeOption[String], ex2: UnsafeOption[String]) = {
         make(new StringTok(s, if (ex1 != null) ex1 else ex2), new Pure(r.asInstanceOf[B]))
     }

--- a/src/main/scala/parsley/internal/deepembedding/SequenceEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/SequenceEmbedding.scala
@@ -110,6 +110,8 @@ private [deepembedding] sealed abstract class Seq[A, B](_discard: =>Parsley[A], 
     final def discard_=(p: Parsley[A]): Unit = left = p
     final override val numInstrs = 1
     def copy[B_ >: B](prev: Parsley[A], next: Parsley[B_]): Seq[A, B_]
+    //TODO I don't think this optimisation is valid anymore, considering how strings error messages have changed. But perhaps we can adapt it somehow?
+    // An error message reflecting something then something would work...
     private def buildResult[R](make: (StringTok, Pure[B]) => Parsley[B])(s: String, r: R, ex1: UnsafeOption[String], ex2: UnsafeOption[String]) = {
         make(new StringTok(s, if (ex1 != null) ex1 else ex2), new Pure(r.asInstanceOf[B]))
     }

--- a/src/main/scala/parsley/internal/deepembedding/SequenceEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/SequenceEmbedding.scala
@@ -111,7 +111,7 @@ private [deepembedding] sealed abstract class Seq[A, B](_discard: =>Parsley[A], 
     final override val numInstrs = 1
     def copy[B_ >: B](prev: Parsley[A], next: Parsley[B_]): Seq[A, B_]
     private def buildResult[R](make: (StringTok, Pure[B]) => Parsley[B])(s: String, r: R, ex1: Option[String], ex2: Option[String]) = {
-        make(new StringTok(s, if (ex1 != null) ex1 else ex2), new Pure(r.asInstanceOf[B]))
+        make(new StringTok(s, if (ex1.nonEmpty) ex1 else ex2), new Pure(r.asInstanceOf[B]))
     }
     private def optimiseStringResult(combine: (String, String) => String, make: (StringTok, Pure[B]) => Parsley[B])
                                     (s: String, ex: Option[String]): Parsley[B] = result match {
@@ -202,12 +202,12 @@ private [deepembedding] object Pure {
     def unapply[A](self: Pure[A]): Option[A] = Some(self.x)
 }
 private [deepembedding] object <*> {
-    def empty[A, B]: A <*> B = new <*>(null, null)
+    def empty[A, B]: A <*> B = new <*>(???, ???)
     def apply[A, B](left: Parsley[A=>B], right: Parsley[A]): <*>[A, B] = empty.ready(left, right)
     def unapply[A, B](self: <*>[A, B]): Option[(Parsley[A=>B], Parsley[A])] = Some((self.left, self.right))
 }
 private [deepembedding] object >>= {
-    def empty[A, B](f: A => Parsley[B], expected: Option[String]): >>=[A, B] = new >>=(null, f, expected)
+    def empty[A, B](f: A => Parsley[B], expected: Option[String]): >>=[A, B] = new >>=(???, f, expected)
     def apply[A, B](p: Parsley[A], f: A => Parsley[B], expected: Option[String]): >>=[A, B] = empty(f, expected).ready(p)
     def unapply[A, B](self: >>=[A, B]): Option[(Parsley[A], A => Parsley[B])] = Some((self.p, self.f))
 }
@@ -215,12 +215,12 @@ private [deepembedding] object Seq {
     def unapply[A, B](self: Seq[A, B]): Option[(Parsley[A], Parsley[B])] = Some((self.discard, self.result))
 }
 private [deepembedding] object *> {
-    def empty[A, B]: A *> B = new *>(null, null)
+    def empty[A, B]: A *> B = new *>(???, ???)
     def apply[A, B](left: Parsley[A], right: Parsley[B]): A *> B = empty.ready(left, right)
     def unapply[A, B](self: A *> B): Option[(Parsley[A], Parsley[B])] = Some((self.left, self.right))
 }
 private [deepembedding] object <* {
-    def empty[A, B]: A <* B = new <*(null, null)
+    def empty[A, B]: A <* B = new <*(???, ???)
     def apply[A, B](left: Parsley[A], right: Parsley[B]): A <* B = empty.ready(right, left)
     def unapply[A, B](self: A <* B): Option[(Parsley[A], Parsley[B])] = Some((self.result, self.discard))
 }

--- a/src/main/scala/parsley/internal/deepembedding/TokenEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/TokenEmbedding.scala
@@ -2,7 +2,7 @@ package parsley.internal.deepembedding
 
 import parsley.token.TokenSet
 import Sign.SignType
-import parsley.internal.{instructions, UnsafeOption}
+import parsley.internal.instructions
 
 private [parsley] final class WhiteSpace(ws: TokenSet, start: String, end: String, line: String, nested: Boolean)
     extends Singleton[Unit]("whiteSpace", new instructions.TokenWhiteSpace(ws, start, end, line, nested))
@@ -17,32 +17,32 @@ private [parsley] final class Sign[A](ty: SignType)
     extends SingletonExpect[A => A]("sign", _ => new Sign(ty), new instructions.TokenSign(ty))
 
 private [parsley] final class Natural(val expected: UnsafeOption[String] = null)
-    extends SingletonExpect[Int]("natural", new Natural(_), new instructions.TokenNatural(expected))
+    extends SingletonExpect[Int]("natural", new Natural(_), new instructions.TokenNatural(Option(expected)))
 
 private [parsley] final class Float(val expected: UnsafeOption[String] = null)
-    extends SingletonExpect[Double]("float", new Float(_), new instructions.TokenFloat(expected))
+    extends SingletonExpect[Double]("float", new Float(_), new instructions.TokenFloat(Option(expected)))
 
 private [parsley] final class Escape(val expected: UnsafeOption[String] = null)
-    extends SingletonExpect[Char]("escape", new Escape(_), new instructions.TokenEscape(expected))
+    extends SingletonExpect[Char]("escape", new Escape(_), new instructions.TokenEscape(Option(expected)))
 
 private [parsley] final class StringLiteral(ws: TokenSet, val expected: UnsafeOption[String] = null)
-    extends SingletonExpect[String]("stringLiteral", new StringLiteral(ws, _), new instructions.TokenString(ws, expected))
+    extends SingletonExpect[String]("stringLiteral", new StringLiteral(ws, _), new instructions.TokenString(ws, Option(expected)))
 
 private [parsley] final class RawStringLiteral(val expected: UnsafeOption[String] = null)
-    extends SingletonExpect[String]("rawStringLiteral", new RawStringLiteral(_), new instructions.TokenRawString(expected))
+    extends SingletonExpect[String]("rawStringLiteral", new RawStringLiteral(_), new instructions.TokenRawString(Option(expected)))
 
 private [parsley] class NonSpecific(combinatorName: String, name: String, illegalName: String, start: TokenSet,
                                     letter: TokenSet, illegal: String => Boolean, val expected: UnsafeOption[String] = null)
     extends SingletonExpect[String](combinatorName, new NonSpecific(combinatorName, name, illegalName, start, letter, illegal, _),
-                                    new instructions.TokenNonSpecific(name, illegalName)(start, letter, illegal, expected))
+                                    new instructions.TokenNonSpecific(name, illegalName)(start, letter, illegal, Option(expected)))
 
 private [parsley] final class Specific(name: String, private [Specific] val specific: String,
                                        letter: TokenSet, caseSensitive: Boolean, val expected: UnsafeOption[String] = null)
     extends SingletonExpect[Unit](s"$name($specific)", new Specific(name, specific, letter, caseSensitive, _),
-                                  new instructions.TokenSpecific(specific, letter, caseSensitive, expected))
+                                  new instructions.TokenSpecific(specific, letter, caseSensitive, Option(expected)))
 
 private [parsley] final class MaxOp(private [MaxOp] val operator: String, ops: Set[String], val expected: UnsafeOption[String] = null)
-    extends SingletonExpect[Unit](s"maxOp($operator)", new MaxOp(operator, ops, _), new instructions.TokenMaxOp(operator, ops, expected))
+    extends SingletonExpect[Unit](s"maxOp($operator)", new MaxOp(operator, ops, _), new instructions.TokenMaxOp(operator, ops, Option(expected)))
 
 private [parsley] object Sign {
     private [parsley] sealed trait SignType {

--- a/src/main/scala/parsley/internal/deepembedding/TokenEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/TokenEmbedding.scala
@@ -16,33 +16,33 @@ private [parsley] final class Comment(start: String, end: String, line: String, 
 private [parsley] final class Sign[A](ty: SignType)
     extends SingletonExpect[A => A]("sign", _ => new Sign(ty), new instructions.TokenSign(ty))
 
-private [parsley] final class Natural(val expected: UnsafeOption[String] = null)
-    extends SingletonExpect[Int]("natural", new Natural(_), new instructions.TokenNatural(Option(expected)))
+private [parsley] final class Natural(val expected: Option[String] = None)
+    extends SingletonExpect[Int]("natural", new Natural(_), new instructions.TokenNatural(expected))
 
-private [parsley] final class Float(val expected: UnsafeOption[String] = null)
-    extends SingletonExpect[Double]("float", new Float(_), new instructions.TokenFloat(Option(expected)))
+private [parsley] final class Float(val expected: Option[String] = None)
+    extends SingletonExpect[Double]("float", new Float(_), new instructions.TokenFloat(expected))
 
-private [parsley] final class Escape(val expected: UnsafeOption[String] = null)
-    extends SingletonExpect[Char]("escape", new Escape(_), new instructions.TokenEscape(Option(expected)))
+private [parsley] final class Escape(val expected: Option[String] = None)
+    extends SingletonExpect[Char]("escape", new Escape(_), new instructions.TokenEscape(expected))
 
-private [parsley] final class StringLiteral(ws: TokenSet, val expected: UnsafeOption[String] = null)
-    extends SingletonExpect[String]("stringLiteral", new StringLiteral(ws, _), new instructions.TokenString(ws, Option(expected)))
+private [parsley] final class StringLiteral(ws: TokenSet, val expected: Option[String] = None)
+    extends SingletonExpect[String]("stringLiteral", new StringLiteral(ws, _), new instructions.TokenString(ws, expected))
 
-private [parsley] final class RawStringLiteral(val expected: UnsafeOption[String] = null)
-    extends SingletonExpect[String]("rawStringLiteral", new RawStringLiteral(_), new instructions.TokenRawString(Option(expected)))
+private [parsley] final class RawStringLiteral(val expected: Option[String] = None)
+    extends SingletonExpect[String]("rawStringLiteral", new RawStringLiteral(_), new instructions.TokenRawString(expected))
 
 private [parsley] class NonSpecific(combinatorName: String, name: String, illegalName: String, start: TokenSet,
-                                    letter: TokenSet, illegal: String => Boolean, val expected: UnsafeOption[String] = null)
+                                    letter: TokenSet, illegal: String => Boolean, val expected: Option[String] = None)
     extends SingletonExpect[String](combinatorName, new NonSpecific(combinatorName, name, illegalName, start, letter, illegal, _),
-                                    new instructions.TokenNonSpecific(name, illegalName)(start, letter, illegal, Option(expected)))
+                                    new instructions.TokenNonSpecific(name, illegalName)(start, letter, illegal, expected))
 
 private [parsley] final class Specific(name: String, private [Specific] val specific: String,
-                                       letter: TokenSet, caseSensitive: Boolean, val expected: UnsafeOption[String] = null)
+                                       letter: TokenSet, caseSensitive: Boolean, val expected: Option[String] = None)
     extends SingletonExpect[Unit](s"$name($specific)", new Specific(name, specific, letter, caseSensitive, _),
-                                  new instructions.TokenSpecific(specific, letter, caseSensitive, Option(expected)))
+                                  new instructions.TokenSpecific(specific, letter, caseSensitive, expected))
 
-private [parsley] final class MaxOp(private [MaxOp] val operator: String, ops: Set[String], val expected: UnsafeOption[String] = null)
-    extends SingletonExpect[Unit](s"maxOp($operator)", new MaxOp(operator, ops, _), new instructions.TokenMaxOp(operator, ops, Option(expected)))
+private [parsley] final class MaxOp(private [MaxOp] val operator: String, ops: Set[String], val expected: Option[String] = None)
+    extends SingletonExpect[Unit](s"maxOp($operator)", new MaxOp(operator, ops, _), new instructions.TokenMaxOp(operator, ops, expected))
 
 private [parsley] object Sign {
     private [parsley] sealed trait SignType {

--- a/src/main/scala/parsley/internal/errors/Builders.scala
+++ b/src/main/scala/parsley/internal/errors/Builders.scala
@@ -1,0 +1,32 @@
+package parsley.internal.errors
+
+private [internal] abstract class LineBuilder {
+    final private [errors] def getLineWithCaret(offset: Int): (String, String) = {
+        // FIXME: Tabs man... tabs
+        val startOffset = nearestNewlineBefore(offset)
+        val endOffset = nearestNewlineAfter(offset)
+        val segment = segmentBetween(startOffset, endOffset)
+        val caretAt = offset - startOffset
+        val caretPad = " " * caretAt
+        (segment.replace('\t', ' '), s"$caretPad^")
+    }
+
+    protected def nearestNewlineBefore(off: Int): Int
+    protected def nearestNewlineAfter(off: Int): Int
+    protected def segmentBetween(start: Int, end: Int): String
+}
+
+private [internal] abstract class ErrorItemBuilder {
+    final private [errors] def apply(offset: Int): ErrorItem = {
+        if (inRange(offset)) Raw(charAt(offset))
+        else EndOfInput
+    }
+    final private [errors] def apply(offset: Int, size: Int): ErrorItem = {
+        if (inRange(offset)) Raw(substring(offset, size))
+        else EndOfInput
+    }
+
+    protected def inRange(offset: Int): Boolean
+    protected def charAt(offset: Int): Char
+    protected def substring(offset: Int, size: Int): String
+}

--- a/src/main/scala/parsley/internal/errors/DefuncError.scala
+++ b/src/main/scala/parsley/internal/errors/DefuncError.scala
@@ -82,20 +82,20 @@ private [internal] case class MergedErrors(err1: DefuncError, err2: DefuncError)
     }
 }
 
-private [errors] case class WithHints private (err: DefuncError, hints: List[Set[ErrorItem]]) extends DefuncError {
+private [errors] case class WithHints private (err: DefuncError, hints: DefuncHints) extends DefuncError {
     val isTrivialError: Boolean = err.isTrivialError
     // So long as the WithHints factory ensures hints is nonEmpty this is false
     val isExpectedEmpty: Boolean = false //err.isExpectedEmpty && hints.isEmpty
     val offset = err.offset
     override def asParseError(implicit builder: ErrorItemBuilder): ParseError = {
-        err.asParseError.withHints(hints)
+        err.asParseError.withHints(hints.toList)
     }
 }
 
 private [internal] object WithHints {
-    def apply(err: DefuncError, hints: Iterable[Set[ErrorItem]], defuncHints: DefuncHints): DefuncError = {
+    def apply(err: DefuncError, hints: DefuncHints): DefuncError = {
         if (hints.isEmpty || !err.isTrivialError) err
-        else new WithHints(err, hints.toList)
+        else new WithHints(err, hints)
     }
 }
 

--- a/src/main/scala/parsley/internal/errors/DefuncError.scala
+++ b/src/main/scala/parsley/internal/errors/DefuncError.scala
@@ -1,0 +1,44 @@
+package parsley.internal.errors
+
+/* This file contains the defunctionalised forms of the error messages.
+ * Essentially, whenever an error is created in the machine, it should make use of one of
+ * these case classes. This means that every error message created will be done in a single
+ * O(1) allocation, avoiding anything to do with the underlying sets, options etc.
+ */
+private [internal] sealed trait DefuncError {
+    def asParseError(implicit builder: ErrorItemBuilder): ParseError
+    protected final def expectedSet(errorItem: Option[ErrorItem]): Set[ErrorItem] = errorItem match {
+        case None => ParseError.NoItems
+        case Some(item) => Set(item)
+    }
+}
+private [internal] case class ClassicExpectedError(offset: Int, line: Int, col: Int, expected: Option[ErrorItem], reason: Option[String]) extends DefuncError {
+    override def asParseError(implicit builder: ErrorItemBuilder): ParseError = {
+        TrivialError(offset, line, col, Some(builder(offset)), expectedSet(expected), reason.fold(ParseError.NoReason)(Set(_)))
+    }
+}
+private [internal] case class ClassicUnexpectedError(offset: Int, line: Int, col: Int, expected: Option[ErrorItem], unexpected: ErrorItem) extends DefuncError {
+    override def asParseError(implicit builder: ErrorItemBuilder): ParseError = {
+        TrivialError(offset, line, col, Some(unexpected), expectedSet(expected), ParseError.NoReason)
+    }
+}
+private [internal] case class ClassicFancyError(offset: Int, line: Int, col: Int, msg: String) extends DefuncError {
+    override def asParseError(implicit builder: ErrorItemBuilder): ParseError = {
+        FailError(offset, line, col, Set(msg))
+    }
+}
+private [internal] case class EmptyError(offset: Int, line: Int, col: Int, expected: Option[ErrorItem]) extends DefuncError {
+    override def asParseError(implicit builder: ErrorItemBuilder): ParseError = {
+        TrivialError(offset, line, col, None, expectedSet(expected), ParseError.NoReason)
+    }
+}
+private [internal] case class StringTokError(offset: Int, line: Int, col: Int, expected: Option[ErrorItem], size: Int) extends DefuncError {
+    override def asParseError(implicit builder: ErrorItemBuilder): ParseError = {
+        TrivialError(offset, line, col, Some(builder(offset, size)), expectedSet(expected), ParseError.NoReason)
+    }
+}
+private [internal] case class EmptyErrorWithReason(offset: Int, line: Int, col: Int, expected: Option[ErrorItem], reason: String) extends DefuncError {
+    override def asParseError(implicit builder: ErrorItemBuilder): ParseError = {
+        TrivialError(offset, line, col, None, expectedSet(expected), Set(reason))
+    }
+}

--- a/src/main/scala/parsley/internal/errors/DefuncHints.scala
+++ b/src/main/scala/parsley/internal/errors/DefuncHints.scala
@@ -19,12 +19,12 @@ private [internal] sealed abstract class DefuncHints {
 
 private [internal] case object EmptyHints extends DefuncHints {
     val size = 0
-    def collect(buff: mutable.ListBuffer[Set[ErrorItem]])(implicit builder: ErrorItemBuilder) = ()
+    def collect(buff: mutable.ListBuffer[Set[ErrorItem]])(implicit builder: ErrorItemBuilder): Unit = ()
 }
 
 private [internal] case class PopHints private (hints: DefuncHints) extends DefuncHints {
     val size = hints.size - 1
-    def collect(buff: mutable.ListBuffer[Set[ErrorItem]])(implicit builder: ErrorItemBuilder) = {
+    def collect(buff: mutable.ListBuffer[Set[ErrorItem]])(implicit builder: ErrorItemBuilder): Unit = {
         hints.collect(buff)
         buff.remove(0)
     }
@@ -35,7 +35,7 @@ private [internal] object PopHints {
 
 private [errors] case class ReplaceHint private (label: String, hints: DefuncHints) extends DefuncHints {
     val size = hints.size
-    def collect(buff: mutable.ListBuffer[Set[ErrorItem]])(implicit builder: ErrorItemBuilder) = {
+    def collect(buff: mutable.ListBuffer[Set[ErrorItem]])(implicit builder: ErrorItemBuilder): Unit = {
         hints.collect(buff)
         buff(0) = Set(Desc(label))
     }
@@ -46,7 +46,7 @@ private [internal] object ReplaceHint {
 
 private [errors] case class MergeHints private (oldHints: DefuncHints, newHints: DefuncHints) extends DefuncHints {
     val size = oldHints.size + newHints.size
-    def collect(buff: mutable.ListBuffer[Set[ErrorItem]])(implicit builder: ErrorItemBuilder) = {
+    def collect(buff: mutable.ListBuffer[Set[ErrorItem]])(implicit builder: ErrorItemBuilder): Unit = {
         oldHints.collect(buff)
         buff ++= newHints.toList
     }
@@ -61,7 +61,7 @@ private [internal] object MergeHints {
 
 private [internal] case class AddError(hints: DefuncHints, err: DefuncError) extends DefuncHints {
     val size = hints.size + 1
-    def collect(buff: mutable.ListBuffer[Set[ErrorItem]])(implicit builder: ErrorItemBuilder) = {
+    def collect(buff: mutable.ListBuffer[Set[ErrorItem]])(implicit builder: ErrorItemBuilder): Unit = {
         hints.collect(buff)
         val TrivialError(_, _, _, _, es, _) = err.asParseError
         buff += es

--- a/src/main/scala/parsley/internal/errors/DefuncHints.scala
+++ b/src/main/scala/parsley/internal/errors/DefuncHints.scala
@@ -1,0 +1,69 @@
+package parsley.internal.errors
+
+import scala.collection.mutable
+
+private [internal] sealed abstract class DefuncHints {
+    private [errors] val size: Int
+    private [errors] def nonEmpty: Boolean = size != 0
+    private [errors] def isEmpty: Boolean = size == 0
+    private [internal] def toList(implicit builder: ErrorItemBuilder): List[Set[ErrorItem]] = {
+        val buff = mutable.ListBuffer.empty[Set[ErrorItem]]
+        collect(buff)
+        buff.toList
+    }
+    private [errors] def collect(buff: mutable.ListBuffer[Set[ErrorItem]])(implicit builder: ErrorItemBuilder): Unit
+    private [internal] def check(hints: Iterable[Set[ErrorItem]])(implicit builder: ErrorItemBuilder): Unit = {
+        assert(hints.toList == toList, "hints should match")
+    }
+}
+
+private [internal] case object EmptyHints extends DefuncHints {
+    val size = 0
+    def collect(buff: mutable.ListBuffer[Set[ErrorItem]])(implicit builder: ErrorItemBuilder) = ()
+}
+
+private [internal] case class PopHints private (hints: DefuncHints) extends DefuncHints {
+    val size = hints.size - 1
+    def collect(buff: mutable.ListBuffer[Set[ErrorItem]])(implicit builder: ErrorItemBuilder) = {
+        hints.collect(buff)
+        buff.remove(0)
+    }
+}
+private [internal] object PopHints {
+    def apply(hints: DefuncHints): DefuncHints = if (hints.size > 1) new PopHints(hints) else EmptyHints
+}
+
+private [errors] case class ReplaceHint private (label: String, hints: DefuncHints) extends DefuncHints {
+    val size = hints.size
+    def collect(buff: mutable.ListBuffer[Set[ErrorItem]])(implicit builder: ErrorItemBuilder) = {
+        hints.collect(buff)
+        buff(0) = Set(Desc(label))
+    }
+}
+private [internal] object ReplaceHint {
+    def apply(label: String, hints: DefuncHints): DefuncHints = if (hints.nonEmpty) new ReplaceHint(label, hints) else hints
+}
+
+private [errors] case class MergeHints private (oldHints: DefuncHints, newHints: DefuncHints) extends DefuncHints {
+    val size = oldHints.size + newHints.size
+    def collect(buff: mutable.ListBuffer[Set[ErrorItem]])(implicit builder: ErrorItemBuilder) = {
+        oldHints.collect(buff)
+        buff ++= newHints.toList
+    }
+}
+private [internal] object MergeHints {
+    def apply(oldHints: DefuncHints, newHints: DefuncHints): DefuncHints = {
+        if (oldHints.isEmpty) newHints
+        else if (newHints.isEmpty) oldHints
+        else new MergeHints(oldHints, newHints)
+    }
+}
+
+private [internal] case class AddError(hints: DefuncHints, err: DefuncError) extends DefuncHints {
+    val size = hints.size + 1
+    def collect(buff: mutable.ListBuffer[Set[ErrorItem]])(implicit builder: ErrorItemBuilder) = {
+        hints.collect(buff)
+        val TrivialError(_, _, _, _, es, _) = err.asParseError
+        buff += es
+    }
+}

--- a/src/main/scala/parsley/internal/errors/DefuncHints.scala
+++ b/src/main/scala/parsley/internal/errors/DefuncHints.scala
@@ -12,9 +12,6 @@ private [internal] sealed abstract class DefuncHints {
         buff.toList
     }
     private [errors] def collect(buff: mutable.ListBuffer[Set[ErrorItem]])(implicit builder: ErrorItemBuilder): Unit
-    private [internal] def check(hints: Iterable[Set[ErrorItem]])(implicit builder: ErrorItemBuilder): Unit = {
-        assert(hints.toList == toList, "hints should match")
-    }
 }
 
 private [internal] case object EmptyHints extends DefuncHints {

--- a/src/main/scala/parsley/internal/errors/Errors.scala
+++ b/src/main/scala/parsley/internal/errors/Errors.scala
@@ -38,6 +38,8 @@ private [internal] sealed abstract class ParseError {
         case Nil => None
         case List(alt) => Some(alt)
         case List(alt1, alt2) => Some(s"$alt2 or $alt1")
+        // If the result would contains "," then it's probably nicer to preserve any potential grouping using ";"
+        case any@(alt::alts) if any.exists(_.contains(",")) => Some(s"${alts.reverse.mkString("; ")}; or $alt")
         case alt::alts => Some(s"${alts.reverse.mkString(", ")}, or $alt")
     }
 

--- a/src/main/scala/parsley/internal/errors/Errors.scala
+++ b/src/main/scala/parsley/internal/errors/Errors.scala
@@ -31,13 +31,6 @@ private [internal] sealed abstract class ParseError {
         val topStr = posStr(sourceName)
         val (line, caret) = helper.getLineWithCaret(offset)
         val info = infoLines.filter(_.nonEmpty).mkString("\n  ")
-        // TODO: Add preamble of parse error?
-        // Apparently, multi-line strings use whatever line endings the file has instead of platform-independent LIKE EVERYTHING ELSE
-        // So we can't use them without breaking the error messages on Windows.
-        /*s"""$topStr:
-           |  ${if (info.isEmpty) Unknown else info}
-           |  >${line}
-           |  >${caret}""".stripMargin*/
         s"$topStr:\n  ${if (info.isEmpty) Unknown else info}\n  >${line}\n  >${caret}"
     }
 }

--- a/src/main/scala/parsley/internal/errors/Errors.scala
+++ b/src/main/scala/parsley/internal/errors/Errors.scala
@@ -9,22 +9,6 @@ private [internal] sealed abstract class ParseError {
     val col: Int
     val line: Int
 
-    final def merge(that: ParseError): ParseError = {
-        if (this.offset < that.offset) that
-        else if (this.offset > that.offset) this
-        else (this, that) match {
-            case (_: FailError, _: TrivialError) => this
-            case (_: TrivialError, _: FailError) => that
-            case (_this: FailError, _that: FailError) => FailError(offset, line, col, _this.msgs union _that.msgs)
-            case (TrivialError(_, _, _, u1, es1, rs1), TrivialError(_, _, _, u2, es2, rs2)) =>
-                val u = (u1, u2) match {
-                    case (Some(u1), Some(u2)) => Some(ErrorItem.higherPriority(u1, u2))
-                    case _ => u1.orElse(u2)
-                }
-                TrivialError(offset, line, col, u, es1 union es2, rs1 union rs2)
-        }
-    }
-
     def withHints(hints: Iterable[Set[ErrorItem]]): ParseError
     def giveReason(reason: String): ParseError
     def pretty(sourceName: Option[String])(implicit helper: LineBuilder): String

--- a/src/main/scala/parsley/internal/errors/Errors.scala
+++ b/src/main/scala/parsley/internal/errors/Errors.scala
@@ -78,7 +78,6 @@ private [internal] case class FailError(offset: Int, line: Int, col: Int, msgs: 
 }
 
 private [internal] object ParseError {
-    def fail(msg: String, offset: Int, line: Int, col: Int): ParseError = FailError(offset, line, col, Set(msg))
     val Unknown = "unknown parse error"
     val NoReason = Set.empty[String]
     val NoItems = Set.empty[ErrorItem]

--- a/src/main/scala/parsley/internal/instructions/ArrayStack.scala
+++ b/src/main/scala/parsley/internal/instructions/ArrayStack.scala
@@ -33,9 +33,6 @@ private [instructions] final class ArrayStack[A](initialSize: Int = ArrayStack.D
     def upeek: Any = array(sp)
     def peek[B <: A]: B = upeek.asInstanceOf[B]
 
-    def update(off: Int, x: A): Unit = array(sp - off) = x
-    def apply(off: Int): Any = array(sp - off)
-
     def drop(x: Int): Unit = sp -= x
 
     // This is off by one, but that's fine, if everything is also off by one :P

--- a/src/main/scala/parsley/internal/instructions/Context.scala
+++ b/src/main/scala/parsley/internal/instructions/Context.scala
@@ -2,7 +2,7 @@ package parsley.internal.instructions
 
 import Stack.{drop, isEmpty, mkString, map, push}
 import parsley.{Failure, Result, Success}
-import parsley.internal.errors._
+import parsley.internal.errors.{ParseError, TrivialError, FailError, LineBuilder, ErrorItemBuilder, ErrorItem, Raw, Desc, EndOfInput}, ParseError.NoReason
 
 import scala.annotation.tailrec
 import scala.collection.mutable
@@ -181,14 +181,14 @@ private [parsley] final class Context(private [instructions] var instrs: Array[I
     }
 
     private [instructions] def failWithMessage(msg: String): Unit = {
-        this.fail(ParseError.fail(msg, offset, line, col))
+        this.fail(new FailError(offset, line, col, Set(msg)))
     }
     private [instructions] def unexpectedFail(expected: Set[ErrorItem], unexpected: Option[ErrorItem]): Unit = {
-        this.fail(new TrivialError(offset, line, col, unexpected, expected, ParseError.NoReason))
+        this.fail(new TrivialError(offset, line, col, unexpected, expected, NoReason))
     }
     private [instructions] def expectedFail(expected: Set[ErrorItem], reason: Option[String]): Unit = {
         val unexpected = new Some(if (offset < inputsz) new Raw(s"$nextChar") else EndOfInput)
-        this.fail(new TrivialError(offset, line, col, unexpected, expected, reason.fold(ParseError.NoReason)(Set(_))))
+        this.fail(new TrivialError(offset, line, col, unexpected, expected, reason.fold(NoReason)(Set(_))))
     }
     private [instructions] def fail(error: ParseError): Unit = {
         this.pushError(error)

--- a/src/main/scala/parsley/internal/instructions/Context.scala
+++ b/src/main/scala/parsley/internal/instructions/Context.scala
@@ -57,8 +57,6 @@ private [parsley] final class Context(private [instructions] var instrs: Array[I
     private [instructions] var regs: Array[AnyRef] = new Array[AnyRef](Context.NumRegs)
     /** Amount of indentation to apply to debug combinators output */
     private [instructions] var debuglvl: Int = 0
-    /** Name which describes the type of input in error messages */
-    private val inputDescriptor = sourceName.fold("input")(_ => "file")
 
     // NEW ERROR MECHANISMS
     private var hints = mutable.ListBuffer.empty[Set[ErrorItem]]

--- a/src/main/scala/parsley/internal/instructions/Context.scala
+++ b/src/main/scala/parsley/internal/instructions/Context.scala
@@ -58,7 +58,7 @@ private [parsley] final class Context(private [instructions] var instrs: Array[I
     private var hints = mutable.ListBuffer.empty[Set[ErrorItem]]
     private var hintsValidOffset = 0
     private var hintStack = Stack.empty[Hints]
-    private [instructions] var errs = Stack.empty[ParseError]
+    private [instructions] var errs: Stack[ParseError] = Stack.empty
 
     private [instructions] def saveHints(shadow: Boolean): Unit = {
         hintStack = push(hintStack, new Hints(hints, hintsValidOffset))

--- a/src/main/scala/parsley/internal/instructions/Context.scala
+++ b/src/main/scala/parsley/internal/instructions/Context.scala
@@ -88,9 +88,7 @@ private [parsley] final class Context(private [instructions] var instrs: Array[I
     /* ERROR RELABELLING BEGIN */
     private [instructions] def mergeHints(): Unit = {
         val hintFrame = this.hintStack.head
-        if (hintFrame.validOffset == offset) {
-            this.hints = MergeHints(hintFrame.hints, this.hints)
-        }
+        if (hintFrame.validOffset == offset) this.hints = MergeHints(hintFrame.hints, this.hints)
         commitHints()
     }
     private [instructions] def replaceHint(label: String): Unit = hints = ReplaceHint(label, hints)

--- a/src/main/scala/parsley/internal/instructions/Context.scala
+++ b/src/main/scala/parsley/internal/instructions/Context.scala
@@ -83,7 +83,7 @@ private [parsley] final class Context(private [instructions] var instrs: Array[I
         commitHints()
     }
     private [instructions] def replaceHint(label: String): Unit = {
-        if (hints.nonEmpty) hints(0) = Set(Desc(label))
+        if (hints.nonEmpty) hints(0) = Set(new Desc(label))
     }
     private [instructions] def popHints: Unit = if (hints.nonEmpty) hints.remove(0)
     /* ERROR RELABELLING END */
@@ -186,17 +186,17 @@ private [parsley] final class Context(private [instructions] var instrs: Array[I
         this.fail(ParseError.fail(msg, offset, line, col))
     }
     private [instructions] def unexpectedFail(expected: UnsafeOption[String], unexpected: String): Unit = {
-        this.fail(TrivialError(offset, line, col, Some(Desc(unexpected)), if (expected == null) Set.empty else Set(Desc(expected)), Set.empty))
+        this.fail(new TrivialError(offset, line, col, Some(new Desc(unexpected)), if (expected == null) Set.empty else Set(new Desc(expected)), Set.empty))
     }
     private [instructions] def expectedFail(expected: Set[ErrorItem], msg: Option[String]): Unit = {
-        val unexpected = if (offset < inputsz) Raw(s"$nextChar") else EndOfInput
-        this.fail(TrivialError(offset, line, col, Some(unexpected), expected, msg.fold(Set.empty[String])(Set(_))))
+        val unexpected = if (offset < inputsz) new Raw(s"$nextChar") else EndOfInput
+        this.fail(new TrivialError(offset, line, col, Some(unexpected), expected, msg.fold(Set.empty[String])(Set(_))))
     }
     private [instructions] def expectedFail(expected: UnsafeOption[String]): Unit = {
-        expectedFail(if (expected == null) Set.empty[ErrorItem] else Set[ErrorItem](Desc(expected)), None)
+        expectedFail(if (expected == null) Set.empty[ErrorItem] else Set[ErrorItem](new Desc(expected)), None)
     }
     private [instructions] def expectedFailWithExplanation(expected: UnsafeOption[String], msg: String): Unit = {
-        expectedFail(if (expected == null) Set.empty[ErrorItem] else Set[ErrorItem](Desc(expected)), Some(msg))
+        expectedFail(if (expected == null) Set.empty[ErrorItem] else Set[ErrorItem](new Desc(expected)), Some(msg))
     }
     private [instructions] def fail(error: ParseError): Unit = {
         this.pushError(error)

--- a/src/main/scala/parsley/internal/instructions/Context.scala
+++ b/src/main/scala/parsley/internal/instructions/Context.scala
@@ -2,7 +2,6 @@ package parsley.internal.instructions
 
 import Stack.{drop, isEmpty, mkString, map, push}
 import parsley.{Failure, Result, Success}
-import parsley.internal.errors.{ParseError, TrivialError, FailError, LineBuilder, ErrorItemBuilder, ErrorItem, Raw, Desc, EndOfInput}, ParseError.NoReason
 import parsley.internal.errors.{DefuncError, WithHints, ClassicExpectedError, ClassicExpectedErrorWithReason, ClassicFancyError, ClassicUnexpectedError}
 
 import scala.annotation.tailrec
@@ -173,7 +172,7 @@ private [parsley] final class Context(private [instructions] var instrs: Array[I
 
     private [instructions] def pushError(err: DefuncError): Unit = this.errs = push(this.errs, this.useHints(err))
     private [instructions] def useHints(err: DefuncError): DefuncError = {
-        if (hintsValidOffset == offset) new WithHints(err, hints)//err.withHints(hints)
+        if (hintsValidOffset == offset) new WithHints(err, hints)
         else {
             hintsValidOffset = offset
             hints.clear()
@@ -182,21 +181,8 @@ private [parsley] final class Context(private [instructions] var instrs: Array[I
     }
 
     private [instructions] def failWithMessage(msg: String): Unit = {
-        this.fail(new ClassicFancyError(offset, line, col, msg))//new FailError(offset, line, col, Set(msg)))
+        this.fail(new ClassicFancyError(offset, line, col, msg))
     }
-    //private [instructions] def unexpectedFail(expected: Set[ErrorItem], unexpected: Option[ErrorItem]): Unit = {
-    //    this.fail(new ClassicUnexpectedError(offset, line, col, expected.headOption, unexpected.get))//new TrivialError(offset, line, col, unexpected, expected, NoReason))
-    //}
-    //private [instructions] def expectedFail(expected: Set[ErrorItem], reason: Option[String]): Unit = {
-        //val unexpected = new Some(if (offset < inputsz) new Raw(s"$nextChar") else EndOfInput)
-        //this.fail(new TrivialError(offset, line, col, unexpected, expected, reason.fold(NoReason)(Set(_))))
-    //}
-    //private [instructions] def expectedFail(expected: Set[ErrorItem]): Unit = {
-    //    this.fail(new ClassicExpectedError(offset, line, col, expected.headOption))
-    //}
-    //private [instructions] def expectedFail(expected: Set[ErrorItem], reason: String): Unit = {
-    //    this.fail(new ClassicExpectedErrorWithReason(offset, line, col, expected.headOption, reason))
-    //}
     private [instructions] def unexpectedFail(expected: Option[ErrorItem], unexpected: ErrorItem): Unit = {
         this.fail(new ClassicUnexpectedError(offset, line, col, expected, unexpected))
     }

--- a/src/main/scala/parsley/internal/instructions/Context.scala
+++ b/src/main/scala/parsley/internal/instructions/Context.scala
@@ -170,9 +170,7 @@ private [parsley] final class Context(private [instructions] var instrs: Array[I
     }
 
     private [instructions] def pushError(err: ParseError): Unit = this.errs = push(this.errs, this.useHints(err))
-    private [instructions] def useHints(): Unit = errs.head = useHints(errs.head)
-
-    private def useHints(err: ParseError): ParseError = {
+    private [instructions] def useHints(err: ParseError): ParseError = {
         if (hintsValidOffset == offset) err.withHints(hints)
         else {
             hintsValidOffset = offset

--- a/src/main/scala/parsley/internal/instructions/Context.scala
+++ b/src/main/scala/parsley/internal/instructions/Context.scala
@@ -257,8 +257,6 @@ private [parsley] final class Context(private [instructions] var instrs: Array[I
     }
     private [instructions] def pushHandler(label: Int): Unit = {
         handlers = push(handlers, new Handler(depth, label, stack.usize))
-        //TODO: This may change
-        //this.saveHints()
     }
     private [instructions] def pushCheck(): Unit = checkStack = push(checkStack, offset)
     private [instructions] def saveState(): Unit = states = push(states, new State(offset, line, col))

--- a/src/main/scala/parsley/internal/instructions/Context.scala
+++ b/src/main/scala/parsley/internal/instructions/Context.scala
@@ -289,7 +289,7 @@ private [parsley] final class Context(private [instructions] var instrs: Array[I
         }
     }
 
-    private implicit val errorItemBuilder = new ErrorItemBuilder {
+    private implicit val errorItemBuilder: ErrorItemBuilder = new ErrorItemBuilder {
         def inRange(offset: Int): Boolean = offset < Context.this.inputsz
         def charAt(offset: Int): Char = Context.this.input.charAt(offset)
         def substring(offset: Int, size: Int): String = Context.this.input.substring(offset, Math.min(offset + size, Context.this.inputsz))

--- a/src/main/scala/parsley/internal/instructions/Context.scala
+++ b/src/main/scala/parsley/internal/instructions/Context.scala
@@ -132,9 +132,9 @@ private [parsley] final class Context(private [instructions] var instrs: Array[I
     @tailrec @inline private [parsley] def runParser[A](): Result[A] = {
         //println(pretty)
         if (status eq Failed) {
-            assert(!isEmpty(errs) && isEmpty(errs.tail), "there should be only one error on failure")
-            assert(isEmpty(handlers), "there should be no handlers left on failure")
-            assert(isEmpty(hintStack), "there should be at most one set of hints left at the end")
+            //assert(!isEmpty(errs) && isEmpty(errs.tail), "there should be only one error on failure")
+            //assert(isEmpty(handlers), "there should be no handlers left on failure")
+            //assert(isEmpty(hintStack), "there should be at most one set of hints left at the end")
             Failure(errs.head.pretty(sourceName, new InputHelper))
         }
         else if (pc < instrs.length) {
@@ -142,9 +142,9 @@ private [parsley] final class Context(private [instructions] var instrs: Array[I
             runParser[A]()
         }
         else if (isEmpty(calls)) {
-            assert(isEmpty(errs), "there should be no errors on success")
-            assert(isEmpty(handlers), "there should be no handlers on success")
-            assert(isEmpty(hintStack), "there should be at most one set of hints left at the end")
+            //assert(isEmpty(errs), "there should be no errors on success")
+            //assert(isEmpty(handlers), "there should be no handlers on success")
+            //assert(isEmpty(hintStack), "there should be at most one set of hints left at the end")
             Success(stack.peek[A])
         }
         else {

--- a/src/main/scala/parsley/internal/instructions/Context.scala
+++ b/src/main/scala/parsley/internal/instructions/Context.scala
@@ -169,18 +169,15 @@ private [parsley] final class Context(private [instructions] var instrs: Array[I
         checkStack = checkStack.tail
     }
 
-    private [instructions] def pushError(err: ParseError): Unit = {
-        this.errs = push(this.errs, err)
-        this.useHints()
-    }
+    private [instructions] def pushError(err: ParseError): Unit = this.errs = push(this.errs, this.useHints(err))
+    private [instructions] def useHints(): Unit = errs.head = useHints(errs.head)
 
-    private [instructions] def useHints(): Unit = {
-        if (hintsValidOffset == offset) {
-            errs.head = errs.head.withHints(hints)
-        }
+    private def useHints(err: ParseError): ParseError = {
+        if (hintsValidOffset == offset) err.withHints(hints)
         else {
             hintsValidOffset = offset
             hints.clear()
+            err
         }
     }
 

--- a/src/main/scala/parsley/internal/instructions/Context.scala
+++ b/src/main/scala/parsley/internal/instructions/Context.scala
@@ -131,22 +131,12 @@ private [parsley] final class Context(private [instructions] var instrs: Array[I
 
     @tailrec @inline private [parsley] def runParser[A](): Result[A] = {
         //println(pretty)
-        if (status eq Failed) {
-            //assert(!isEmpty(errs) && isEmpty(errs.tail), "there should be only one error on failure")
-            //assert(isEmpty(handlers), "there should be no handlers left on failure")
-            //assert(isEmpty(hintStack), "there should be at most one set of hints left at the end")
-            Failure(errs.head.pretty(sourceName, new InputHelper))
-        }
+        if (status eq Failed) Failure(errs.head.pretty(sourceName, new InputHelper))
         else if (pc < instrs.length) {
             instrs(pc)(this)
             runParser[A]()
         }
-        else if (isEmpty(calls)) {
-            //assert(isEmpty(errs), "there should be no errors on success")
-            //assert(isEmpty(handlers), "there should be no handlers on success")
-            //assert(isEmpty(hintStack), "there should be at most one set of hints left at the end")
-            Success(stack.peek[A])
-        }
+        else if (isEmpty(calls)) Success(stack.peek[A])
         else {
             ret()
             runParser[A]()

--- a/src/main/scala/parsley/internal/instructions/Context.scala
+++ b/src/main/scala/parsley/internal/instructions/Context.scala
@@ -2,7 +2,12 @@ package parsley.internal.instructions
 
 import Stack.{drop, isEmpty, mkString, map, push}
 import parsley.{Failure, Result, Success}
-import parsley.internal.errors.{DefuncError, WithHints, ClassicExpectedError, ClassicExpectedErrorWithReason, ClassicFancyError, ClassicUnexpectedError}
+import parsley.internal.errors.{
+    TrivialError,
+    ErrorItem, Desc,
+    LineBuilder, ErrorItemBuilder,
+    DefuncError, ClassicExpectedError, ClassicExpectedErrorWithReason, ClassicFancyError, ClassicUnexpectedError, WithHints
+}
 
 import scala.annotation.tailrec
 import scala.collection.mutable

--- a/src/main/scala/parsley/internal/instructions/Context.scala
+++ b/src/main/scala/parsley/internal/instructions/Context.scala
@@ -88,11 +88,13 @@ private [parsley] final class Context(private [instructions] var instrs: Array[I
     private [instructions] def popHints: Unit = if (hints.nonEmpty) hints.remove(0)
     /* ERROR RELABELLING END */
 
-    private [instructions] def addErrorToHints(): Unit = errs.head match {
+    private def addErrorToHints(): Unit = errs.head match {
         case TrivialError(errOffset, _, _, _, es, _) if errOffset == offset && es.nonEmpty =>
             // If our new hints have taken place further in the input stream, then they must invalidate the old ones
-            if (hintsValidOffset < offset) hints.clear()
-            hintsValidOffset = offset
+            if (hintsValidOffset < offset) {
+                hints.clear()
+                hintsValidOffset = offset
+            }
             hints += new Hint(es)
         case _ =>
     }

--- a/src/main/scala/parsley/internal/instructions/Context.scala
+++ b/src/main/scala/parsley/internal/instructions/Context.scala
@@ -53,9 +53,9 @@ private [parsley] final class Context(private [instructions] var instrs: Array[I
     private val inputDescriptor = sourceName.fold("input")(_ => "file")
 
     // NEW ERROR MECHANISMS
-    private var hints = mutable.ListBuffer.empty[Hint]
+    private var hints = mutable.ListBuffer.empty[Set[ErrorItem]]
     private var hintsValidOffset = 0
-    private var hintStack = Stack.empty[(Int, mutable.ListBuffer[Hint])]
+    private var hintStack = Stack.empty[(Int, mutable.ListBuffer[Set[ErrorItem]])]
     private [instructions] var errs = Stack.empty[ParseError]
 
     private [instructions] def saveHints(shadow: Boolean): Unit = {
@@ -83,7 +83,7 @@ private [parsley] final class Context(private [instructions] var instrs: Array[I
         commitHints()
     }
     private [instructions] def replaceHint(label: String): Unit = {
-        if (hints.nonEmpty) hints(0) = new Hint(Set(Desc(label)))
+        if (hints.nonEmpty) hints(0) = Set(Desc(label))
     }
     private [instructions] def popHints: Unit = if (hints.nonEmpty) hints.remove(0)
     /* ERROR RELABELLING END */
@@ -95,7 +95,7 @@ private [parsley] final class Context(private [instructions] var instrs: Array[I
                 hints.clear()
                 hintsValidOffset = offset
             }
-            hints += new Hint(es)
+            hints += es
         case _ =>
     }
     private [instructions] def addErrorToHintsAndPop(): Unit = {

--- a/src/main/scala/parsley/internal/instructions/CoreInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/CoreInstrs.scala
@@ -135,15 +135,16 @@ private [internal] final class JumpGood(var label: Int) extends InstrWithLabel {
     // $COVERAGE-ON$
 }
 
-private [internal] object Catch extends Instr {
+private [internal] final class Catch(var label: Int) extends InstrWithLabel {
     override def apply(ctx: Context): Unit = {
         ctx.restoreHints()
         ctx.catchNoConsumed {
+            ctx.pushHandler(label)
             ctx.inc()
         }
     }
     // $COVERAGE-OFF$
-    override def toString: String = s"Catch"
+    override def toString: String = s"Catch($label)"
     // $COVERAGE-ON$
 }
 

--- a/src/main/scala/parsley/internal/instructions/CoreInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/CoreInstrs.scala
@@ -3,7 +3,7 @@ package parsley.internal.instructions
 import Stack.{isEmpty, push}
 import parsley.internal.ResizableArray
 import parsley.internal.deepembedding.Parsley
-import parsley.internal.errors._
+import parsley.internal.errors.{ErrorItem, Desc, ParseError, TrivialError}, ParseError.NoReason
 
 import scala.annotation.tailrec
 
@@ -76,7 +76,7 @@ private [internal] object Return extends Instr {
 private [internal] final class Empty(_expected: Option[String]) extends Instr {
     val expected = _expected.fold(Set.empty[ErrorItem])(e => Set[ErrorItem](Desc(e)))
     override def apply(ctx: Context): Unit = {
-        ctx.fail(TrivialError(ctx.offset, ctx.line, ctx.col, None, expected, ParseError.NoReason))
+        ctx.fail(TrivialError(ctx.offset, ctx.line, ctx.col, None, expected, NoReason))
     }
     // $COVERAGE-OFF$
     override def toString: String = "Empty"

--- a/src/main/scala/parsley/internal/instructions/CoreInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/CoreInstrs.scala
@@ -58,7 +58,7 @@ private [internal] final class Call(_instrs: =>Array[Instr]) extends Instr {
     // $COVERAGE-ON$
 }
 
-private [internal] final class GoSub(var label: Int) extends JumpInstr {
+private [internal] final class GoSub(var label: Int) extends InstrWithLabel {
     override def apply(ctx: Context): Unit = ctx.call(ctx.instrs, label)
     // $COVERAGE-OFF$
     override def toString: String = s"GoSub($label)"
@@ -82,7 +82,7 @@ private [internal] final class Empty(_expected: Option[String]) extends Instr {
     // $COVERAGE-ON$
 }
 
-private [internal] final class PushHandler(var label: Int) extends JumpInstr {
+private [internal] final class PushHandler(var label: Int) extends InstrWithLabel {
     override def apply(ctx: Context): Unit = {
         ctx.pushHandler(label)
         ctx.inc()
@@ -92,7 +92,7 @@ private [internal] final class PushHandler(var label: Int) extends JumpInstr {
     // $COVERAGE-ON$
 }
 
-private [internal] final class PushHandlerAndState(var label: Int, saveHints: Boolean, hideHints: Boolean) extends JumpInstr {
+private [internal] final class PushHandlerAndState(var label: Int, saveHints: Boolean, hideHints: Boolean) extends InstrWithLabel {
     override def apply(ctx: Context): Unit = {
         ctx.pushHandler(label)
         ctx.saveState()
@@ -104,7 +104,7 @@ private [internal] final class PushHandlerAndState(var label: Int, saveHints: Bo
     // $COVERAGE-ON$
 }
 
-private [internal] final class InputCheck(var label: Int, saveHints: Boolean = false) extends JumpInstr {
+private [internal] final class InputCheck(var label: Int, saveHints: Boolean = false) extends InstrWithLabel {
     override def apply(ctx: Context): Unit = {
         ctx.pushCheck()
         ctx.pushHandler(label)
@@ -116,14 +116,14 @@ private [internal] final class InputCheck(var label: Int, saveHints: Boolean = f
     // $COVERAGE-ON$
 }
 
-private [internal] final class Jump(var label: Int) extends JumpInstr {
+private [internal] final class Jump(var label: Int) extends InstrWithLabel {
     override def apply(ctx: Context): Unit = ctx.pc = label
     // $COVERAGE-OFF$
     override def toString: String = s"Jump($label)"
     // $COVERAGE-ON$
 }
 
-private [internal] final class JumpGood(var label: Int) extends JumpInstr {
+private [internal] final class JumpGood(var label: Int) extends InstrWithLabel {
     override def apply(ctx: Context): Unit = {
         ctx.handlers = ctx.handlers.tail
         ctx.checkStack = ctx.checkStack.tail
@@ -170,7 +170,7 @@ private [instructions] trait Logger {
     final protected def indent(ctx: Context) = " " * (ctx.debuglvl * 2)
 }
 
-private [internal] final class LogBegin(var label: Int, val name: String, break: Boolean) extends JumpInstr with Logger {
+private [internal] final class LogBegin(var label: Int, val name: String, break: Boolean) extends InstrWithLabel with Logger {
     override def apply(ctx: Context): Unit = {
         println(preludeString('>', ctx))
         if (break) doBreak(ctx)

--- a/src/main/scala/parsley/internal/instructions/CoreInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/CoreInstrs.scala
@@ -137,11 +137,10 @@ private [internal] final class JumpGood(var label: Int) extends JumpInstr {
 
 private [internal] object Catch extends Instr {
     override def apply(ctx: Context): Unit = {
+        ctx.restoreHints()
         ctx.catchNoConsumed {
             ctx.inc()
-            //ctx.addErrorToHints() //TODO: This actually does NOTHING?!
         }
-        ctx.restoreHints()
     }
     // $COVERAGE-OFF$
     override def toString: String = s"Catch"

--- a/src/main/scala/parsley/internal/instructions/CoreInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/CoreInstrs.scala
@@ -25,17 +25,6 @@ private [internal] object Pop extends Instr {
     // $COVERAGE-ON$
 }
 
-private [internal] object Flip extends Instr {
-    override def apply(ctx: Context): Unit = {
-        val x = ctx.stack(1)
-        ctx.stack(1) = ctx.stack.upeek
-        ctx.exchangeAndContinue(x)
-    }
-    // $COVERAGE-OFF$
-    override def toString: String = "Flip"
-    // $COVERAGE-ON$
-}
-
 // Applicative Functors
 private [internal] object Apply extends Instr {
     override def apply(ctx: Context): Unit = {

--- a/src/main/scala/parsley/internal/instructions/CoreInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/CoreInstrs.scala
@@ -3,7 +3,7 @@ package parsley.internal.instructions
 import Stack.{isEmpty, push}
 import parsley.internal.ResizableArray
 import parsley.internal.deepembedding.Parsley
-import parsley.internal.errors.{ErrorItem, Desc, ParseError, TrivialError}, ParseError.NoReason
+import parsley.internal.errors.{ErrorItem, Desc, ParseError, TrivialError, EmptyError}, ParseError.NoReason
 
 import scala.annotation.tailrec
 
@@ -74,9 +74,11 @@ private [internal] object Return extends Instr {
 }
 
 private [internal] final class Empty(_expected: Option[String]) extends Instr {
-    val expected = _expected.fold(Set.empty[ErrorItem])(e => Set[ErrorItem](Desc(e)))
+    //val expected = _expected.fold(Set.empty[ErrorItem])(e => Set[ErrorItem](Desc(e)))
+    val expected = _expected.map(Desc)
     override def apply(ctx: Context): Unit = {
-        ctx.fail(TrivialError(ctx.offset, ctx.line, ctx.col, None, expected, NoReason))
+        //ctx.fail(TrivialError(ctx.offset, ctx.line, ctx.col, None, expected, NoReason))
+        ctx.fail(new EmptyError(ctx.offset, ctx.line, ctx.col, expected))
     }
     // $COVERAGE-OFF$
     override def toString: String = "Empty"

--- a/src/main/scala/parsley/internal/instructions/CoreInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/CoreInstrs.scala
@@ -3,6 +3,7 @@ package parsley.internal.instructions
 import Stack.{isEmpty, push}
 import parsley.internal.ResizableArray
 import parsley.internal.deepembedding.Parsley
+import parsley.internal.errors._
 
 import scala.annotation.tailrec
 

--- a/src/main/scala/parsley/internal/instructions/CoreInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/CoreInstrs.scala
@@ -150,7 +150,7 @@ private [internal] object Catch extends Instr {
     override def apply(ctx: Context): Unit = {
         ctx.catchNoConsumed {
             ctx.inc()
-            ctx.addErrorToHints()
+            //ctx.addErrorToHints() //TODO: This actually does NOTHING?!
         }
         ctx.restoreHints()
     }

--- a/src/main/scala/parsley/internal/instructions/CoreInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/CoreInstrs.scala
@@ -2,7 +2,6 @@ package parsley.internal.instructions
 
 import Stack.{isEmpty, push}
 import parsley.internal.ResizableArray
-import parsley.internal.UnsafeOption
 import parsley.internal.deepembedding.Parsley
 
 import scala.annotation.tailrec
@@ -73,9 +72,10 @@ private [internal] object Return extends Instr {
     // $COVERAGE-ON$
 }
 
-private [internal] final class Empty(expected: UnsafeOption[String]) extends Instr {
+private [internal] final class Empty(_expected: Option[String]) extends Instr {
+    val expected = _expected.fold(Set.empty[ErrorItem])(e => Set[ErrorItem](Desc(e)))
     override def apply(ctx: Context): Unit = {
-        ctx.fail(TrivialError(ctx.offset, ctx.line, ctx.col, None, if (expected == null) Set.empty else Set(Desc(expected)), Set.empty))
+        ctx.fail(TrivialError(ctx.offset, ctx.line, ctx.col, None, expected, ParseError.NoReason))
     }
     // $COVERAGE-OFF$
     override def toString: String = "Empty"

--- a/src/main/scala/parsley/internal/instructions/ErrorInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/ErrorInstrs.scala
@@ -2,7 +2,7 @@ package parsley.internal.instructions
 
 import parsley.internal.ResizableArray
 
-import parsley.internal.errors.{ErrorItem, Desc, TrivialError, FailError}
+import parsley.internal.errors.{ErrorItem, Desc, TrivialError, FailError, WithReason, MergedErrors, WithLabel}
 
 private [internal] final class ApplyError(label: String) extends Instr {
     val isHide: Boolean = label.isEmpty
@@ -24,14 +24,14 @@ private [internal] final class ApplyError(label: String) extends Instr {
             ctx.errs.head = ctx.useHints {
                 // EERR
                 // the top of the error stack is adjusted:
-                if (ctx.offset == ctx.checkStack.head) ctx.errs.head match {
+                if (ctx.offset == ctx.checkStack.head) new WithLabel(ctx.errs.head, label) /*match {
                     // - if it is a fail, it is left alone
                     case err: FailError              => err
                     //  - otherwise if this is a hide, the expected set is discarded
                     case err: TrivialError if isHide => err.copy(expecteds = Set.empty)
                     //  - otherwise expected set is replaced by singleton containing this label
                     case err: TrivialError           => err.copy(expecteds = Set(Desc(label)))
-                }
+                }*/
                 // CERR
                 // do nothing
                 else ctx.errs.head
@@ -55,7 +55,7 @@ private [internal] object MergeErrors extends Instr {
         else {
             val err2 = ctx.errs.head
             ctx.errs = ctx.errs.tail
-            ctx.errs.head = ctx.errs.head.merge(err2)
+            ctx.errs.head = new MergedErrors(ctx.errs.head, err2)
             ctx.fail()
         }
     }
@@ -72,7 +72,7 @@ private [internal] class ApplyReason(reason: String) extends Instr {
             ctx.inc()
         }
         else {
-            ctx.errs.head = ctx.errs.head.giveReason(reason)
+            ctx.errs.head = new WithReason(ctx.errs.head, reason)
             ctx.fail()
         }
     }
@@ -90,11 +90,12 @@ private [internal] final class Fail(msg: String) extends Instr {
 }
 
 private [internal] final class Unexpected(msg: String, _expected: Option[String]) extends Instr {
-    val expected: Set[ErrorItem] = _expected match {
+    /*val expected: Set[ErrorItem] = _expected match {
         case Some(ex) => Set(Desc(ex))
         case None => Set.empty
-    }
-    val unexpected = Some(Desc(msg))
+    }*/
+    private [this] val expected = _expected.map(Desc)
+    private [this] val unexpected = Desc(msg)
     override def apply(ctx: Context): Unit = ctx.unexpectedFail(expected, unexpected)
     // $COVERAGE-OFF$
     override def toString: String = s"Unexpected($msg)"
@@ -110,11 +111,12 @@ private [internal] final class FastFail[A](msggen: A=>String) extends Instr {
 }
 
 private [internal] final class FastUnexpected[A](_msggen: A=>String, _expected: Option[String]) extends Instr {
-    private [this] def msggen(x: Any) = new Some(new Desc(_msggen(x.asInstanceOf[A])))
-    val expected: Set[ErrorItem] = _expected match {
+    private [this] def msggen(x: Any) = new Desc(_msggen(x.asInstanceOf[A]))
+    /*val expected: Set[ErrorItem] = _expected match {
         case Some(ex) => Set(Desc(ex))
         case None => Set.empty
-    }
+    }*/
+    private [this] val expected = _expected.map(Desc)
     override def apply(ctx: Context): Unit = ctx.unexpectedFail(expected = expected, unexpected = msggen(ctx.stack.upop()))
     // $COVERAGE-OFF$
     override def toString: String = "FastUnexpected(?)"

--- a/src/main/scala/parsley/internal/instructions/ErrorInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/ErrorInstrs.scala
@@ -2,6 +2,8 @@ package parsley.internal.instructions
 
 import parsley.internal.ResizableArray
 
+import parsley.internal.errors._
+
 private [internal] final class ApplyError(label: String) extends Instr {
     val isHide: Boolean = label.isEmpty
     override def apply(ctx: Context): Unit = {

--- a/src/main/scala/parsley/internal/instructions/ErrorInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/ErrorInstrs.scala
@@ -66,9 +66,9 @@ private [internal] class ApplyReason(reason: String) extends Instr {
         }
         else {
             if (ctx.offset == ctx.checkStack.head) ctx.errs.head = new WithReason(ctx.errs.head, reason)
-            ctx.checkStack = ctx.checkStack.tail
             ctx.fail()
         }
+        ctx.checkStack = ctx.checkStack.tail
     }
 
     // $COVERAGE-OFF$

--- a/src/main/scala/parsley/internal/instructions/ErrorInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/ErrorInstrs.scala
@@ -65,7 +65,8 @@ private [internal] class ApplyReason(reason: String) extends Instr {
             ctx.inc()
         }
         else {
-            ctx.errs.head = new WithReason(ctx.errs.head, reason)
+            if (ctx.offset == ctx.checkStack.head) ctx.errs.head = new WithReason(ctx.errs.head, reason)
+            ctx.checkStack = ctx.checkStack.tail
             ctx.fail()
         }
     }

--- a/src/main/scala/parsley/internal/instructions/ErrorInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/ErrorInstrs.scala
@@ -2,7 +2,7 @@ package parsley.internal.instructions
 
 import parsley.internal.ResizableArray
 
-import parsley.internal.errors._
+import parsley.internal.errors.{ErrorItem, Desc, TrivialError, FailError}
 
 private [internal] final class ApplyError(label: String) extends Instr {
     val isHide: Boolean = label.isEmpty

--- a/src/main/scala/parsley/internal/instructions/ErrorInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/ErrorInstrs.scala
@@ -19,19 +19,21 @@ private [internal] final class ApplyError(label: String) extends Instr {
         }
         else {
             ctx.restoreHints()
-            // EERR
-            // the top of the error stack is adjusted:
-            if (ctx.offset == ctx.checkStack.head) ctx.errs.head = ctx.errs.head match {
-                // - if it is a fail, it is left alone
-                case err: FailError              => err
-                //  - otherwise if this is a hide, the expected set is discarded
-                case err: TrivialError if isHide => err.copy(expecteds = Set.empty)
-                //  - otherwise expected set is replaced by singleton containing this label
-                case err: TrivialError           => err.copy(expecteds = Set(Desc(label)))
+            ctx.errs.head = ctx.useHints {
+                // EERR
+                // the top of the error stack is adjusted:
+                if (ctx.offset == ctx.checkStack.head) ctx.errs.head match {
+                    // - if it is a fail, it is left alone
+                    case err: FailError              => err
+                    //  - otherwise if this is a hide, the expected set is discarded
+                    case err: TrivialError if isHide => err.copy(expecteds = Set.empty)
+                    //  - otherwise expected set is replaced by singleton containing this label
+                    case err: TrivialError           => err.copy(expecteds = Set(Desc(label)))
+                }
+                // CERR
+                // do nothing
+                else ctx.errs.head
             }
-            // CERR
-            // do nothing
-            ctx.useHints()
             ctx.fail()
         }
         ctx.checkStack = ctx.checkStack.tail

--- a/src/main/scala/parsley/internal/instructions/ErrorInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/ErrorInstrs.scala
@@ -24,7 +24,7 @@ private [internal] final class ApplyError(label: String) extends Instr {
             ctx.errs.head = ctx.useHints {
                 // EERR
                 // the top of the error stack is adjusted:
-                if (ctx.offset == ctx.checkStack.head) new WithLabel(ctx.errs.head, label)
+                if (ctx.offset == ctx.checkStack.head) WithLabel(ctx.errs.head, label)
                 // CERR
                 // do nothing
                 else ctx.errs.head
@@ -48,7 +48,7 @@ private [internal] object MergeErrors extends Instr {
         else {
             val err2 = ctx.errs.head
             ctx.errs = ctx.errs.tail
-            ctx.errs.head = new MergedErrors(ctx.errs.head, err2)
+            ctx.errs.head = MergedErrors(ctx.errs.head, err2)
             ctx.fail()
         }
     }

--- a/src/main/scala/parsley/internal/instructions/ErrorInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/ErrorInstrs.scala
@@ -24,14 +24,7 @@ private [internal] final class ApplyError(label: String) extends Instr {
             ctx.errs.head = ctx.useHints {
                 // EERR
                 // the top of the error stack is adjusted:
-                if (ctx.offset == ctx.checkStack.head) new WithLabel(ctx.errs.head, label) /*match {
-                    // - if it is a fail, it is left alone
-                    case err: FailError              => err
-                    //  - otherwise if this is a hide, the expected set is discarded
-                    case err: TrivialError if isHide => err.copy(expecteds = Set.empty)
-                    //  - otherwise expected set is replaced by singleton containing this label
-                    case err: TrivialError           => err.copy(expecteds = Set(Desc(label)))
-                }*/
+                if (ctx.offset == ctx.checkStack.head) new WithLabel(ctx.errs.head, label)
                 // CERR
                 // do nothing
                 else ctx.errs.head
@@ -90,10 +83,6 @@ private [internal] final class Fail(msg: String) extends Instr {
 }
 
 private [internal] final class Unexpected(msg: String, _expected: Option[String]) extends Instr {
-    /*val expected: Set[ErrorItem] = _expected match {
-        case Some(ex) => Set(Desc(ex))
-        case None => Set.empty
-    }*/
     private [this] val expected = _expected.map(Desc)
     private [this] val unexpected = Desc(msg)
     override def apply(ctx: Context): Unit = ctx.unexpectedFail(expected, unexpected)
@@ -112,10 +101,6 @@ private [internal] final class FastFail[A](msggen: A=>String) extends Instr {
 
 private [internal] final class FastUnexpected[A](_msggen: A=>String, _expected: Option[String]) extends Instr {
     private [this] def msggen(x: Any) = new Desc(_msggen(x.asInstanceOf[A]))
-    /*val expected: Set[ErrorItem] = _expected match {
-        case Some(ex) => Set(Desc(ex))
-        case None => Set.empty
-    }*/
     private [this] val expected = _expected.map(Desc)
     override def apply(ctx: Context): Unit = ctx.unexpectedFail(expected = expected, unexpected = msggen(ctx.stack.upop()))
     // $COVERAGE-OFF$

--- a/src/main/scala/parsley/internal/instructions/Errors.scala
+++ b/src/main/scala/parsley/internal/instructions/Errors.scala
@@ -4,7 +4,7 @@ import ParseError.Unknown
 import Raw.Unprintable
 import scala.util.matching.Regex
 
-private [internal] sealed trait ParseError {
+private [internal] sealed abstract class ParseError {
     val offset: Int
     val col: Int
     val line: Int

--- a/src/main/scala/parsley/internal/instructions/Errors.scala
+++ b/src/main/scala/parsley/internal/instructions/Errors.scala
@@ -123,5 +123,7 @@ private [internal] case object EndOfInput extends ErrorItem {
 }
 
 private [instructions] final class Hint(val hint: Set[ErrorItem]) extends AnyVal {
+    // $COVERAGE-OFF$
     override def toString: String = hint.toString
+    // $COVERAGE-ON$
 }

--- a/src/main/scala/parsley/internal/instructions/Errors.scala
+++ b/src/main/scala/parsley/internal/instructions/Errors.scala
@@ -106,7 +106,7 @@ private [internal] object ErrorItem {
     }
 }
 private [internal] case class Raw(cs: String) extends ErrorItem {
-    override val msg = cs match {
+    override lazy val msg = cs match {
         case "\n"            => "newline"
         case "\t"            => "tab"
         case " "             => "space"

--- a/src/main/scala/parsley/internal/instructions/Errors.scala
+++ b/src/main/scala/parsley/internal/instructions/Errors.scala
@@ -90,6 +90,7 @@ private [internal] case class FailError(offset: Int, line: Int, col: Int, msgs: 
 private [internal] object ParseError {
     def fail(msg: String, offset: Int, line: Int, col: Int): ParseError = FailError(offset, line, col, Set(msg))
     val Unknown = "unknown parse error"
+    val NoReason = Set.empty[String]
 }
 
 private [internal] sealed trait ErrorItem {

--- a/src/main/scala/parsley/internal/instructions/IntrinsicInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/IntrinsicInstrs.scala
@@ -2,6 +2,8 @@ package parsley.internal.instructions
 
 import Stack.isEmpty
 
+import parsley.internal.errors._
+
 import scala.annotation.tailrec
 
 private [internal] final class Lift2[A, B, C](_f: (A, B) => C) extends Instr {
@@ -76,8 +78,8 @@ private [internal] final class StringTok private [instructions] (s: String, x: A
         else if (j < sz) {
             // The offset, line and column haven't been edited yet, so are in the right place
             val err = new TrivialError(ctx.offset, ctx.line, ctx.col,
-                Some(if (ctx.inputsz > ctx.offset) new Raw(ctx.input.substring(ctx.offset, Math.min(ctx.offset + sz, ctx.inputsz))) else EndOfInput),
-                errorItem, Set.empty
+                new Some(if (ctx.inputsz > ctx.offset) new Raw(ctx.input.substring(ctx.offset, Math.min(ctx.offset + sz, ctx.inputsz))) else EndOfInput),
+                errorItem, ParseError.NoReason
             )
             ctx.offset = i
             ctx.fail(err)

--- a/src/main/scala/parsley/internal/instructions/IntrinsicInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/IntrinsicInstrs.scala
@@ -29,7 +29,7 @@ private [internal] final class Lift3[A, B, C, D](_f: (A, B, C) => D) extends Ins
 }
 
 private [internal] class CharTok(c: Char, x: Any, _expected: UnsafeOption[String]) extends Instr {
-    private val errorItem: Set[ErrorItem] = Set(if (_expected == null) Raw(c) else Desc(_expected))
+    private val errorItem: Set[ErrorItem] = Set(if (_expected == null) Raw(c) else new Desc(_expected))
     override def apply(ctx: Context): Unit = {
         if (ctx.moreInput && ctx.nextChar == c) {
             ctx.consumeChar()
@@ -43,7 +43,7 @@ private [internal] class CharTok(c: Char, x: Any, _expected: UnsafeOption[String
 }
 
 private [internal] final class StringTok private [instructions] (s: String, x: Any, _expected: UnsafeOption[String]) extends Instr {
-    private [this] val errorItem: Set[ErrorItem] = Set(if (_expected == null) Raw(s) else Desc(_expected))
+    private [this] val errorItem: Set[ErrorItem] = Set(if (_expected == null) new Raw(s) else new Desc(_expected))
     private [this] val cs = s.toCharArray
     private [this] val sz = cs.length
     private [this] val adjustAtIndex = new Array[(Int => Int, Int => Int)](s.length + 1)
@@ -84,8 +84,8 @@ private [internal] final class StringTok private [instructions] (s: String, x: A
         val origLine = ctx.line
         val origCol = ctx.col
         go(ctx, ctx.offset, 0,
-            TrivialError(origOffset, origLine, origCol,
-                Some(if (ctx.inputsz > origOffset) Raw(ctx.input.substring(origOffset, Math.min(origOffset + sz, ctx.inputsz))) else EndOfInput),
+            new TrivialError(origOffset, origLine, origCol,
+                Some(if (ctx.inputsz > origOffset) new Raw(ctx.input.substring(origOffset, Math.min(origOffset + sz, ctx.inputsz))) else EndOfInput),
                 errorItem, Set.empty
             ))
     }
@@ -108,7 +108,7 @@ private [internal] final class Filter[A](_pred: A=>Boolean, expected: UnsafeOpti
     private [this] val pred = _pred.asInstanceOf[Any=>Boolean]
     override def apply(ctx: Context): Unit = {
         if (pred(ctx.stack.upeek)) ctx.inc()
-        else ctx.fail(TrivialError(ctx.offset, ctx.line, ctx.col, None, if (expected == null) Set.empty else Set(Desc(expected)), Set.empty))
+        else ctx.fail(TrivialError(ctx.offset, ctx.line, ctx.col, None, if (expected == null) Set.empty else Set(new Desc(expected)), Set.empty))
     }
     // $COVERAGE-OFF$
     override def toString: String = "Filter(?)"
@@ -120,7 +120,7 @@ private [internal] final class FilterOut[A](_pred: PartialFunction[A, String], e
     override def apply(ctx: Context): Unit = {
         if (pred.isDefinedAt(ctx.stack.upeek)) {
             val reason = pred(ctx.stack.upop())
-            ctx.fail(TrivialError(ctx.offset, ctx.line, ctx.col, None, if (expected == null) Set.empty else Set(Desc(expected)), Set(reason)))
+            ctx.fail(TrivialError(ctx.offset, ctx.line, ctx.col, None, if (expected == null) Set.empty else Set(new Desc(expected)), Set(reason)))
         }
         else ctx.inc()
     }
@@ -167,7 +167,7 @@ private [internal] class Eof(_expected: UnsafeOption[String]) extends Instr {
     override def apply(ctx: Context): Unit = {
         if (ctx.offset == ctx.inputsz) ctx.pushAndContinue(())
         else {
-            ctx.expectedFail(Set[ErrorItem](if (_expected == null) EndOfInput else Desc(_expected)), None)
+            ctx.expectedFail(Set[ErrorItem](if (_expected == null) EndOfInput else new Desc(_expected)), None)
         }
     }
     // $COVERAGE-OFF$

--- a/src/main/scala/parsley/internal/instructions/IntrinsicInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/IntrinsicInstrs.scala
@@ -68,22 +68,20 @@ private [internal] final class StringTok private [instructions] (s: String, x: A
 
     @tailrec private def go(ctx: Context, i: Int, j: Int): Unit = {
         if (j < sz && i < ctx.inputsz && ctx.input.charAt(i) == cs(j)) go(ctx, i + 1, j + 1)
+        else if (j < sz) {
+            // The offset, line and column haven't been edited yet, so are in the right place
+            val err = new TrivialError(ctx.offset, ctx.line, ctx.col,
+                Some(if (ctx.inputsz > ctx.offset) new Raw(ctx.input.substring(ctx.offset, Math.min(ctx.offset + sz, ctx.inputsz))) else EndOfInput),
+                errorItem, Set.empty
+            )
+            ctx.offset = i
+            ctx.fail(err)
+        }
         else {
-            if (j < sz) {
-                // The offset, line and column haven't been edited yet, so are in the right place
-                val err = new TrivialError(ctx.offset, ctx.line, ctx.col,
-                    Some(if (ctx.inputsz > ctx.offset) new Raw(ctx.input.substring(ctx.offset, Math.min(ctx.offset + sz, ctx.inputsz))) else EndOfInput),
-                    errorItem, Set.empty
-                )
-                ctx.offset = i
-                ctx.fail(err)
-            }
-            else {
-                ctx.col = colAdjust(ctx.col)
-                ctx.line = lineAdjust(ctx.line)
-                ctx.offset = i
-                ctx.pushAndContinue(x)
-            }
+            ctx.col = colAdjust(ctx.col)
+            ctx.line = lineAdjust(ctx.line)
+            ctx.offset = i
+            ctx.pushAndContinue(x)
         }
     }
 

--- a/src/main/scala/parsley/internal/instructions/IntrinsicInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/IntrinsicInstrs.scala
@@ -1,6 +1,5 @@
 package parsley.internal.instructions
 
-import parsley.internal.UnsafeOption
 import Stack.isEmpty
 
 import scala.annotation.tailrec
@@ -28,8 +27,11 @@ private [internal] final class Lift3[A, B, C, D](_f: (A, B, C) => D) extends Ins
     // $COVERAGE-ON$
 }
 
-private [internal] class CharTok(c: Char, x: Any, _expected: UnsafeOption[String]) extends Instr {
-    private val errorItem: Set[ErrorItem] = Set(if (_expected == null) Raw(c) else new Desc(_expected))
+private [internal] class CharTok(c: Char, x: Any, _expected: Option[String]) extends Instr {
+    private [this] final val errorItem = Set[ErrorItem](_expected match {
+        case Some(e) => Desc(e)
+        case None    => Raw(c)
+    })
     override def apply(ctx: Context): Unit = {
         if (ctx.moreInput && ctx.nextChar == c) {
             ctx.consumeChar()
@@ -42,8 +44,11 @@ private [internal] class CharTok(c: Char, x: Any, _expected: UnsafeOption[String
     // $COVERAGE-ON$
 }
 
-private [internal] final class StringTok private [instructions] (s: String, x: Any, _expected: UnsafeOption[String]) extends Instr {
-    private [this] val errorItem: Set[ErrorItem] = Set(if (_expected == null) new Raw(s) else new Desc(_expected))
+private [internal] final class StringTok private [instructions] (s: String, x: Any, _expected: Option[String]) extends Instr {
+    private [this] val errorItem: Set[ErrorItem] = Set(_expected match {
+        case Some(e) => Desc(e)
+        case None    => Raw(s)
+    })
     private [this] val cs = s.toCharArray
     private [this] val sz = cs.length
     def makeAdjusters(col: Int, line: Int, tabprefix: Option[Int]): (Int => Int, Int => Int) =
@@ -55,16 +60,16 @@ private [internal] final class StringTok private [instructions] (s: String, x: A
                 (x: Int) => outer + x - ((x + inner) & 3)
             case None => (x: Int) => x + col
         }, (x: Int) => x)
-    @tailrec def compute(cs: Array[Char], i: Int = 0, col: Int = 0, line: Int = 0)(implicit tabprefix: Option[Int] = None): (Int => Int, Int => Int) = {
+    @tailrec def compute(i: Int, col: Int, line: Int)(implicit tabprefix: Option[Int]): (Int => Int, Int => Int) = {
         if (i < cs.length) cs(i) match {
-            case '\n' => compute(cs, i + 1, 1, line + 1)(Some(0))
-            case '\t' if tabprefix.isEmpty => compute(cs, i + 1, 0, line)(Some(col))
-            case '\t' => compute(cs, i + 1, col + 4 - ((col - 1) & 3), line)
-            case _ => compute(cs, i + 1, col + 1, line)
+            case '\n' => compute(i + 1, 1, line + 1)(Some(0))
+            case '\t' if tabprefix.isEmpty => compute(i + 1, 0, line)(Some(col))
+            case '\t' => compute(i + 1, col + 4 - ((col - 1) & 3), line)
+            case _ => compute(i + 1, col + 1, line)
         }
         else makeAdjusters(col, line, tabprefix)
     }
-    private [this] val (colAdjust, lineAdjust) = compute(cs)
+    private [this] val (colAdjust, lineAdjust) = compute(0, 0, 0)(None)
 
     @tailrec private def go(ctx: Context, i: Int, j: Int): Unit = {
         if (j < sz && i < ctx.inputsz && ctx.input.charAt(i) == cs(j)) go(ctx, i + 1, j + 1)
@@ -101,23 +106,31 @@ private [internal] final class If(var label: Int) extends JumpInstr {
     // $COVERAGE-ON$
 }
 
-private [internal] final class Filter[A](_pred: A=>Boolean, expected: UnsafeOption[String]) extends Instr {
+private [internal] final class Filter[A](_pred: A=>Boolean, _expected: Option[String]) extends Instr {
     private [this] val pred = _pred.asInstanceOf[Any=>Boolean]
+    private [this] val expected = _expected match {
+        case None => Set.empty[ErrorItem]
+        case Some(e) => Set[ErrorItem](new Desc(e))
+    }
     override def apply(ctx: Context): Unit = {
         if (pred(ctx.stack.upeek)) ctx.inc()
-        else ctx.fail(TrivialError(ctx.offset, ctx.line, ctx.col, None, if (expected == null) Set.empty else Set(new Desc(expected)), Set.empty))
+        else ctx.fail(TrivialError(ctx.offset, ctx.line, ctx.col, None, expected, ParseError.NoReason))
     }
     // $COVERAGE-OFF$
     override def toString: String = "Filter(?)"
     // $COVERAGE-ON$
 }
 
-private [internal] final class FilterOut[A](_pred: PartialFunction[A, String], expected: UnsafeOption[String]) extends Instr {
+private [internal] final class FilterOut[A](_pred: PartialFunction[A, String], _expected: Option[String]) extends Instr {
     private [this] val pred = _pred.asInstanceOf[PartialFunction[Any, String]]
+    private [this] val expected = _expected match {
+        case None => Set.empty[ErrorItem]
+        case Some(e) => Set[ErrorItem](new Desc(e))
+    }
     override def apply(ctx: Context): Unit = {
         if (pred.isDefinedAt(ctx.stack.upeek)) {
             val reason = pred(ctx.stack.upop())
-            ctx.fail(TrivialError(ctx.offset, ctx.line, ctx.col, None, if (expected == null) Set.empty else Set(new Desc(expected)), Set(reason)))
+            ctx.fail(TrivialError(ctx.offset, ctx.line, ctx.col, None, expected, Set(reason)))
         }
         else ctx.inc()
     }
@@ -137,7 +150,11 @@ private [internal] final class GuardAgainst[A](_pred: PartialFunction[A, String]
     // $COVERAGE-ON$
 }
 
-private [internal] final class NotFollowedBy(expected: UnsafeOption[String]) extends Instr {
+private [internal] final class NotFollowedBy(_expected: Option[String]) extends Instr {
+    private [this] final val expected: Set[ErrorItem] = _expected match {
+        case Some(ex) => Set(Desc(ex))
+        case None => Set.empty
+    }
     override def apply(ctx: Context): Unit = {
         // Recover the previous state; notFollowedBy NEVER consumes input
         ctx.restoreState()
@@ -145,7 +162,7 @@ private [internal] final class NotFollowedBy(expected: UnsafeOption[String]) ext
         // A previous success is a failure
         if (ctx.status eq Good) {
             ctx.handlers = ctx.handlers.tail
-            ctx.unexpectedFail(expected = expected, unexpected = "\"" + ctx.stack.upop().toString + "\"")
+            ctx.unexpectedFail(expected = expected, unexpected = new Some(new Raw(ctx.stack.upop().toString)))
         }
         // A failure is what we wanted
         else {
@@ -159,12 +176,12 @@ private [internal] final class NotFollowedBy(expected: UnsafeOption[String]) ext
     // $COVERAGE-ON$
 }
 
-private [internal] class Eof(_expected: UnsafeOption[String]) extends Instr {
-    val expected: String = if (_expected == null) "end of input" else _expected
+private [internal] final class Eof(_expected: Option[String]) extends Instr {
+    private [this] final val expected = Set[ErrorItem](Desc(_expected.getOrElse("end of input")))
     override def apply(ctx: Context): Unit = {
         if (ctx.offset == ctx.inputsz) ctx.pushAndContinue(())
         else {
-            ctx.expectedFail(Set[ErrorItem](if (_expected == null) EndOfInput else new Desc(_expected)), None)
+            ctx.expectedFail(expected, reason = None)
         }
     }
     // $COVERAGE-OFF$
@@ -223,9 +240,17 @@ private [internal] final class Local(var label: Int, reg: Int) extends JumpInstr
 
 // Companion Objects
 private [internal] object CharTok {
-    def apply(c: Char, expected: UnsafeOption[String]): Instr = new CharTok(c, c, expected)
+    def apply(c: Char, expected: Option[String]): Instr = new CharTok(c, c, expected)
 }
 
 private [internal] object StringTok {
-    def apply(s: String, expected: UnsafeOption[String]): StringTok = new StringTok(s, s, expected)
+    def apply(s: String, expected: Option[String]): StringTok = new StringTok(s, s, expected)
+}
+
+private [internal] object CharTokFastPerform {
+    def apply[A >: Char, B](c: Char, f: A => B, expected: Option[String]): CharTok = new CharTok(c, f(c), expected)
+}
+
+private [internal] object StringTokFastPerform {
+    def apply(s: String, f: String => Any, expected: Option[String]): StringTok = new StringTok(s, f(s), expected)
 }

--- a/src/main/scala/parsley/internal/instructions/IntrinsicInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/IntrinsicInstrs.scala
@@ -2,7 +2,7 @@ package parsley.internal.instructions
 
 import Stack.isEmpty
 
-import parsley.internal.errors._
+import parsley.internal.errors.{TrivialError, ErrorItem, Desc, Raw, EndOfInput, ParseError}, ParseError.NoReason
 
 import scala.annotation.tailrec
 
@@ -79,7 +79,7 @@ private [internal] final class StringTok private [instructions] (s: String, x: A
             // The offset, line and column haven't been edited yet, so are in the right place
             val err = new TrivialError(ctx.offset, ctx.line, ctx.col,
                 new Some(if (ctx.inputsz > ctx.offset) new Raw(ctx.input.substring(ctx.offset, Math.min(ctx.offset + sz, ctx.inputsz))) else EndOfInput),
-                errorItem, ParseError.NoReason
+                errorItem, NoReason
             )
             ctx.offset = i
             ctx.fail(err)

--- a/src/main/scala/parsley/internal/instructions/IntrinsicInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/IntrinsicInstrs.scala
@@ -47,7 +47,10 @@ private [internal] class CharTok(c: Char, x: Any, _expected: Option[String]) ext
 }
 
 private [internal] final class StringTok private [instructions] (s: String, x: Any, _expected: Option[String]) extends Instr {
-    private [this] val errorItem = _expected.map(Desc)
+    private [this] final val errorItem = Some(_expected match {
+        case Some(e) => Desc(e)
+        case None    => Raw(s)
+    })
     private [this] val cs = s.toCharArray
     private [this] val sz = cs.length
     def makeAdjusters(col: Int, line: Int, tabprefix: Option[Int]): (Int => Int, Int => Int) =

--- a/src/main/scala/parsley/internal/instructions/IntrinsicInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/IntrinsicInstrs.scala
@@ -96,7 +96,7 @@ private [internal] final class StringTok private [instructions] (s: String, x: A
     // $COVERAGE-ON$
 }
 
-private [internal] final class If(var label: Int) extends JumpInstr {
+private [internal] final class If(var label: Int) extends InstrWithLabel {
     override def apply(ctx: Context): Unit = {
         if (ctx.stack.pop()) ctx.pc = label
         else ctx.inc()
@@ -200,7 +200,7 @@ private [internal] final class Modify[S](reg: Int, _f: S => S) extends Instr {
     // $COVERAGE-ON$
 }
 
-private [internal] final class Local(var label: Int, reg: Int) extends JumpInstr with Stateful {
+private [internal] final class Local(var label: Int, reg: Int) extends InstrWithLabel with Stateful {
     private var saved: AnyRef = _
     private var inUse = false
 

--- a/src/main/scala/parsley/internal/instructions/IterativeInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/IterativeInstrs.scala
@@ -5,7 +5,7 @@ import Stack.isEmpty
 
 import scala.collection.mutable.ListBuffer
 
-private [internal] final class Many(var label: Int) extends JumpInstr with Stateful {
+private [internal] final class Many(var label: Int) extends InstrWithLabel with Stateful {
     private [this] val acc: ListBuffer[Any] = ListBuffer.empty
     override def apply(ctx: Context): Unit = {
         if (ctx.status eq Good) {
@@ -27,7 +27,7 @@ private [internal] final class Many(var label: Int) extends JumpInstr with State
     // $COVERAGE-ON$
     override def copy: Many = new Many(label)
 }
-private [internal] final class SkipMany(var label: Int) extends JumpInstr {
+private [internal] final class SkipMany(var label: Int) extends InstrWithLabel {
     override def apply(ctx: Context): Unit = {
         if (ctx.status eq Good) {
             ctx.stack.pop_()
@@ -45,7 +45,7 @@ private [internal] final class SkipMany(var label: Int) extends JumpInstr {
     // $COVERAGE-ON$
 }
 
-private [internal] final class ChainPost(var label: Int) extends JumpInstr with Stateful {
+private [internal] final class ChainPost(var label: Int) extends InstrWithLabel with Stateful {
     private [this] var acc: Any = _
     override def apply(ctx: Context): Unit = {
         if (ctx.status eq Good) {
@@ -79,7 +79,7 @@ private [internal] final class ChainPost(var label: Int) extends JumpInstr with 
     override def copy: ChainPost = new ChainPost(label)
 }
 
-private [internal] final class ChainPre(var label: Int) extends JumpInstr with Stateful {
+private [internal] final class ChainPre(var label: Int) extends InstrWithLabel with Stateful {
     private var acc: Any => Any = _
     override def apply(ctx: Context): Unit = {
         if (ctx.status eq Good) {
@@ -104,7 +104,7 @@ private [internal] final class ChainPre(var label: Int) extends JumpInstr with S
     // $COVERAGE-ON$
     override def copy: ChainPre = new ChainPre(label)
 }
-private [internal] final class Chainl(var label: Int) extends JumpInstr with Stateful {
+private [internal] final class Chainl(var label: Int) extends InstrWithLabel with Stateful {
     private [this] var acc: Any = _
     override def apply(ctx: Context): Unit = {
         if (ctx.status eq Good) {
@@ -155,7 +155,7 @@ private [instructions] sealed trait DualHandler {
         ctx.pc = label
     }
 }
-private [internal] final class Chainr[A, B](var label: Int, _wrap: A => B) extends JumpInstr with DualHandler with Stateful{
+private [internal] final class Chainr[A, B](var label: Int, _wrap: A => B) extends InstrWithLabel with DualHandler with Stateful{
     private [this] val wrap: Any => B = _wrap.asInstanceOf[Any => B]
     private [this] var acc: Any => Any = _
     override def apply(ctx: Context): Unit = {
@@ -190,7 +190,7 @@ private [internal] final class Chainr[A, B](var label: Int, _wrap: A => B) exten
     override def copy: Chainr[A, B] = new Chainr(label, wrap)
 }
 
-private [internal] final class SepEndBy1(var label: Int) extends JumpInstr with DualHandler with Stateful {
+private [internal] final class SepEndBy1(var label: Int) extends InstrWithLabel with DualHandler with Stateful {
     private [this] val acc: ListBuffer[Any] = ListBuffer.empty
     override def apply(ctx: Context): Unit = {
         if (ctx.status eq Good) {
@@ -220,7 +220,7 @@ private [internal] final class SepEndBy1(var label: Int) extends JumpInstr with 
     override def copy: SepEndBy1 = new SepEndBy1(label)
 }
 
-private [internal] final class ManyUntil(var label: Int) extends JumpInstr with Stateful {
+private [internal] final class ManyUntil(var label: Int) extends InstrWithLabel with Stateful {
     private [this] val acc: ListBuffer[Any] = ListBuffer.empty
     override def apply(ctx: Context): Unit = {
         if (ctx.status eq Good) {

--- a/src/main/scala/parsley/internal/instructions/IterativeInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/IterativeInstrs.scala
@@ -1,7 +1,6 @@
 package parsley.internal.instructions
 
 import parsley.internal.deepembedding
-import parsley.internal.errors._
 import Stack.isEmpty
 
 import scala.collection.mutable.ListBuffer

--- a/src/main/scala/parsley/internal/instructions/IterativeInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/IterativeInstrs.scala
@@ -1,6 +1,5 @@
 package parsley.internal.instructions
 
-import parsley.internal.UnsafeOption
 import parsley.internal.deepembedding
 import Stack.isEmpty
 

--- a/src/main/scala/parsley/internal/instructions/IterativeInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/IterativeInstrs.scala
@@ -1,6 +1,7 @@
 package parsley.internal.instructions
 
 import parsley.internal.deepembedding
+import parsley.internal.errors._
 import Stack.isEmpty
 
 import scala.collection.mutable.ListBuffer

--- a/src/main/scala/parsley/internal/instructions/OptInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/OptInstrs.scala
@@ -46,27 +46,26 @@ private [internal] final class JumpGoodAttempt(var label: Int) extends JumpInstr
         }
         else {
             ctx.restoreState()
-            //ctx.addErrorToHints() //TODO: This actually does NOTHING?!
             ctx.restoreHints()
             ctx.status = Good
             ctx.inc()
         }
     }
     // $COVERAGE-OFF$
-    override def toString: String = s"JumpGood'($label)"
+    override def toString: String = s"JumpGoodAttempt($label)"
     // $COVERAGE-ON$
 }
 
 private [internal] final class RecoverWith[A](x: A) extends Instr {
     override def apply(ctx: Context): Unit = {
+        ctx.restoreHints() // This must be before adding the error to hints
         ctx.catchNoConsumed {
             ctx.addErrorToHintsAndPop()
             ctx.pushAndContinue(x)
         }
-        ctx.restoreHints()
     }
     // $COVERAGE-OFF$
-    override def toString: String = s"Recover($x)"
+    override def toString: String = s"RecoverWith($x)"
     // $COVERAGE-ON$
 }
 
@@ -80,14 +79,14 @@ private [internal] final class AlwaysRecoverWith[A](x: A) extends Instr {
         }
         else {
             ctx.restoreState()
+            ctx.restoreHints() // This must be before adding the error to hints
             ctx.addErrorToHintsAndPop()
             ctx.status = Good
-            ctx.restoreHints()
             ctx.pushAndContinue(x)
         }
     }
     // $COVERAGE-OFF$
-    override def toString: String = s"AlwaysRecover($x)"
+    override def toString: String = s"AlwaysRecoverWith($x)"
     // $COVERAGE-ON$
 }
 

--- a/src/main/scala/parsley/internal/instructions/OptInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/OptInstrs.scala
@@ -119,10 +119,7 @@ private [internal] final class JumpTable(prefixes: List[Char], labels: List[Int]
 
     private def addErrors(ctx: Context): Unit = {
         val unexpected = new Some(if (ctx.offset < ctx.inputsz) new Raw(s"${ctx.nextChar}") else EndOfInput)
-        // We need to save hints here so that the jump table does not get a chance to use the hints before it
-        ctx.saveHints(shadow = false)
-        ctx.pushError(TrivialError(ctx.offset, ctx.line, ctx.col, unexpected, errorItems, messages))
-        ctx.restoreHints()
+        ctx.errs = push(ctx.errs, new TrivialError(ctx.offset, ctx.line, ctx.col, unexpected, errorItems, messages))
     }
 
     override def relabel(labels: Array[Int]): Unit = {

--- a/src/main/scala/parsley/internal/instructions/OptInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/OptInstrs.scala
@@ -39,23 +39,31 @@ private [internal] final class SatisfyExchange[A](f: Char => Boolean, x: A, _exp
     // $COVERAGE-ON$
 }
 
-private [internal] final class JumpGoodAttempt(var label: Int) extends InstrWithLabel {
+private [internal] final class JumpGoodAttempt(private [this] var jumpLabel: Int, private [this] var merge: Int) extends Instr {
     override def apply(ctx: Context): Unit = {
         if (ctx.status eq Good) {
             ctx.states = ctx.states.tail
             ctx.handlers = ctx.handlers.tail
             ctx.commitHints()
-            ctx.pc = label
+            ctx.pc = jumpLabel
         }
         else {
             ctx.restoreState()
             ctx.restoreHints()
             ctx.status = Good
+            ctx.pushHandler(merge)
             ctx.inc()
         }
     }
+
+    override def relabel(labels: Array[Int]): this.type = {
+        jumpLabel = labels(jumpLabel)
+        merge = labels(merge)
+        this
+    }
+
     // $COVERAGE-OFF$
-    override def toString: String = s"JumpGoodAttempt($label)"
+    override def toString: String = s"JumpGoodAttempt($jumpLabel, $merge)"
     // $COVERAGE-ON$
 }
 

--- a/src/main/scala/parsley/internal/instructions/OptInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/OptInstrs.scala
@@ -39,7 +39,7 @@ private [internal] final class SatisfyExchange[A](f: Char => Boolean, x: A, _exp
     // $COVERAGE-ON$
 }
 
-private [internal] final class JumpGoodAttempt(var label: Int) extends JumpInstr {
+private [internal] final class JumpGoodAttempt(var label: Int) extends InstrWithLabel {
     override def apply(ctx: Context): Unit = {
         if (ctx.status eq Good) {
             ctx.states = ctx.states.tail
@@ -122,10 +122,11 @@ private [internal] final class JumpTable(prefixes: List[Char], labels: List[Int]
         ctx.errs = push(ctx.errs, new TrivialError(ctx.offset, ctx.line, ctx.col, unexpected, errorItems, messages))
     }
 
-    override def relabel(labels: Array[Int]): Unit = {
+    override def relabel(labels: Array[Int]): this.type = {
         jumpTable.mapValuesInPlace((_, v) => labels(v))
         default = labels(default)
         defaultPreamble = default - 1
+        this
     }
     // $COVERAGE-OFF$
     override def toString: String = s"JumpTable(${jumpTable.map{case (k, v) => k.toChar -> v}.mkString(", ")}, _ -> $default)"

--- a/src/main/scala/parsley/internal/instructions/OptInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/OptInstrs.scala
@@ -140,7 +140,3 @@ private [internal] object CharTokFastPerform {
 private [internal] object StringTokFastPerform {
     def apply(s: String, f: String => Any, expected: UnsafeOption[String]): StringTok = new StringTok(s, f(s), expected)
 }
-
-private [internal] object Exchange {
-    def unapply[A](ex: Exchange[A]): Option[A] = Some(ex.x)
-}

--- a/src/main/scala/parsley/internal/instructions/OptInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/OptInstrs.scala
@@ -6,7 +6,7 @@ import Stack.push
 import scala.annotation.tailrec
 import scala.language.implicitConversions
 import scala.collection.mutable
-import parsley.internal.errors.{TrivialError, ErrorItem, Desc, Raw, EndOfInput, ParseError, MultiExpectedError}, ParseError.NoReason
+import parsley.internal.errors.{ErrorItem, Desc, MultiExpectedError}
 
 private [internal] final class Perform[-A, +B](_f: A => B) extends Instr {
     private [Perform] val f = _f.asInstanceOf[Any => B]
@@ -24,10 +24,6 @@ private [internal] final class Exchange[A](private [Exchange] val x: A) extends 
 }
 
 private [internal] final class SatisfyExchange[A](f: Char => Boolean, x: A, _expected: Option[String]) extends Instr {
-    /*private [this] final val expected: Set[ErrorItem] = _expected match {
-        case Some(ex) => Set(Desc(ex))
-        case None => Set.empty
-    }*/
     private [this] final val expected = _expected.map(Desc)
     override def apply(ctx: Context): Unit = {
         if (ctx.moreInput && f(ctx.nextChar)) {
@@ -129,8 +125,6 @@ private [internal] final class JumpTable(prefixes: List[Char], labels: List[Int]
     }
 
     private def addErrors(ctx: Context): Unit = {
-        //val unexpected = new Some(if (ctx.offset < ctx.inputsz) new Raw(s"${ctx.nextChar}") else EndOfInput)
-        //ctx.errs = push(ctx.errs, new TrivialError(ctx.offset, ctx.line, ctx.col, unexpected, errorItems, ParseError.NoReason))
         ctx.errs = push(ctx.errs, new MultiExpectedError(ctx.offset, ctx.line, ctx.col, errorItems))
         ctx.pushHandler(merge)
     }

--- a/src/main/scala/parsley/internal/instructions/OptInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/OptInstrs.scala
@@ -46,7 +46,7 @@ private [internal] final class JumpGoodAttempt(var label: Int) extends JumpInstr
         }
         else {
             ctx.restoreState()
-            ctx.addErrorToHints()
+            //ctx.addErrorToHints() //TODO: This actually does NOTHING?!
             ctx.restoreHints()
             ctx.status = Good
             ctx.inc()

--- a/src/main/scala/parsley/internal/instructions/OptInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/OptInstrs.scala
@@ -6,6 +6,7 @@ import Stack.push
 import scala.annotation.tailrec
 import scala.language.implicitConversions
 import scala.collection.mutable
+import parsley.internal.errors._
 
 private [internal] final class Perform[-A, +B](_f: A => B) extends Instr {
     private [Perform] val f = _f.asInstanceOf[Any => B]

--- a/src/main/scala/parsley/internal/instructions/PrimitiveInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/PrimitiveInstrs.scala
@@ -2,12 +2,15 @@ package parsley.internal.instructions
 
 import Stack.{isEmpty, push}
 import parsley.internal.ResizableArray
-import parsley.internal.UnsafeOption
 
-private [internal] final class Satisfies(f: Char => Boolean, expected: UnsafeOption[String]) extends Instr {
+private [internal] final class Satisfies(f: Char => Boolean, _expected: Option[String]) extends Instr {
+    val expected: Set[ErrorItem] = _expected match {
+        case Some(ex) => Set(Desc(ex))
+        case None => Set.empty
+    }
     override def apply(ctx: Context): Unit = {
         if (ctx.moreInput && f(ctx.nextChar)) ctx.pushAndContinue(ctx.consumeChar())
-        else ctx.expectedFail(expected)
+        else ctx.expectedFail(expected, reason = None)
     }
     // $COVERAGE-OFF$
     override def toString: String = "Sat(?)"

--- a/src/main/scala/parsley/internal/instructions/PrimitiveInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/PrimitiveInstrs.scala
@@ -2,6 +2,7 @@ package parsley.internal.instructions
 
 import Stack.{isEmpty, push}
 import parsley.internal.ResizableArray
+import parsley.internal.errors._
 
 private [internal] final class Satisfies(f: Char => Boolean, _expected: Option[String]) extends Instr {
     val expected: Set[ErrorItem] = _expected match {

--- a/src/main/scala/parsley/internal/instructions/PrimitiveInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/PrimitiveInstrs.scala
@@ -5,10 +5,6 @@ import parsley.internal.ResizableArray
 import parsley.internal.errors.{ErrorItem, Desc}
 
 private [internal] final class Satisfies(f: Char => Boolean, _expected: Option[String]) extends Instr {
-    /*val expected: Set[ErrorItem] = _expected match {
-        case Some(ex) => Set(Desc(ex))
-        case None => Set.empty
-    }*/
     private [this] final val expected = _expected.map(Desc)
     override def apply(ctx: Context): Unit = {
         if (ctx.moreInput && f(ctx.nextChar)) ctx.pushAndContinue(ctx.consumeChar())

--- a/src/main/scala/parsley/internal/instructions/PrimitiveInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/PrimitiveInstrs.scala
@@ -5,13 +5,14 @@ import parsley.internal.ResizableArray
 import parsley.internal.errors.{ErrorItem, Desc}
 
 private [internal] final class Satisfies(f: Char => Boolean, _expected: Option[String]) extends Instr {
-    val expected: Set[ErrorItem] = _expected match {
+    /*val expected: Set[ErrorItem] = _expected match {
         case Some(ex) => Set(Desc(ex))
         case None => Set.empty
-    }
+    }*/
+    private [this] final val expected = _expected.map(Desc)
     override def apply(ctx: Context): Unit = {
         if (ctx.moreInput && f(ctx.nextChar)) ctx.pushAndContinue(ctx.consumeChar())
-        else ctx.expectedFail(expected, reason = None)
+        else ctx.expectedFail(expected)
     }
     // $COVERAGE-OFF$
     override def toString: String = "Sat(?)"

--- a/src/main/scala/parsley/internal/instructions/PrimitiveInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/PrimitiveInstrs.scala
@@ -87,7 +87,7 @@ private [internal] final class Put(reg: Int) extends Instr {
     // $COVERAGE-ON$
 }
 
-private [parsley] final class CalleeSave(var label: Int, _slots: List[Int]) extends JumpInstr with Stateful {
+private [parsley] final class CalleeSave(var label: Int, _slots: List[Int]) extends InstrWithLabel with Stateful {
     private val saveArray = new Array[AnyRef](_slots.length)
     private val slots = _slots.zipWithIndex
     private var inUse = false

--- a/src/main/scala/parsley/internal/instructions/PrimitiveInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/PrimitiveInstrs.scala
@@ -2,7 +2,7 @@ package parsley.internal.instructions
 
 import Stack.{isEmpty, push}
 import parsley.internal.ResizableArray
-import parsley.internal.errors._
+import parsley.internal.errors.{ErrorItem, Desc}
 
 private [internal] final class Satisfies(f: Char => Boolean, _expected: Option[String]) extends Instr {
     val expected: Set[ErrorItem] = _expected match {

--- a/src/main/scala/parsley/internal/instructions/TokenInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/TokenInstrs.scala
@@ -2,13 +2,14 @@ package parsley.internal.instructions
 
 import parsley.internal.deepembedding.Sign.{SignType, IntType, DoubleType}
 import parsley.token.TokenSet
-import parsley.internal.{Radix, UnsafeOption}
+import parsley.internal.Radix
 
 import scala.annotation.tailrec
 
 private [instructions] abstract class CommentLexer(start: String, end: String, line: String, nested: Boolean) extends Instr {
     protected final val lineAllowed = line.nonEmpty
     protected final val multiAllowed = start.nonEmpty && end.nonEmpty
+    protected final val endOfComment = Set[ErrorItem](Desc("end of comment"))
 
     protected final def singleLineComment(ctx: Context): Unit = {
         ctx.fastUncheckedConsumeChars(line.length)
@@ -52,7 +53,7 @@ private [instructions] abstract class WhiteSpaceLike(start: String, end: String,
         spaces(ctx)
         val startsMulti = ctx.moreInput && ctx.input.startsWith(start, ctx.offset)
         if (startsMulti && multiLineComment(ctx)) multisOnly(ctx)
-        else if (startsMulti) ctx.expectedFail("end of comment")
+        else if (startsMulti) ctx.expectedFail(expected = endOfComment, reason = None)
         else ctx.pushAndContinue(())
     }
 
@@ -65,7 +66,7 @@ private [instructions] abstract class WhiteSpaceLike(start: String, end: String,
         if (ctx.moreInput && ctx.input.startsWith(sharedPrefix, ctx.offset)) {
             val startsMulti = ctx.input.startsWith(factoredStart, ctx.offset + sharedPrefix.length)
             if (startsMulti && multiLineComment(ctx)) singlesAndMultis(ctx)
-            else if (startsMulti) ctx.expectedFail("end of comment")
+            else if (startsMulti) ctx.expectedFail(expected = endOfComment, reason = None)
             else if (ctx.input.startsWith(factoredLine, ctx.offset + sharedPrefix.length)) {
                 singleLineComment(ctx)
                 singlesAndMultis(ctx)
@@ -85,15 +86,17 @@ private [instructions] abstract class WhiteSpaceLike(start: String, end: String,
 }
 
 private [internal] final class TokenComment(start: String, end: String, line: String, nested: Boolean) extends CommentLexer(start, end, line, nested) {
+    private [this] final val comment = Set[ErrorItem](Desc("comment"))
+
     // PRE: one of the comments is supported
     // PRE: Multi-line comments may not prefix single-line, but single-line may prefix multi-line
     override def apply(ctx: Context): Unit = {
         val startsMulti = multiAllowed && ctx.input.startsWith(start, ctx.offset)
         // If neither comment is available we fail
-        if (!ctx.moreInput || (!lineAllowed || !ctx.input.startsWith(line, ctx.offset)) && !startsMulti) ctx.expectedFail("comment")
+        if (!ctx.moreInput || (!lineAllowed || !ctx.input.startsWith(line, ctx.offset)) && !startsMulti) ctx.expectedFail(expected = comment, reason = None)
         // One of the comments must be available
         else if (startsMulti && multiLineComment(ctx)) ctx.pushAndContinue(())
-        else if (startsMulti) ctx.expectedFail("end of comment")
+        else if (startsMulti) ctx.expectedFail(expected = endOfComment, reason = None)
         // It clearly wasn't the multi-line comment, so we are left with single line
         else {
             singleLineComment(ctx)
@@ -122,8 +125,11 @@ private [internal] final class TokenSkipComments(start: String, end: String, lin
 }
 
 private [internal] final class TokenNonSpecific(name: String, illegalName: String)
-                                               (start: TokenSet, letter: TokenSet, illegal: String => Boolean, _expected: UnsafeOption[String]) extends Instr {
-    private val expected = if (_expected == null) name else _expected
+                                               (start: TokenSet, letter: TokenSet, illegal: String => Boolean, _expected: Option[String]) extends Instr {
+    val expected: Set[ErrorItem] = _expected match {
+        case Some(ex) => Set(Desc(ex))
+        case None => Set.empty
+    }
 
     override def apply(ctx: Context): Unit = {
         if (ctx.moreInput && start(ctx.nextChar)) {
@@ -131,13 +137,13 @@ private [internal] final class TokenNonSpecific(name: String, illegalName: Strin
             ctx.offset += 1
             restOfToken(ctx, initialOffset)
         }
-        else ctx.expectedFail(expected)
+        else ctx.expectedFail(expected, reason = None)
     }
 
     private def ensureLegal(ctx: Context, tok: String) = {
         if (illegal(tok)) {
             ctx.offset -= tok.length
-            ctx.unexpectedFail(expected = expected, unexpected = s"$illegalName $tok")
+            ctx.unexpectedFail(expected = expected, unexpected = new Some(new Desc(s"$illegalName $tok")))
         }
         else {
             ctx.col += tok.length
@@ -158,9 +164,9 @@ private [internal] final class TokenNonSpecific(name: String, illegalName: Strin
     // $COVERAGE-ON$
 }
 
-private [instructions] abstract class TokenSpecificAllowTrailing(_specific: String, caseSensitive: Boolean, _expected: UnsafeOption[String]) extends Instr {
-    private final val expected = if (_expected == null) _specific else _expected
-    protected final val expectedEnd = if (_expected == null) "end of " + _specific else _expected
+private [instructions] abstract class TokenSpecificAllowTrailing(_specific: String, caseSensitive: Boolean, _expected: Option[String]) extends Instr {
+    private final val expected = Set[ErrorItem](Desc(_expected.getOrElse(_specific)))
+    protected final val expectedEnd = Set[ErrorItem](Desc(_expected.getOrElse(s"end of ${_specific}")))
     private final val specific = (if (caseSensitive) _specific else _specific.toLowerCase).toCharArray
     private final val strsz = specific.length
     protected def postprocess(ctx: Context, i: Int): Unit
@@ -172,7 +178,7 @@ private [instructions] abstract class TokenSpecificAllowTrailing(_specific: Stri
 
     @tailrec final private def readSpecific(ctx: Context, i: Int, j: Int): Unit = {
         if (j < strsz && readCharCaseHandled(ctx, i) == specific(j)) readSpecific(ctx, i + 1, j + 1)
-        else if (j < strsz) ctx.expectedFail(expected)
+        else if (j < strsz) ctx.expectedFail(expected, reason = None)
         else {
             ctx.saveState()
             ctx.fastUncheckedConsumeChars(strsz)
@@ -182,15 +188,15 @@ private [instructions] abstract class TokenSpecificAllowTrailing(_specific: Stri
 
     final override def apply(ctx: Context): Unit = {
         if (ctx.inputsz >= ctx.offset + strsz) readSpecific(ctx, ctx.offset, 0)
-        else ctx.expectedFail(expected)
+        else ctx.expectedFail(expected, reason = None)
     }
 }
 
-private [internal] final class TokenSpecific(_specific: String, letter: TokenSet, caseSensitive: Boolean, expected: UnsafeOption[String])
+private [internal] final class TokenSpecific(_specific: String, letter: TokenSet, caseSensitive: Boolean, expected: Option[String])
     extends TokenSpecificAllowTrailing(_specific, caseSensitive, expected) {
     override def postprocess(ctx: Context, i: Int): Unit = {
         if (i < ctx.inputsz && letter(ctx.input.charAt(i))) {
-            ctx.expectedFail(expectedEnd)
+            ctx.expectedFail(expectedEnd, reason = None)
             ctx.restoreState()
         }
         else {
@@ -204,7 +210,7 @@ private [internal] final class TokenSpecific(_specific: String, letter: TokenSet
     // $COVERAGE-ON$
 }
 
-private [internal] final class TokenMaxOp(operator: String, _ops: Set[String], expected: UnsafeOption[String])
+private [internal] final class TokenMaxOp(operator: String, _ops: Set[String], expected: Option[String])
     extends TokenSpecificAllowTrailing(operator, true, expected) {
     private val ops = Radix(_ops.collect {
         case op if op.length > operator.length && op.startsWith(operator) => op.substring(operator.length)
@@ -214,7 +220,7 @@ private [internal] final class TokenMaxOp(operator: String, _ops: Set[String], e
         lazy val ops_ = ops.suffixes(ctx.input.charAt(i))
         val possibleOpsRemain = i < ctx.inputsz && ops.nonEmpty
         if (possibleOpsRemain && ops_.contains("")) {
-            ctx.expectedFail(expectedEnd)
+            ctx.expectedFail(expectedEnd, reason = None)
             ctx.restoreState()
         }
         else if (possibleOpsRemain) go(ctx, i + 1, ops_)

--- a/src/main/scala/parsley/internal/instructions/TokenInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/TokenInstrs.scala
@@ -3,6 +3,7 @@ package parsley.internal.instructions
 import parsley.internal.deepembedding.Sign.{SignType, IntType, DoubleType}
 import parsley.token.TokenSet
 import parsley.internal.Radix
+import parsley.internal.errors._
 
 import scala.annotation.tailrec
 

--- a/src/main/scala/parsley/internal/instructions/TokenInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/TokenInstrs.scala
@@ -127,7 +127,6 @@ private [internal] final class TokenSkipComments(start: String, end: String, lin
 
 private [internal] final class TokenNonSpecific(name: String, illegalName: String)
                                                (start: TokenSet, letter: TokenSet, illegal: String => Boolean, _expected: Option[String]) extends Instr {
-    //val expected: Some = Set(Desc(_expected.getOrElse(name)))
     private [this] final val expected = Some(Desc(_expected.getOrElse(name)))
 
     override def apply(ctx: Context): Unit = {

--- a/src/main/scala/parsley/internal/instructions/TokenInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/TokenInstrs.scala
@@ -10,7 +10,7 @@ import scala.annotation.tailrec
 private [instructions] abstract class CommentLexer(start: String, end: String, line: String, nested: Boolean) extends Instr {
     protected final val lineAllowed = line.nonEmpty
     protected final val multiAllowed = start.nonEmpty && end.nonEmpty
-    protected final val endOfComment = Set[ErrorItem](Desc("end of comment"))
+    protected final val endOfComment = Some(Desc("end of comment"))
 
     protected final def singleLineComment(ctx: Context): Unit = {
         ctx.fastUncheckedConsumeChars(line.length)
@@ -54,7 +54,7 @@ private [instructions] abstract class WhiteSpaceLike(start: String, end: String,
         spaces(ctx)
         val startsMulti = ctx.moreInput && ctx.input.startsWith(start, ctx.offset)
         if (startsMulti && multiLineComment(ctx)) multisOnly(ctx)
-        else if (startsMulti) ctx.expectedFail(expected = endOfComment, reason = None)
+        else if (startsMulti) ctx.expectedFail(expected = endOfComment)
         else ctx.pushAndContinue(())
     }
 
@@ -67,7 +67,7 @@ private [instructions] abstract class WhiteSpaceLike(start: String, end: String,
         if (ctx.moreInput && ctx.input.startsWith(sharedPrefix, ctx.offset)) {
             val startsMulti = ctx.input.startsWith(factoredStart, ctx.offset + sharedPrefix.length)
             if (startsMulti && multiLineComment(ctx)) singlesAndMultis(ctx)
-            else if (startsMulti) ctx.expectedFail(expected = endOfComment, reason = None)
+            else if (startsMulti) ctx.expectedFail(expected = endOfComment)
             else if (ctx.input.startsWith(factoredLine, ctx.offset + sharedPrefix.length)) {
                 singleLineComment(ctx)
                 singlesAndMultis(ctx)
@@ -87,17 +87,17 @@ private [instructions] abstract class WhiteSpaceLike(start: String, end: String,
 }
 
 private [internal] final class TokenComment(start: String, end: String, line: String, nested: Boolean) extends CommentLexer(start, end, line, nested) {
-    private [this] final val comment = Set[ErrorItem](Desc("comment"))
+    private [this] final val comment = Some(Desc("comment"))
 
     // PRE: one of the comments is supported
     // PRE: Multi-line comments may not prefix single-line, but single-line may prefix multi-line
     override def apply(ctx: Context): Unit = {
         val startsMulti = multiAllowed && ctx.input.startsWith(start, ctx.offset)
         // If neither comment is available we fail
-        if (!ctx.moreInput || (!lineAllowed || !ctx.input.startsWith(line, ctx.offset)) && !startsMulti) ctx.expectedFail(expected = comment, reason = None)
+        if (!ctx.moreInput || (!lineAllowed || !ctx.input.startsWith(line, ctx.offset)) && !startsMulti) ctx.expectedFail(expected = comment)
         // One of the comments must be available
         else if (startsMulti && multiLineComment(ctx)) ctx.pushAndContinue(())
-        else if (startsMulti) ctx.expectedFail(expected = endOfComment, reason = None)
+        else if (startsMulti) ctx.expectedFail(expected = endOfComment)
         // It clearly wasn't the multi-line comment, so we are left with single line
         else {
             singleLineComment(ctx)
@@ -127,7 +127,8 @@ private [internal] final class TokenSkipComments(start: String, end: String, lin
 
 private [internal] final class TokenNonSpecific(name: String, illegalName: String)
                                                (start: TokenSet, letter: TokenSet, illegal: String => Boolean, _expected: Option[String]) extends Instr {
-    val expected: Set[ErrorItem] = Set(Desc(_expected.getOrElse(name)))
+    //val expected: Some = Set(Desc(_expected.getOrElse(name)))
+    private [this] final val expected = Some(Desc(_expected.getOrElse(name)))
 
     override def apply(ctx: Context): Unit = {
         if (ctx.moreInput && start(ctx.nextChar)) {
@@ -135,13 +136,13 @@ private [internal] final class TokenNonSpecific(name: String, illegalName: Strin
             ctx.offset += 1
             restOfToken(ctx, initialOffset)
         }
-        else ctx.expectedFail(expected, reason = None)
+        else ctx.expectedFail(expected)
     }
 
     private def ensureLegal(ctx: Context, tok: String) = {
         if (illegal(tok)) {
             ctx.offset -= tok.length
-            ctx.unexpectedFail(expected = expected, unexpected = new Some(new Desc(s"$illegalName $tok")))
+            ctx.unexpectedFail(expected = expected, unexpected = new Desc(s"$illegalName $tok"))
         }
         else {
             ctx.col += tok.length
@@ -163,8 +164,8 @@ private [internal] final class TokenNonSpecific(name: String, illegalName: Strin
 }
 
 private [instructions] abstract class TokenSpecificAllowTrailing(_specific: String, caseSensitive: Boolean, _expected: Option[String]) extends Instr {
-    private final val expected = Set[ErrorItem](Desc(_expected.getOrElse(_specific)))
-    protected final val expectedEnd = Set[ErrorItem](Desc(_expected.getOrElse(s"end of ${_specific}")))
+    private final val expected = Some(Desc(_expected.getOrElse(_specific)))
+    protected final val expectedEnd = Some(Desc(_expected.getOrElse(s"end of ${_specific}")))
     private final val specific = (if (caseSensitive) _specific else _specific.toLowerCase).toCharArray
     private final val strsz = specific.length
     protected def postprocess(ctx: Context, i: Int): Unit
@@ -176,7 +177,7 @@ private [instructions] abstract class TokenSpecificAllowTrailing(_specific: Stri
 
     @tailrec final private def readSpecific(ctx: Context, i: Int, j: Int): Unit = {
         if (j < strsz && readCharCaseHandled(ctx, i) == specific(j)) readSpecific(ctx, i + 1, j + 1)
-        else if (j < strsz) ctx.expectedFail(expected, reason = None)
+        else if (j < strsz) ctx.expectedFail(expected)
         else {
             ctx.saveState()
             ctx.fastUncheckedConsumeChars(strsz)
@@ -186,7 +187,7 @@ private [instructions] abstract class TokenSpecificAllowTrailing(_specific: Stri
 
     final override def apply(ctx: Context): Unit = {
         if (ctx.inputsz >= ctx.offset + strsz) readSpecific(ctx, ctx.offset, 0)
-        else ctx.expectedFail(expected, reason = None)
+        else ctx.expectedFail(expected)
     }
 }
 
@@ -194,7 +195,7 @@ private [internal] final class TokenSpecific(_specific: String, letter: TokenSet
     extends TokenSpecificAllowTrailing(_specific, caseSensitive, expected) {
     override def postprocess(ctx: Context, i: Int): Unit = {
         if (i < ctx.inputsz && letter(ctx.input.charAt(i))) {
-            ctx.expectedFail(expectedEnd, reason = None)
+            ctx.expectedFail(expectedEnd)
             ctx.restoreState()
         }
         else {
@@ -218,7 +219,7 @@ private [internal] final class TokenMaxOp(operator: String, _ops: Set[String], e
         lazy val ops_ = ops.suffixes(ctx.input.charAt(i))
         val possibleOpsRemain = i < ctx.inputsz && ops.nonEmpty
         if (possibleOpsRemain && ops_.contains("")) {
-            ctx.expectedFail(expectedEnd, reason = None)
+            ctx.expectedFail(expectedEnd)
             ctx.restoreState()
         }
         else if (possibleOpsRemain) go(ctx, i + 1, ops_)

--- a/src/main/scala/parsley/internal/instructions/TokenInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/TokenInstrs.scala
@@ -3,7 +3,7 @@ package parsley.internal.instructions
 import parsley.internal.deepembedding.Sign.{SignType, IntType, DoubleType}
 import parsley.token.TokenSet
 import parsley.internal.Radix
-import parsley.internal.errors._
+import parsley.internal.errors.{ErrorItem, Desc}
 
 import scala.annotation.tailrec
 

--- a/src/main/scala/parsley/internal/instructions/TokenInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/TokenInstrs.scala
@@ -126,10 +126,7 @@ private [internal] final class TokenSkipComments(start: String, end: String, lin
 
 private [internal] final class TokenNonSpecific(name: String, illegalName: String)
                                                (start: TokenSet, letter: TokenSet, illegal: String => Boolean, _expected: Option[String]) extends Instr {
-    val expected: Set[ErrorItem] = _expected match {
-        case Some(ex) => Set(Desc(ex))
-        case None => Set.empty
-    }
+    val expected: Set[ErrorItem] = Set(Desc(_expected.getOrElse(name)))
 
     override def apply(ctx: Context): Unit = {
         if (ctx.moreInput && start(ctx.nextChar)) {

--- a/src/main/scala/parsley/internal/instructions/TokenNumericInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/TokenNumericInstrs.scala
@@ -2,7 +2,7 @@ package parsley.internal.instructions
 
 import parsley.character
 import parsley.internal.deepembedding.Sign.{SignType, IntType, DoubleType}
-import parsley.internal.errors._
+import parsley.internal.errors.{ErrorItem, Desc}
 
 import scala.annotation.tailrec
 

--- a/src/main/scala/parsley/internal/instructions/TokenNumericInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/TokenNumericInstrs.scala
@@ -2,6 +2,7 @@ package parsley.internal.instructions
 
 import parsley.character
 import parsley.internal.deepembedding.Sign.{SignType, IntType, DoubleType}
+import parsley.internal.errors._
 
 import scala.annotation.tailrec
 

--- a/src/main/scala/parsley/internal/instructions/TokenNumericInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/TokenNumericInstrs.scala
@@ -2,7 +2,6 @@ package parsley.internal.instructions
 
 import parsley.character
 import parsley.internal.deepembedding.Sign.{SignType, IntType, DoubleType}
-import parsley.internal.UnsafeOption
 
 import scala.annotation.tailrec
 
@@ -49,8 +48,8 @@ private [instructions] trait NumericReader {
     protected final val hexadecimal = subDecimal(16, character.isHexDigit)
 }
 
-private [internal] final class TokenNatural(_expected: UnsafeOption[String]) extends Instr with NumericReader {
-    val expected = if (_expected == null) "natural" else _expected
+private [internal] final class TokenNatural(_expected: Option[String]) extends Instr with NumericReader {
+    val expected = Set[ErrorItem](Desc(_expected.getOrElse("natural")))
     override def apply(ctx: Context): Unit = {
         if (ctx.moreInput && ctx.nextChar == '0') {
             ctx.fastUncheckedConsumeChars(1)
@@ -60,14 +59,14 @@ private [internal] final class TokenNatural(_expected: UnsafeOption[String]) ext
                 ctx.fastUncheckedConsumeChars(1)
                 (if (hexa) hexadecimal else octal)(ctx, 0, true) match {
                     case Some(x) => ctx.pushAndContinue(x)
-                    case None => ctx.expectedFail(expected)
+                    case None => ctx.expectedFail(expected, reason = None)
                 }
             }
             else ctx.pushAndContinue(decimal(ctx, 0, true).getOrElse(0))
         }
         else decimal(ctx, 0, true) match {
             case Some(x) => ctx.pushAndContinue(x)
-            case None => ctx.expectedFail(expected)
+            case None => ctx.expectedFail(expected, reason = None)
         }
     }
 
@@ -76,14 +75,14 @@ private [internal] final class TokenNatural(_expected: UnsafeOption[String]) ext
     // $COVERAGE-ON$
 }
 
-private [internal] final class TokenFloat(_expected: UnsafeOption[String]) extends Instr {
-    val expected = if (_expected == null) "unsigned float" else _expected
+private [internal] final class TokenFloat(_expected: Option[String]) extends Instr {
+    val expected = Set[ErrorItem](Desc(_expected.getOrElse("unsigned float")))
     override def apply(ctx: Context): Unit = {
         val initialOffset = ctx.offset
         if (decimal(ctx)) {
             lexFraction(ctx, initialOffset)
         }
-        else ctx.expectedFail(expected)
+        else ctx.expectedFail(expected, reason = None)
     }
 
     @tailrec private final def decimal(ctx: Context, first: Boolean = true): Boolean = {
@@ -106,23 +105,23 @@ private [internal] final class TokenFloat(_expected: UnsafeOption[String]) exten
     private final def attemptCastAndContinue(ctx: Context, initialOffset: Int): Unit = {
         try ctx.pushAndContinue(ctx.input.substring(initialOffset, ctx.offset).toDouble)
         catch {
-            case _: NumberFormatException => ctx.expectedFail(expected)
+            case _: NumberFormatException => ctx.expectedFail(expected, reason = None)
         }
     }
 
     private final def lexExponent(ctx: Context, initialOffset: Int, missingOk: Boolean): Unit = {
         val requireExponent = ctx.moreInput && (ctx.nextChar == 'e' || ctx.nextChar == 'E')
         if (requireExponent && exponent(ctx)) attemptCastAndContinue(ctx, initialOffset)
-        else if (requireExponent) ctx.expectedFail(expected)
+        else if (requireExponent) ctx.expectedFail(expected, reason = None)
         else if (missingOk) attemptCastAndContinue(ctx, initialOffset)
-        else ctx.expectedFail(expected)
+        else ctx.expectedFail(expected, reason = None)
     }
 
     private final def lexFraction(ctx: Context, initialOffset: Int) = {
         if (ctx.moreInput && ctx.nextChar == '.') {
             ctx.fastUncheckedConsumeChars(1)
             if (decimal(ctx)) lexExponent(ctx, initialOffset, missingOk = true)
-            else ctx.expectedFail(expected)
+            else ctx.expectedFail(expected, reason = None)
         }
         else lexExponent(ctx, initialOffset, missingOk = false)
     }

--- a/src/main/scala/parsley/internal/instructions/TokenStringInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/TokenStringInstrs.scala
@@ -1,7 +1,7 @@
 package parsley.internal.instructions
 
 import parsley.token.TokenSet
-import parsley.internal.errors._
+import parsley.internal.errors.{ErrorItem, Desc}
 
 import scala.annotation.tailrec
 

--- a/src/main/scala/parsley/internal/instructions/TokenStringInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/TokenStringInstrs.scala
@@ -1,6 +1,7 @@
 package parsley.internal.instructions
 
 import parsley.token.TokenSet
+import parsley.internal.errors._
 
 import scala.annotation.tailrec
 

--- a/src/main/scala/parsley/internal/instructions/TokenStringInstrs.scala
+++ b/src/main/scala/parsley/internal/instructions/TokenStringInstrs.scala
@@ -1,16 +1,16 @@
 package parsley.internal.instructions
 
-import parsley.internal.UnsafeOption
 import parsley.token.TokenSet
 
 import scala.annotation.tailrec
 
-private [internal] class TokenEscape(_expected: UnsafeOption[String]) extends Instr with NumericReader {
-    private [this] final val expected = if (_expected == null) "escape code" else _expected
+private [internal] class TokenEscape(_expected: Option[String]) extends Instr with NumericReader {
+    private [this] final val expected = Set[ErrorItem](Desc(_expected.getOrElse("escape code")))
+    private [this] final val explain = Some("invalid escape sequence")
     override def apply(ctx: Context): Unit = escape(ctx) match {
         case TokenEscape.EscapeChar(escapeChar) =>ctx.pushAndContinue(escapeChar)
-        case TokenEscape.BadCode => ctx.expectedFailWithExplanation(expected, msg = "invalid escape sequence")
-        case TokenEscape.NoParse => ctx.expectedFail(expected)
+        case TokenEscape.BadCode => ctx.expectedFail(expected, reason = explain)
+        case TokenEscape.NoParse => ctx.expectedFail(expected, reason = None)
     }
 
     private final def consumeAndReturn(ctx: Context, n: Int, c: Char) = {
@@ -143,10 +143,10 @@ private [instructions] object TokenEscape {
 }
 
 private [instructions] sealed trait TokenStringLike extends Instr {
-    protected val expected: UnsafeOption[String]
-    final protected lazy val expectedString = if (expected == null) "string" else expected
-    final protected lazy val expectedEos = if (expected == null) "end of string" else expected
-    final protected lazy val expectedChar = if (expected == null) "string character" else expected
+    protected val expected: Option[String]
+    final protected lazy val expectedString = Set[ErrorItem](Desc(expected.getOrElse("string")))
+    final protected lazy val expectedEos = Set[ErrorItem](Desc(expected.getOrElse("end of string")))
+    final protected lazy val expectedChar = Set[ErrorItem](Desc(expected.getOrElse("string character")))
 
     // All failures must be handled by this function
     protected def handleEscaped(ctx: Context, builder: StringBuilder): Boolean
@@ -162,21 +162,20 @@ private [instructions] sealed trait TokenStringLike extends Instr {
                     builder += c
                     ctx.fastUncheckedConsumeChars(1)
                     restOfString(ctx, builder)
-                case _ => ctx.expectedFail(expectedChar)
+                case _ => ctx.expectedFail(expectedChar, reason = None)
             }
-            else ctx.expectedFail(expectedEos)
+            else ctx.expectedFail(expectedEos, reason = None)
     }
     final override def apply(ctx: Context): Unit = {
         if (ctx.moreInput && ctx.nextChar == '"') {
             ctx.fastUncheckedConsumeChars(1)
             restOfString(ctx, new StringBuilder())
         }
-        else ctx.expectedFail(expectedString)
+        else ctx.expectedFail(expectedString, reason = None)
     }
 }
 
-private [internal] final class TokenRawString(_expected: UnsafeOption[String]) extends TokenStringLike {
-    override val expected = _expected
+private [internal] final class TokenRawString(val expected: Option[String]) extends TokenStringLike {
     override def handleEscaped(ctx: Context, builder: StringBuilder): Boolean = {
         builder += '\\'
         if (ctx.moreInput && ctx.nextChar > '\u0016') {
@@ -185,7 +184,7 @@ private [internal] final class TokenRawString(_expected: UnsafeOption[String]) e
             true
         }
         else {
-            ctx.expectedFail(expectedChar)
+            ctx.expectedFail(expectedChar, reason = None)
             false
         }
     }
@@ -195,15 +194,15 @@ private [internal] final class TokenRawString(_expected: UnsafeOption[String]) e
     // $COVERAGE-ON$
 }
 
-private [internal] final class TokenString(ws: TokenSet, _expected: UnsafeOption[String]) extends TokenEscape(_expected) with TokenStringLike {
-    override val expected = _expected
-    private val expectedEscape = if (_expected == null) "escape code" else _expected
-    private val expectedGap = if (_expected == null) "end of string gap" else _expected
+private [internal] final class TokenString(ws: TokenSet, val expected: Option[String]) extends TokenEscape(expected) with TokenStringLike {
+    private [this] final val expectedEscape = Set[ErrorItem](Desc(expected.getOrElse("escape code")))
+    private [this] final val expectedGap = Set[ErrorItem](Desc(expected.getOrElse("end of string gap")))
+    private [this] final val explain = Some("invalid escape sequence")
 
     private def readGap(ctx: Context): Boolean = {
         val completedGap = ctx.moreInput && ctx.nextChar == '\\'
         if (completedGap) ctx.fastUncheckedConsumeChars(1)
-        else ctx.expectedFail(expectedGap)
+        else ctx.expectedFail(expectedGap, reason = None)
         completedGap
     }
 
@@ -218,10 +217,10 @@ private [internal] final class TokenString(ws: TokenSet, _expected: UnsafeOption
                 builder += c
                 true
             case TokenEscape.BadCode =>
-                ctx.expectedFailWithExplanation(expectedEscape, "invalid escape sequence")
+                ctx.expectedFail(expectedEscape, reason = explain)
                 false
             case TokenEscape.NoParse =>
-                ctx.expectedFail(expectedEscape)
+                ctx.expectedFail(expectedEscape, reason = None)
                 false
         }
     }

--- a/src/main/scala/parsley/internal/instructions/package.scala
+++ b/src/main/scala/parsley/internal/instructions/package.scala
@@ -11,16 +11,19 @@ package object instructions
 
     private [internal] abstract class Instr {
         def apply(ctx: Context): Unit
-        def relabel(labels: Array[Int]): Unit = ()
+        def relabel(labels: Array[Int]): this.type = this
         // Instructions should override this if they have mutable state inside!
         def copy: Instr = this
     }
 
     private [internal] trait Stateful
 
-    private [internal] abstract class JumpInstr extends Instr {
+    private [internal] abstract class InstrWithLabel extends Instr {
         var label: Int
-        override def relabel(labels: Array[Int]): Unit = label = labels(label)
+        override def relabel(labels: Array[Int]): this.type = {
+            label = labels(label)
+            this
+        }
     }
 
     // It's 2018 and Labels are making a come-back, along with 2 pass assembly

--- a/src/main/scala/parsley/internal/package.scala
+++ b/src/main/scala/parsley/internal/package.scala
@@ -1,5 +1,0 @@
-package parsley
-
-package object internal {
-    private [internal] type UnsafeOption[A >: Null] = A
-}

--- a/src/main/scala/parsley/token/BitSet.scala
+++ b/src/main/scala/parsley/token/BitSet.scala
@@ -22,6 +22,7 @@ private [parsley] final class BitSet(gen: Either[Set[Char], Char => Boolean]) ex
         }
         (max, arr)
     }
+    // $COVERAGE-OFF$
     def setup(f: Char => Boolean): (Int, Array[Int]) =
     {
         var i: Int = 0
@@ -42,6 +43,7 @@ private [parsley] final class BitSet(gen: Either[Set[Char], Char => Boolean]) ex
         java.lang.System.arraycopy(bigarr, 0, arr, 0, (max >> 5) + 1)
         (max, arr)
     }
+    // $COVERAGE-ON$
 
     def contains(c: Char): Boolean = c <= max && ((arr(c >> 5) >> (c & 31)) & 1) == 1
     def apply(c: Char): Boolean = contains(c)

--- a/src/main/scala/parsley/token/Impl.scala
+++ b/src/main/scala/parsley/token/Impl.scala
@@ -53,7 +53,10 @@ object CharSet
   * costs
   * @since 2.2.0
   */
+@deprecated("This will be removed in Parsley 3.0, use Predicate instead", "2.8.4")
+// $COVERAGE-OFF$
 object BitGen
 {
     def apply(f: Char => Boolean): Impl = BitSetImpl(new BitSet(Right(f)))
 }
+// $COVERAGE-ON$

--- a/src/main/scala/parsley/token/Lexer.scala
+++ b/src/main/scala/parsley/token/Lexer.scala
@@ -133,7 +133,7 @@ class Lexer(lang: LanguageDef)
         case BitSetImpl(ws) => new Parsley(new deepembedding.StringLiteral(ws))
         case Predicate(ws) => new Parsley(new deepembedding.StringLiteral(ws))
         case NotRequired => new Parsley(new deepembedding.StringLiteral(_ => false))
-        case _ => between('"'.unsafeLabel("string"), '"'.unsafeLabel("end of string"), many(stringChar)) <#> (_.flatten.mkString)
+        case _ => between('"'.unsafeLabel("string"), '"'.unsafeLabel("end of string"), many(stringChar)).map(_.flatten.mkString)
     }
 
     /**This non-lexeme parser parses a string in a raw fashion. The escape characters in the string
@@ -155,9 +155,9 @@ class Lexer(lang: LanguageDef)
     {
         '\\' *> (escapeGap #> None
              <|> escapeEmpty #> None
-             <|> (escapeCode <#> (Some(_))).explain("invalid escape sequence"))
+             <|> (escapeCode.map(Some(_))).explain("invalid escape sequence"))
     }
-    private lazy val stringChar: Parsley[Option[Char]] = ((stringLetter <#> (Some(_))) <|> stringEscape).label("string character")
+    private lazy val stringChar: Parsley[Option[Char]] = ((stringLetter.map(Some(_))) <|> stringEscape).label("string character")
 
     // Numbers
     /**This lexeme parser parses a natural number (a positive whole number). Returns the value of

--- a/src/test/scala/parsley/CombinatorTests.scala
+++ b/src/test/scala/parsley/CombinatorTests.scala
@@ -47,7 +47,7 @@ class CombinatorTests extends ParsleyTest {
     }
 
     "decide" must "succeed for Some" in {
-        decide('a' <#> (Option(_))).runParser("a") should be (Success('a'))
+        decide('a'.map(Option(_))).runParser("a") should be (Success('a'))
     }
     it must "fail for None" in {
         decide(pure(None)).runParser("") shouldBe a [Failure]

--- a/src/test/scala/parsley/ErrorMessageTests.scala
+++ b/src/test/scala/parsley/ErrorMessageTests.scala
@@ -31,6 +31,25 @@ class ErrorMessageTests extends ParsleyTest {
         t.runParser("e") should be {
             Failure("(line 1, column 1):\n  unexpected \"e\"\n  expected \"c\", bee, or hi\n  >e\n  >^")
         }
+        t.runParser("ae") should be {
+            Failure("(line 1, column 2):\n  unexpected \"e\"\n  expected \"c\" or bee\n  >ae\n  > ^")
+        }
+    }
+    it should "not relabel hidden things" in {
+        val s = (optional('a').hide *> optional('b')).label("hi") *> 'c'
+        s.runParser("e") should be {
+            Failure("(line 1, column 1):\n  unexpected \"e\"\n  expected \"c\" or hi\n  >e\n  >^")
+        }
+        s.runParser("ae") should be {
+            Failure("(line 1, column 2):\n  unexpected \"e\"\n  expected \"b\" or \"c\"\n  >ae\n  > ^")
+        }
+        val t = (optional('a').hide *> optional('b').label("bee")).label("hi") *> 'c'
+        t.runParser("e") should be {
+            Failure("(line 1, column 1):\n  unexpected \"e\"\n  expected \"c\" or hi\n  >e\n  >^")
+        }
+        t.runParser("ae") should be {
+            Failure("(line 1, column 2):\n  unexpected \"e\"\n  expected \"c\" or bee\n  >ae\n  > ^")
+        }
     }
 
     "explain" should "provide a message, but only on failure" in {

--- a/src/test/scala/parsley/ErrorMessageTests.scala
+++ b/src/test/scala/parsley/ErrorMessageTests.scala
@@ -33,6 +33,22 @@ class ErrorMessageTests extends ParsleyTest {
         }
     }
 
+    "explain" should "provide a message, but only on failure" in {
+        Parsley.empty.explain("oops!").runParser("") shouldBe Failure("(line 1, column 1):\n  oops!\n  >\n  >^")
+        'a'.explain("requires an a").runParser("b") shouldBe Failure("(line 1, column 1):\n  unexpected \"b\"\n  expected \"a\"\n  requires an a\n  >b\n  >^")
+        ('a'.explain("an a") <|> 'b'.explain("a b")).runParser("c") shouldBe {
+            Failure("(line 1, column 1):\n  unexpected \"c\"\n  expected \"a\" or \"b\"\n  an a\n  a b\n  >c\n  >^")
+        }
+        ('a'.explain("should be absent") *> 'b').runParser("a") shouldBe {
+            Failure("(line 1, column 2):\n  unexpected end of input\n  expected \"b\"\n  >a\n  > ^")
+        }
+    }
+    it should "not have any effect when more input has been consumed since it was added" in {
+        ('a'.explain("should be absent") <|> ('b' *> digit)).runParser("b") shouldBe {
+            Failure("(line 1, column 2):\n  unexpected end of input\n  expected digit\n  >b\n  > ^")
+        }
+    }
+
     "fail" should "yield a raw message" in {
         Parsley.fail("hi").runParser("b") should be {
             Failure("(line 1, column 1):\n  hi\n  >b\n  >^")
@@ -72,7 +88,6 @@ class ErrorMessageTests extends ParsleyTest {
         }
     }
     it should "produce an expected error under influence of ? in <|> chain" in {
-        //println(internal.instructions.pretty(('a' <|> Parsley.empty ? "something, at least").internal.instrs))
         ('a' <|> Parsley.empty ? "something, at least").runParser("b") should be {
             Failure("(line 1, column 1):\n  unexpected \"b\"\n  expected \"a\" or something, at least\n  >b\n  >^")
         }

--- a/src/test/scala/parsley/ExpressionParserTests.scala
+++ b/src/test/scala/parsley/ExpressionParserTests.scala
@@ -198,7 +198,7 @@ class ExpressionParserTests extends ParsleyTest {
         val tok = new token.Lexer(lang)
 
         lazy val ops: List[Ops[Expr, Expr]] = List(
-            Ops(Postfix)(tok.parens(expr </> Constant("")) <#> (e1 => (e2: Expr) => Binary(e2, e1))),
+            Ops(Postfix)(tok.parens(expr </> Constant("")).map(e1 => (e2: Expr) => Binary(e2, e1))),
             Ops(InfixL)('.' #> Binary),
             Ops(InfixR)(".=" #> Binary),
             Ops(InfixR)(',' #> Binary)


### PR DESCRIPTION
Parsley 2.6.0 gave us an entirely new error mechanism, which, as far as I am concerned, generates some beautiful error messages. This innovation came at an _incredibly_ heavy cost. For some preliminary benchmarks, it looks to have slowed down Parsley by over **three** times!

Obviously, the focus during implementation was correctness. At the moment, testing is still done in an ad-hoc manner, so error message unit tests need to be standardised ASAP. Already I've been able to apply some trivial optimisations to the implementation (including removing entirely dead code that was there for no reason?!) and this has brought about a 20% improvement on an example which doesn't even make heavy use of the code! Unfortunately, this doesn't bring us _nearly_ close enough to our original performance so there is a lot of work left to be done.

- [x] Expensive Set operations are still being used in some places, firstly, I want `UnsafeOption` _gone_ from the codebase, it doesn't offer us anything anymore, we should be using `ErrorItem`s directly. Factoring out the `ErrorItem`s into the instructions that generate them provides a healthy speed boost.
- [x] Some of the code paths involving the new stuff are performing redundant work to keep the code easier to work with. These can be rewritten in a more intelligent (and faster) way, without sacrificing abstraction.
    - [x] `JumpTable`
    - [x] `ApplyError`
    - [x] `pushError`
- [x] Some operations are using expensive pattern matches when a type check would do
- [x] Use of case class `apply` is slowing down the overall throughput when constructing errors
- [x] Hints objects are not useful, they should go, just in case they are being instantiated
- [x] The storage of both the valid offset and old hints on the `hintStack` should be done with a bespoke object instead of `(Int, Hints)`, because firstly I suspect that `Int` has to be boxed, and we are using pattern matching to extract it.
- [x] `Set` operations such as union, etc, are common on some code paths. These operations may not even come to fruition if the error that created them is discarded. Making this work lazy will go a long way to improving the non-hard failing code paths. This can be done using a CPS'd defunctionalised language for manipulating sets. This would replace the existing `TrivialError`. We'll want an adapter between the optimised and naive representations, because the naive one _will_ be exposed to the user in Parsley 3. The translation between the two will result in the reduction and evaluation
     - [x] Every individual way of constructing an error message should be defunctionalised
     - [x] Every way of constructing an error which includes hints should be defunctionalised
     - [x] Every way of manipulating errors when they have been made must be defunctionalised
     - [ ] The scheme must be evaluated in a _cheap_ stacksafe way (we can just use `Cont` to start with)
- [x] The error message in `StringTok` is generated lazily. This is a wasted thunk when we could just pass the three ints into the `go` function (which should be marked as inline)
- [x] The offset function array in `StringTok` is no longer needed, since the row and column are not adjusted on failure.
- [x] It may be worth investigating merging the `hintStack` and the `handlerStack`. It seems like they are always used together, even if handlers sometimes do not interact with the hints? This would save a memory allocation per push.
- [x] Some of the instructions involved with `<|>` are now always followed by `PushHandler` for a `MergeErrors` instruction. If these instructions are only ever used for `<|>`, then it would make sense to just merge the logic in, saving on an instruction.
    - [x] `Catch`
    - [x] `JumpTable`
    - [x] `JumpGoodAttempt`

If I see more opportunities for optimisation I'll add them here.