### PR TITLE
Optimised defunc evaluation

### DIFF
--- a/src/main/scala/parsley/Parsley.scala
+++ b/src/main/scala/parsley/Parsley.scala
@@ -62,7 +62,12 @@ final class Parsley[+A] private [parsley] (private [parsley] val internal: deepe
       * @return Either a success with a value of type `A` or a failure with error message
       * @since 2.3.0
       */
-    def parseFromFile(file: File): Result[A] = new Context(internal.threadSafeInstrs, Source.fromFile(file).mkString, Some(file.getName)).runParser()
+    def parseFromFile(file: File): Result[A] = {
+        val src = Source.fromFile(file)
+        val input = src.mkString
+        src.close()
+        new Context(internal.threadSafeInstrs, input, Some(file.getName)).runParser()
+    }
 }
 /** This object contains the core "function-style" combinators as well as the implicit classes which provide
   * the "method-style" combinators. All parsers will likely require something from within! */

--- a/src/main/scala/parsley/internal/deepembedding/GeneralisedEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/GeneralisedEmbedding.scala
@@ -100,8 +100,7 @@ private [deepembedding] abstract class Ternary[A, B, C, D](__first: =>Parsley[A]
         (implicit seen: Set[Parsley[_]], state: LetFinderState, label: Option[String]): Cont[Unit, Unit] = {
         _first.findLets >> _second.findLets >> _third.findLets
     }
-    final override def preprocess[Cont[_, +_]: ContOps, D_ >: D](implicit seen: Set[Parsley[_]], sub: SubMap,
-                                                           label: Option[String]): Cont[Unit, Parsley[D_]] =
+    final override def preprocess[Cont[_, +_]: ContOps, D_ >: D](implicit seen: Set[Parsley[_]], sub: SubMap, label: Option[String]): Cont[Unit, Parsley[D_]] =
         for (first <- _first.optimised; second <- _second.optimised; third <- _third.optimised) yield {
             empty.ready(first, second, third)
         }

--- a/src/main/scala/parsley/internal/errors/Builders.scala
+++ b/src/main/scala/parsley/internal/errors/Builders.scala
@@ -15,18 +15,3 @@ private [internal] abstract class LineBuilder {
     protected def nearestNewlineAfter(off: Int): Int
     protected def segmentBetween(start: Int, end: Int): String
 }
-
-private [internal] abstract class ErrorItemBuilder {
-    final private [errors] def apply(offset: Int): ErrorItem = {
-        if (inRange(offset)) Raw(charAt(offset))
-        else EndOfInput
-    }
-    final private [errors] def apply(offset: Int, size: Int): ErrorItem = {
-        if (inRange(offset)) Raw(substring(offset, size))
-        else EndOfInput
-    }
-
-    protected def inRange(offset: Int): Boolean
-    protected def charAt(offset: Int): Char
-    protected def substring(offset: Int, size: Int): String
-}

--- a/src/main/scala/parsley/internal/errors/DefuncHints.scala
+++ b/src/main/scala/parsley/internal/errors/DefuncHints.scala
@@ -2,6 +2,13 @@ package parsley.internal.errors
 
 import scala.collection.mutable
 
+// TODO: We can optimise the way this works by adding "do-not-compute" indices during evaluation
+// This means that merging hints does not need to make a new buffer and unneeded work can be skipped
+// entirely.
+// TODO: After this system is in place, we need a similar one which tracks what indices of each object
+// have made it into the final value already. If an object is encountered again (i.e. during a merge)
+// we can safely discard the computation of all values which have already appeared in the output: this
+// reduces the potential complexity of the evaluator down from O(2^n) down to O(n)
 private [internal] sealed abstract class DefuncHints {
     private [errors] val size: Int
     private [errors] def nonEmpty: Boolean = size != 0

--- a/src/main/scala/parsley/internal/errors/Errors.scala
+++ b/src/main/scala/parsley/internal/errors/Errors.scala
@@ -9,7 +9,7 @@ private [internal] sealed abstract class ParseError {
     val col: Int
     val line: Int
 
-    def withHints(hints: Iterable[Set[ErrorItem]]): ParseError
+    def withHints(hints: Set[ErrorItem]): ParseError
     def giveReason(reason: String): ParseError
     def pretty(sourceName: Option[String])(implicit helper: LineBuilder): String
 
@@ -38,7 +38,7 @@ private [internal] sealed abstract class ParseError {
 private [internal] case class TrivialError(offset: Int, line: Int, col: Int,
                                            unexpected: Option[ErrorItem], expecteds: Set[ErrorItem], reasons: Set[String])
     extends ParseError {
-    def withHints(hints: Iterable[Set[ErrorItem]]): ParseError = copy(expecteds = hints.foldLeft(expecteds)(_ union _))
+    def withHints(hints: Set[ErrorItem]): ParseError = copy(expecteds = expecteds union hints)
     def giveReason(reason: String): ParseError = copy(reasons = reasons + reason)
 
     def pretty(sourceName: Option[String])(implicit helper: LineBuilder): String = {
@@ -49,7 +49,7 @@ private [internal] case class TrivialError(offset: Int, line: Int, col: Int,
     private def expectedInfo: Option[String] = disjunct(expecteds.map(_.msg).toList).map(es => s"expected $es")
 }
 private [internal] case class FailError(offset: Int, line: Int, col: Int, msgs: Set[String]) extends ParseError {
-    def withHints(hints: Iterable[Set[ErrorItem]]): ParseError = this
+    def withHints(hints: Set[ErrorItem]): ParseError = this
     def giveReason(reason: String): ParseError = this
     def pretty(sourceName: Option[String])(implicit helper: LineBuilder): String = {
         assemble(sourceName, msgs.toList)

--- a/src/main/scala/parsley/internal/machine/Context.scala
+++ b/src/main/scala/parsley/internal/machine/Context.scala
@@ -3,10 +3,9 @@ package parsley.internal.machine
 import instructions.Instr
 import stacks.{ArrayStack, Stack, CallStack, CheckStack, HandlerStack, StateStack, HintStack, ErrorStack}, Stack.StackExt
 import parsley.{Failure, Result, Success}
-import parsley.internal.errors.{
-    TrivialError,
-    ErrorItem, Desc,
-    LineBuilder, ErrorItemBuilder,
+import parsley.internal.errors.{ErrorItem, LineBuilder}
+import parsley.internal.machine.errors.{
+    ErrorItemBuilder,
     DefuncError, ClassicExpectedError, ClassicExpectedErrorWithReason, ClassicFancyError, ClassicUnexpectedError, WithHints,
     DefuncHints, EmptyHints, MergeHints, ReplaceHint, PopHints, AddError
 }

--- a/src/main/scala/parsley/internal/machine/Context.scala
+++ b/src/main/scala/parsley/internal/machine/Context.scala
@@ -118,7 +118,7 @@ private [parsley] final class Context(private [machine] var instrs: Array[Instr]
            |  checks    = ${checkStack.mkString(", ")}
            |  registers = ${regs.zipWithIndex.map{case (r, i) => s"r$i = $r"}.mkString("\n              ")}
            |  errors    = ${errs.mkString(", ")}
-           |  hints     = ($hintsValidOffset, ${hints.toList}):${hintStack.mkString(", ")}
+           |  hints     = ($hintsValidOffset, ${hints.toSet}):${hintStack.mkString(", ")}
            |]""".stripMargin
     }
     // $COVERAGE-ON$

--- a/src/main/scala/parsley/internal/machine/errors/Builders.scala
+++ b/src/main/scala/parsley/internal/machine/errors/Builders.scala
@@ -1,0 +1,18 @@
+package parsley.internal.machine.errors
+
+import parsley.internal.errors.{ErrorItem, Raw, EndOfInput}
+
+private [machine] abstract class ErrorItemBuilder {
+    final private [errors] def apply(offset: Int): ErrorItem = {
+        if (inRange(offset)) Raw(charAt(offset))
+        else EndOfInput
+    }
+    final private [errors] def apply(offset: Int, size: Int): ErrorItem = {
+        if (inRange(offset)) Raw(substring(offset, size))
+        else EndOfInput
+    }
+
+    protected def inRange(offset: Int): Boolean
+    protected def charAt(offset: Int): Char
+    protected def substring(offset: Int, size: Int): String
+}

--- a/src/main/scala/parsley/internal/machine/errors/DefuncError.scala
+++ b/src/main/scala/parsley/internal/machine/errors/DefuncError.scala
@@ -1,4 +1,6 @@
-package parsley.internal.errors
+package parsley.internal.machine.errors
+
+import parsley.internal.errors.{ParseError, TrivialError, FailError, ErrorItem, Desc}
 
 /* This file contains the defunctionalised forms of the error messages.
  * Essentially, whenever an error is created in the machine, it should make use of one of

--- a/src/main/scala/parsley/internal/machine/errors/DefuncError.scala
+++ b/src/main/scala/parsley/internal/machine/errors/DefuncError.scala
@@ -76,7 +76,8 @@ private [internal] case class MultiExpectedError(offset: Int, line: Int, col: In
 }
 
 private [errors] case class MergedErrors private (err1: DefuncError, err2: DefuncError) extends DefuncError {
-    val isTrivialError: Boolean = err1.isTrivialError && err2.isTrivialError
+    // So long as the MergedErrors factory checks for parity and offset checks this is fine
+    val isTrivialError: Boolean = err1.isTrivialError
     val isExpectedEmpty: Boolean = !isTrivialError || err1.isExpectedEmpty && err2.isExpectedEmpty
     // So long as the MergedErrors factory checks that they are equal we can pick arbitrarily
     val offset = err1.offset //Math.max(err1.offset, err2.offset)
@@ -105,7 +106,8 @@ private [internal] object MergedErrors {
 }
 
 private [errors] case class WithHints private (err: DefuncError, hints: DefuncHints) extends DefuncError {
-    val isTrivialError: Boolean = err.isTrivialError
+    // So long as the WithHints factory ensures the err is trivial this is true
+    val isTrivialError: Boolean = true //err.isTrivialError
     // So long as the WithHints factory ensures hints is nonEmpty this is false
     val isExpectedEmpty: Boolean = false //err.isExpectedEmpty && hints.isEmpty
     val offset = err.offset

--- a/src/main/scala/parsley/internal/machine/errors/DefuncError.scala
+++ b/src/main/scala/parsley/internal/machine/errors/DefuncError.scala
@@ -36,12 +36,12 @@ private [machine] sealed abstract class DefuncError {
 
 object BaseError {
     def unapply(err: DefuncError): Option[Option[ErrorItem]] = err match {
-        case ClassicExpectedError(_, _, _, expected) => Some(expected)
-        case ClassicExpectedErrorWithReason(_, _, _, expected, _) => Some(expected)
-        case ClassicUnexpectedError(_, _, _, expected, _) => Some(expected)
-        case EmptyError(_, _, _, expected) => Some(expected)
-        case EmptyErrorWithReason(_, _, _, expected, _) => Some(expected)
-        case StringTokError(_, _, _, expected, _) => Some(expected)
+        case err: ClassicExpectedError => Some(err.expected)
+        case err: ClassicExpectedErrorWithReason => Some(err.expected)
+        case err: ClassicUnexpectedError => Some(err.expected)
+        case err: EmptyError => Some(err.expected)
+        case err: EmptyErrorWithReason => Some(err.expected)
+        case err: StringTokError => Some(err.expected)
         case _ => None
     }
 }

--- a/src/main/scala/parsley/internal/machine/errors/DefuncError.scala
+++ b/src/main/scala/parsley/internal/machine/errors/DefuncError.scala
@@ -112,7 +112,7 @@ private [errors] case class WithHints private (err: DefuncError, hints: DefuncHi
     val isExpectedEmpty: Boolean = false //err.isExpectedEmpty && hints.isEmpty
     val offset = err.offset
     override def asParseError(implicit builder: ErrorItemBuilder): ParseError = {
-        err.asParseError.withHints(hints.toList)
+        err.asParseError.withHints(hints.toSet)
     }
 }
 

--- a/src/main/scala/parsley/internal/machine/errors/DefuncError.scala
+++ b/src/main/scala/parsley/internal/machine/errors/DefuncError.scala
@@ -17,15 +17,15 @@ private [machine] sealed abstract class DefuncError {
     private [machine] def asParseError(implicit builder: ErrorItemBuilder): ParseError
     @tailrec private [errors] final def collectHints(set: mutable.Set[ErrorItem]): Unit = (this: @unchecked) match {
         case BaseError(expected) => for (item <- expected) set += item
-        case MultiExpectedError(_, _, _, expected) => set ++= expected
-        case WithLabel(_, label) => if (label.nonEmpty) set += Desc(label)
-        case WithReason(err, _) => err.collectHints(set)
-        case WithHints(err, hints) =>
-            hints.collect(set, 0)
-            err.collectHints(set)
-        case MergedErrors(err1, err2) =>
-            err1.collectHintsNonTail(set)
-            err2.collectHints(set)
+        case self: MultiExpectedError => set ++= self.expected
+        case self: WithLabel => if (self.label.nonEmpty) set += Desc(self.label)
+        case self: WithReason => self.err.collectHints(set)
+        case self: WithHints =>
+            self.hints.collect(set, 0)
+            self.err.collectHints(set)
+        case self: MergedErrors =>
+            self.err1.collectHintsNonTail(set)
+            self.err2.collectHints(set)
     }
     final private def collectHintsNonTail(set: mutable.Set[ErrorItem]): Unit = collectHints(set)
     protected final def expectedSet(errorItem: Option[ErrorItem]): Set[ErrorItem] = errorItem match {

--- a/src/main/scala/parsley/internal/machine/errors/DefuncError.scala
+++ b/src/main/scala/parsley/internal/machine/errors/DefuncError.scala
@@ -15,7 +15,7 @@ private [machine] sealed abstract class DefuncError {
     val isExpectedEmpty: Boolean
     val offset: Int
     private [machine] def asParseError(implicit builder: ErrorItemBuilder): ParseError
-    @tailrec private [errors] final def collectHints(set: mutable.Set[ErrorItem])(implicit builder: ErrorItemBuilder): Unit = (this: @unchecked) match {
+    @tailrec private [errors] final def collectHints(set: mutable.Set[ErrorItem]): Unit = (this: @unchecked) match {
         case BaseError(expected) => for (item <- expected) set += item
         case MultiExpectedError(_, _, _, expected) => set ++= expected
         case WithLabel(_, label) => if (label.nonEmpty) set += Desc(label)
@@ -27,7 +27,7 @@ private [machine] sealed abstract class DefuncError {
             err1.collectHintsNonTail(set)
             err2.collectHints(set)
     }
-    final private def collectHintsNonTail(set: mutable.Set[ErrorItem])(implicit builder: ErrorItemBuilder): Unit = collectHints(set)
+    final private def collectHintsNonTail(set: mutable.Set[ErrorItem]): Unit = collectHints(set)
     protected final def expectedSet(errorItem: Option[ErrorItem]): Set[ErrorItem] = errorItem match {
         case None => ParseError.NoItems
         case Some(item) => Set(item)

--- a/src/main/scala/parsley/internal/machine/errors/DefuncHints.scala
+++ b/src/main/scala/parsley/internal/machine/errors/DefuncHints.scala
@@ -15,7 +15,10 @@ private [machine] sealed abstract class DefuncHints {
     private [errors] val size: Int
     private [errors] def nonEmpty: Boolean = size != 0
     private [errors] def isEmpty: Boolean = size == 0
-    private [machine] def toList(implicit builder: ErrorItemBuilder): List[Set[ErrorItem]] = {
+    private [machine] def toSet(implicit builder: ErrorItemBuilder): Set[ErrorItem] = {
+        toList.foldLeft(Set.empty[ErrorItem])(_ union _)
+    }
+    private [errors] def toList(implicit builder: ErrorItemBuilder): List[Set[ErrorItem]] = {
         val buff = mutable.ListBuffer.empty[Set[ErrorItem]]
         collect(buff)
         buff.toList

--- a/src/main/scala/parsley/internal/machine/errors/DefuncHints.scala
+++ b/src/main/scala/parsley/internal/machine/errors/DefuncHints.scala
@@ -1,6 +1,6 @@
 package parsley.internal.machine.errors
 
-import parsley.internal.errors.{TrivialError, ErrorItem, Desc}
+import parsley.internal.errors.{ErrorItem, Desc}
 
 import scala.collection.mutable
 import scala.annotation.tailrec

--- a/src/main/scala/parsley/internal/machine/errors/DefuncHints.scala
+++ b/src/main/scala/parsley/internal/machine/errors/DefuncHints.scala
@@ -3,6 +3,7 @@ package parsley.internal.machine.errors
 import parsley.internal.errors.{TrivialError, ErrorItem, Desc}
 
 import scala.collection.mutable
+import scala.annotation.tailrec
 
 // TODO: After this system is in place, we need a similar one which tracks what indices of each object
 // have made it into the final value already. If an object is encountered again (i.e. during a merge)
@@ -18,6 +19,7 @@ private [machine] sealed abstract class DefuncHints {
         set.toSet
     }
     private [errors] def collect(set: mutable.Set[ErrorItem], skipNext: Int)(implicit builder: ErrorItemBuilder): Int
+    //@tailrec final private [errors] def collect(set: mutable.Set[ErrorItem], skipNext: Int)(implicit builder: ErrorItemBuilder): Int = this match
 }
 
 private [machine] case object EmptyHints extends DefuncHints {

--- a/src/main/scala/parsley/internal/machine/errors/DefuncHints.scala
+++ b/src/main/scala/parsley/internal/machine/errors/DefuncHints.scala
@@ -60,10 +60,7 @@ private [errors] case class MergeHints private (oldHints: DefuncHints, newHints:
     val size = oldHints.size + newHints.size
     def collect(buff: mutable.ListBuffer[Set[ErrorItem]], skipNext: Int)(implicit builder: ErrorItemBuilder): Int = {
         val skipNext_ = oldHints.collect(buff, skipNext)
-        val newBuff = mutable.ListBuffer.empty[Set[ErrorItem]]
-        val skipNext__ = newHints.collect(newBuff, skipNext_)
-        buff ++= newBuff.toList
-        skipNext__
+        newHints.collect(buff, skipNext_)
     }
 }
 private [machine] object MergeHints {

--- a/src/main/scala/parsley/internal/machine/errors/DefuncHints.scala
+++ b/src/main/scala/parsley/internal/machine/errors/DefuncHints.scala
@@ -14,7 +14,7 @@ private [machine] sealed abstract class DefuncHints {
     private [errors] def isEmpty: Boolean = size == 0
     private [machine] def toSet(implicit builder: ErrorItemBuilder): Set[ErrorItem] = {
         val set = mutable.Set.empty[ErrorItem]
-        assert(collect(set, 0) == 0)
+        collect(set, 0)
         set.toSet
     }
     private [errors] def collect(set: mutable.Set[ErrorItem], skipNext: Int)(implicit builder: ErrorItemBuilder): Int
@@ -68,8 +68,7 @@ private [machine] case class AddError(hints: DefuncHints, err: DefuncError) exte
     def collect(set: mutable.Set[ErrorItem], skipNext: Int)(implicit builder: ErrorItemBuilder): Int = {
         hints.collect(set, skipNext) match {
             case 0 =>
-                val TrivialError(_, _, _, _, es, _) = err.asParseError
-                set ++= es
+                err.collectHints(set)
                 0
             case skipNext => skipNext - 1
         }

--- a/src/main/scala/parsley/internal/machine/errors/DefuncHints.scala
+++ b/src/main/scala/parsley/internal/machine/errors/DefuncHints.scala
@@ -59,7 +59,9 @@ private [machine] object ReplaceHint {
 private [errors] case class MergeHints private (oldHints: DefuncHints, newHints: DefuncHints) extends DefuncHints {
     val size = oldHints.size + newHints.size
     def collect(buff: mutable.ListBuffer[Set[ErrorItem]], skipNext: Int)(implicit builder: ErrorItemBuilder): Int = {
-        val skipNext_ = oldHints.collect(buff, skipNext)
+        val skipNext_ =
+            if (oldHints.size < skipNext) skipNext - oldHints.size
+            else oldHints.collect(buff, skipNext)
         newHints.collect(buff, skipNext_)
     }
 }

--- a/src/main/scala/parsley/internal/machine/errors/DefuncHints.scala
+++ b/src/main/scala/parsley/internal/machine/errors/DefuncHints.scala
@@ -5,12 +5,8 @@ import parsley.internal.errors.{ErrorItem, Desc}
 import scala.collection.mutable
 import scala.annotation.tailrec
 
-// TODO: After this system is in place, we need a similar one which tracks what indices of each object
-// have made it into the final value already. If an object is encountered again (i.e. during a merge)
-// we can safely discard the computation of all values which have already appeared in the output: this
-// reduces the potential complexity of the evaluator down from O(2^n) down to O(n)
-private [machine] sealed abstract class DefuncHints {
-    private [errors] val size: Int
+private [machine] sealed abstract class DefuncHints(private [errors] val size: Int) {
+    private var incorporatedAfter: Int = size
     private [errors] def nonEmpty: Boolean = size != 0
     private [errors] def isEmpty: Boolean = size == 0
     private [machine] def toSet: Set[ErrorItem] = {
@@ -18,46 +14,42 @@ private [machine] sealed abstract class DefuncHints {
         collect(set, 0)
         set.toSet
     }
-    @tailrec final private [errors] def collect(set: mutable.Set[ErrorItem], skipNext: Int): Unit = this match {
-        case EmptyHints =>
-        case self: PopHints => self.hints.collect(set, skipNext + 1)
-        case self: ReplaceHint =>
-            if (skipNext > 0) self.hints.collect(set, skipNext)
-            else self.hints.collect(set += Desc(self.label), skipNext+1)
-        case self: MergeHints =>
-            if (self.oldHints.size < skipNext) self.newHints.collect(set, skipNext - self.oldHints.size)
-            else {
-                self.oldHints.collectNonTail(set, skipNext)
-                self.newHints.collect(set, 0)
-            }
-        case self: AddError =>
-            if (skipNext - self.hints.size <= 0) self.err.collectHints(set)
-            self.hints.collect(set, skipNext)
+    @tailrec final private [errors] def collect(set: mutable.Set[ErrorItem], skipNext: Int): Unit = if (skipNext < incorporatedAfter) {
+        // This error only needs to provide the first `skipNext` elements if we encounter it again
+        incorporatedAfter = skipNext
+        this match {
+            case EmptyHints =>
+            case self: PopHints => self.hints.collect(set, skipNext + 1)
+            case self: ReplaceHint =>
+                if (skipNext > 0) self.hints.collect(set, skipNext)
+                else self.hints.collect(set += Desc(self.label), skipNext+1)
+            case self: MergeHints =>
+                if (self.oldHints.size < skipNext) self.newHints.collect(set, skipNext - self.oldHints.size)
+                else {
+                    self.oldHints.collectNonTail(set, skipNext)
+                    self.newHints.collect(set, 0)
+                }
+            case self: AddError =>
+                if (skipNext - self.hints.size <= 0) self.err.collectHints(set)
+                self.hints.collect(set, skipNext)
+        }
     }
     final private def collectNonTail(set: mutable.Set[ErrorItem], skipNext: Int): Unit = collect(set, skipNext)
 }
 
-private [machine] case object EmptyHints extends DefuncHints {
-    val size = 0
-}
+private [machine] case object EmptyHints extends DefuncHints(size = 0)
 
-private [machine] case class PopHints private (hints: DefuncHints) extends DefuncHints {
-    val size = hints.size - 1
-}
+private [machine] case class PopHints private (hints: DefuncHints) extends DefuncHints(size = hints.size - 1)
 private [machine] object PopHints {
     def apply(hints: DefuncHints): DefuncHints = if (hints.size > 1) new PopHints(hints) else EmptyHints
 }
 
-private [errors] case class ReplaceHint private (label: String, hints: DefuncHints) extends DefuncHints {
-    val size = hints.size
-}
+private [errors] case class ReplaceHint private (label: String, hints: DefuncHints) extends DefuncHints(size = hints.size)
 private [machine] object ReplaceHint {
     def apply(label: String, hints: DefuncHints): DefuncHints = if (hints.nonEmpty) new ReplaceHint(label, hints) else hints
 }
 
-private [errors] case class MergeHints private (oldHints: DefuncHints, newHints: DefuncHints) extends DefuncHints {
-    val size = oldHints.size + newHints.size
-}
+private [errors] case class MergeHints private (oldHints: DefuncHints, newHints: DefuncHints) extends DefuncHints(size = oldHints.size + newHints.size)
 private [machine] object MergeHints {
     def apply(oldHints: DefuncHints, newHints: DefuncHints): DefuncHints = {
         if (oldHints.isEmpty) newHints
@@ -66,6 +58,4 @@ private [machine] object MergeHints {
     }
 }
 
-private [machine] case class AddError(hints: DefuncHints, err: DefuncError) extends DefuncHints {
-    val size = hints.size + 1
-}
+private [machine] case class AddError(hints: DefuncHints, err: DefuncError) extends DefuncHints(size = hints.size + 1)

--- a/src/main/scala/parsley/internal/machine/errors/DefuncHints.scala
+++ b/src/main/scala/parsley/internal/machine/errors/DefuncHints.scala
@@ -13,12 +13,12 @@ private [machine] sealed abstract class DefuncHints {
     private [errors] val size: Int
     private [errors] def nonEmpty: Boolean = size != 0
     private [errors] def isEmpty: Boolean = size == 0
-    private [machine] def toSet(implicit builder: ErrorItemBuilder): Set[ErrorItem] = {
+    private [machine] def toSet: Set[ErrorItem] = {
         val set = mutable.Set.empty[ErrorItem]
         collect(set, 0)
         set.toSet
     }
-    @tailrec final private [errors] def collect(set: mutable.Set[ErrorItem], skipNext: Int)(implicit builder: ErrorItemBuilder): Unit = this match {
+    @tailrec final private [errors] def collect(set: mutable.Set[ErrorItem], skipNext: Int): Unit = this match {
         case EmptyHints =>
         case self: PopHints => self.hints.collect(set, skipNext + 1)
         case self: ReplaceHint =>
@@ -34,7 +34,7 @@ private [machine] sealed abstract class DefuncHints {
             if (skipNext - self.hints.size <= 0) self.err.collectHints(set)
             self.hints.collect(set, skipNext)
     }
-    final private def collectNonTail(set: mutable.Set[ErrorItem], skipNext: Int)(implicit builder: ErrorItemBuilder): Unit = collect(set, skipNext)
+    final private def collectNonTail(set: mutable.Set[ErrorItem], skipNext: Int): Unit = collect(set, skipNext)
 }
 
 private [machine] case object EmptyHints extends DefuncHints {

--- a/src/main/scala/parsley/internal/machine/errors/DefuncHints.scala
+++ b/src/main/scala/parsley/internal/machine/errors/DefuncHints.scala
@@ -4,9 +4,6 @@ import parsley.internal.errors.{TrivialError, ErrorItem, Desc}
 
 import scala.collection.mutable
 
-// TODO: We can optimise the way this works by adding "do-not-compute" indices during evaluation
-// This means that merging hints does not need to make a new buffer and unneeded work can be skipped
-// entirely.
 // TODO: After this system is in place, we need a similar one which tracks what indices of each object
 // have made it into the final value already. If an object is encountered again (i.e. during a merge)
 // we can safely discard the computation of all values which have already appeared in the output: this
@@ -16,26 +13,22 @@ private [machine] sealed abstract class DefuncHints {
     private [errors] def nonEmpty: Boolean = size != 0
     private [errors] def isEmpty: Boolean = size == 0
     private [machine] def toSet(implicit builder: ErrorItemBuilder): Set[ErrorItem] = {
-        toList.foldLeft(Set.empty[ErrorItem])(_ union _)
+        val set = mutable.Set.empty[ErrorItem]
+        assert(collect(set, 0) == 0)
+        set.toSet
     }
-    private [errors] def toList(implicit builder: ErrorItemBuilder): List[Set[ErrorItem]] = {
-        val buff = mutable.ListBuffer.empty[Set[ErrorItem]]
-        val skipNext = collect(buff, 0)
-        assert(skipNext == 0)
-        buff.toList
-    }
-    private [errors] def collect(buff: mutable.ListBuffer[Set[ErrorItem]], skipNext: Int)(implicit builder: ErrorItemBuilder): Int
+    private [errors] def collect(set: mutable.Set[ErrorItem], skipNext: Int)(implicit builder: ErrorItemBuilder): Int
 }
 
 private [machine] case object EmptyHints extends DefuncHints {
     val size = 0
-    def collect(buff: mutable.ListBuffer[Set[ErrorItem]], skipNext: Int)(implicit builder: ErrorItemBuilder): Int = skipNext
+    def collect(set: mutable.Set[ErrorItem], skipNext: Int)(implicit builder: ErrorItemBuilder): Int = skipNext
 }
 
 private [machine] case class PopHints private (hints: DefuncHints) extends DefuncHints {
     val size = hints.size - 1
-    def collect(buff: mutable.ListBuffer[Set[ErrorItem]], skipNext: Int)(implicit builder: ErrorItemBuilder): Int = {
-        hints.collect(buff, skipNext + 1)
+    def collect(set: mutable.Set[ErrorItem], skipNext: Int)(implicit builder: ErrorItemBuilder): Int = {
+        hints.collect(set, skipNext + 1)
     }
 }
 private [machine] object PopHints {
@@ -44,12 +37,9 @@ private [machine] object PopHints {
 
 private [errors] case class ReplaceHint private (label: String, hints: DefuncHints) extends DefuncHints {
     val size = hints.size
-    def collect(buff: mutable.ListBuffer[Set[ErrorItem]], skipNext: Int)(implicit builder: ErrorItemBuilder): Int = {
-        if (skipNext > 0) hints.collect(buff, skipNext)
-        else {
-            buff += Set(Desc(label))
-            hints.collect(buff, skipNext+1)
-        }
+    def collect(set: mutable.Set[ErrorItem], skipNext: Int)(implicit builder: ErrorItemBuilder): Int = {
+        if (skipNext > 0) hints.collect(set, skipNext)
+        else hints.collect(set += Desc(label), skipNext+1)
     }
 }
 private [machine] object ReplaceHint {
@@ -58,11 +48,11 @@ private [machine] object ReplaceHint {
 
 private [errors] case class MergeHints private (oldHints: DefuncHints, newHints: DefuncHints) extends DefuncHints {
     val size = oldHints.size + newHints.size
-    def collect(buff: mutable.ListBuffer[Set[ErrorItem]], skipNext: Int)(implicit builder: ErrorItemBuilder): Int = {
+    def collect(set: mutable.Set[ErrorItem], skipNext: Int)(implicit builder: ErrorItemBuilder): Int = {
         val skipNext_ =
             if (oldHints.size < skipNext) skipNext - oldHints.size
-            else oldHints.collect(buff, skipNext)
-        newHints.collect(buff, skipNext_)
+            else oldHints.collect(set, skipNext)
+        newHints.collect(set, skipNext_)
     }
 }
 private [machine] object MergeHints {
@@ -75,13 +65,13 @@ private [machine] object MergeHints {
 
 private [machine] case class AddError(hints: DefuncHints, err: DefuncError) extends DefuncHints {
     val size = hints.size + 1
-    def collect(buff: mutable.ListBuffer[Set[ErrorItem]], skipNext: Int)(implicit builder: ErrorItemBuilder): Int = {
-        val skipNext_ = hints.collect(buff, skipNext)
-        if (skipNext_ == 0) {
-            val TrivialError(_, _, _, _, es, _) = err.asParseError
-            buff += es
-            0
+    def collect(set: mutable.Set[ErrorItem], skipNext: Int)(implicit builder: ErrorItemBuilder): Int = {
+        hints.collect(set, skipNext) match {
+            case 0 =>
+                val TrivialError(_, _, _, _, es, _) = err.asParseError
+                set ++= es
+                0
+            case skipNext => skipNext - 1
         }
-        else skipNext_ - 1
     }
 }

--- a/src/main/scala/parsley/internal/machine/instructions/CoreInstrs.scala
+++ b/src/main/scala/parsley/internal/machine/instructions/CoreInstrs.scala
@@ -3,7 +3,8 @@ package parsley.internal.machine.instructions
 import parsley.internal.machine.{Context, Good, Recover, Failed}
 import parsley.internal.ResizableArray
 import parsley.internal.deepembedding.Parsley
-import parsley.internal.errors.{ErrorItem, Desc, ParseError, TrivialError, EmptyError}, ParseError.NoReason
+import parsley.internal.errors.{ErrorItem, Desc}
+import parsley.internal.machine.errors.EmptyError
 
 import scala.annotation.tailrec
 

--- a/src/main/scala/parsley/internal/machine/instructions/ErrorInstrs.scala
+++ b/src/main/scala/parsley/internal/machine/instructions/ErrorInstrs.scala
@@ -3,7 +3,8 @@ package parsley.internal.machine.instructions
 import parsley.internal.machine.{Context, Good}
 import parsley.internal.ResizableArray
 
-import parsley.internal.errors.{ErrorItem, Desc, TrivialError, FailError, WithReason, MergedErrors, WithLabel}
+import parsley.internal.errors.{ErrorItem, Desc}
+import parsley.internal.machine.errors.{WithReason, MergedErrors, WithLabel}
 
 private [internal] final class ApplyError(label: String) extends Instr {
     val isHide: Boolean = label.isEmpty

--- a/src/main/scala/parsley/internal/machine/instructions/IntrinsicInstrs.scala
+++ b/src/main/scala/parsley/internal/machine/instructions/IntrinsicInstrs.scala
@@ -1,7 +1,8 @@
 package parsley.internal.machine.instructions
 
+import parsley.internal.errors.{Desc, Raw}
 import parsley.internal.machine.{Context, Good}
-import parsley.internal.errors.{Desc, Raw, EmptyError, EmptyErrorWithReason, StringTokError}
+import parsley.internal.machine.errors.{EmptyError, EmptyErrorWithReason, StringTokError}
 
 import scala.annotation.tailrec
 

--- a/src/main/scala/parsley/internal/machine/instructions/OptInstrs.scala
+++ b/src/main/scala/parsley/internal/machine/instructions/OptInstrs.scala
@@ -6,7 +6,8 @@ import parsley.internal.machine.{Context, Good}
 import scala.annotation.tailrec
 import scala.language.implicitConversions
 import scala.collection.mutable
-import parsley.internal.errors.{ErrorItem, Desc, MultiExpectedError}
+import parsley.internal.errors.{ErrorItem, Desc}
+import parsley.internal.machine.errors.MultiExpectedError
 import parsley.internal.machine.stacks.ErrorStack
 
 private [internal] final class Perform[-A, +B](_f: A => B) extends Instr {

--- a/src/main/scala/parsley/internal/machine/stacks/ErrorStack.scala
+++ b/src/main/scala/parsley/internal/machine/stacks/ErrorStack.scala
@@ -1,6 +1,6 @@
 package parsley.internal.machine.stacks
 
-import parsley.internal.errors.DefuncError
+import parsley.internal.machine.errors.DefuncError
 
 private [machine] final class ErrorStack(var error: DefuncError, val tail: ErrorStack)
 private [machine] object ErrorStack extends Stack[ErrorStack] {

--- a/src/main/scala/parsley/internal/machine/stacks/HintStack.scala
+++ b/src/main/scala/parsley/internal/machine/stacks/HintStack.scala
@@ -1,6 +1,6 @@
 package parsley.internal.machine.stacks
 
-import parsley.internal.errors.DefuncHints
+import parsley.internal.machine.errors.DefuncHints
 
 private [machine] final class HintStack(val hints: DefuncHints, val validOffset: Int, val tail: HintStack)
 private [machine] object HintStack extends Stack[HintStack] {

--- a/src/test/scala/parsley/internal/machine/errors/DefuncErrorTests.scala
+++ b/src/test/scala/parsley/internal/machine/errors/DefuncErrorTests.scala
@@ -2,10 +2,133 @@ package parsley.internal.machine.errors
 
 import parsley.ParsleyTest
 
+import parsley.internal.errors.{TrivialError, FailError, Raw, Desc, EndOfInput}
 import scala.language.implicitConversions
 
 import MockedBuilders.mockedErrorItemBuilder
+import scala.annotation.nowarn
 
+@nowarn("msg=deprecated")
 class DefuncErrorTests extends ParsleyTest {
-    //TODO: Add tests to verify the defunc behaviours
+    "ClassicExpectedError" should "evaluate to TrivialError" in {
+        val err = ClassicExpectedError(0, 0, 0, None)
+        err should be a 'trivialError
+        err.asParseError shouldBe a [TrivialError]
+    }
+
+    "ClassicExpectedErrorWithReason" should "evaluate to TrivialError" in {
+        val err = ClassicExpectedErrorWithReason(0, 0, 0, None, "")
+        err should be a 'trivialError
+        err.asParseError shouldBe a [TrivialError]
+    }
+
+    "ClassicUnexpectedError" should "evaluate to TrivialError" in {
+        val err = ClassicUnexpectedError(0, 0, 0, None, EndOfInput)
+        err should be a 'trivialError
+        err.asParseError shouldBe a [TrivialError]
+    }
+
+    "ClassicFancyError" should "evaluate to FancyError" in {
+        val err = ClassicFancyError(0, 0, 0, "")
+        err shouldNot be a 'trivialError
+        err.asParseError shouldBe a [FailError]
+    }
+
+    "EmptyError" should "evaluate to TrivialError" in {
+        val err = EmptyError(0, 0, 0, None)
+        err should be a 'trivialError
+        err.asParseError shouldBe a [TrivialError]
+    }
+
+    "StringTokError" should "evaluate to TrivialError" in {
+        val err = StringTokError(0, 0, 0, None, 1)
+        err should be a 'trivialError
+        err.asParseError shouldBe a [TrivialError]
+    }
+
+    "EmptyErrorWithReason" should "evaluate to TrivialError" in {
+        val err = EmptyErrorWithReason(0, 0, 0, None, "")
+        err should be a 'trivialError
+        err.asParseError shouldBe a [TrivialError]
+    }
+
+    "MultiExpectedError" should "evaluate to TrivialError" in {
+        val err = MultiExpectedError(0, 0, 0, Set.empty)
+        err should be a 'trivialError
+        err.asParseError shouldBe a [TrivialError]
+    }
+
+    "MergedErrors" should "be trivial if both children are" in {
+        val err = MergedErrors(EmptyError(0, 0, 0, None), MultiExpectedError(0, 0, 0, Set.empty))
+        err should be a 'trivialError
+        err.asParseError shouldBe a [TrivialError]
+    }
+    they should "be a trivial error if one trivial child is further than the other fancy child" in {
+        val err1 = MergedErrors(EmptyError(1, 0, 0, None), ClassicFancyError(0, 0, 0, ""))
+        err1 should be a 'trivialError
+        err1.asParseError shouldBe a [TrivialError]
+
+        val err2 = MergedErrors(ClassicFancyError(0, 0, 0, ""), EmptyError(1, 0, 0, None))
+        err2 should be a 'trivialError
+        err2.asParseError shouldBe a [TrivialError]
+    }
+    they should "be a fancy error in any other case" in {
+        val err1 = MergedErrors(EmptyError(0, 0, 0, None), ClassicFancyError(0, 0, 0, ""))
+        err1 shouldNot be a 'trivialError
+        err1.asParseError shouldBe a [FailError]
+
+        val err2 = MergedErrors(ClassicFancyError(0, 0, 0, ""), EmptyError(0, 0, 0, None))
+        err2 shouldNot be a 'trivialError
+        err2.asParseError shouldBe a [FailError]
+
+        val err3 = MergedErrors(EmptyError(0, 0, 0, None), ClassicFancyError(1, 0, 0, ""))
+        err3 shouldNot be a 'trivialError
+        err3.asParseError shouldBe a [FailError]
+
+        val err4 = MergedErrors(ClassicFancyError(1, 0, 0, ""), EmptyError(0, 0, 0, None))
+        err4 shouldNot be a 'trivialError
+        err4.asParseError shouldBe a [FailError]
+
+        val err5 = MergedErrors(ClassicFancyError(0, 0, 0, ""), ClassicFancyError(0, 0, 0, ""))
+        err5 shouldNot be a 'trivialError
+        err5.asParseError shouldBe a [FailError]
+
+        val err6 = MergedErrors(ClassicFancyError(1, 0, 0, ""), ClassicFancyError(0, 0, 0, ""))
+        err6 shouldNot be a 'trivialError
+        err6.asParseError shouldBe a [FailError]
+    }
+
+    "WithHints" should "be trivial if its child is" in {
+        val err = WithHints(ClassicExpectedError(0, 0, 0, None), EmptyHints)
+        err should be a 'trivialError
+        err.asParseError shouldBe a [TrivialError]
+    }
+    it should "support fancy errors as not trivial" in {
+        val err = WithHints(ClassicFancyError(0, 0, 0, ""), EmptyHints)
+        err shouldNot be a 'trivialError
+        err.asParseError shouldBe a [FailError]
+    }
+
+    "WithReason" should "be trivial if its child is" in {
+        val err = WithReason(ClassicExpectedError(0, 0, 0, None), "")
+        err should be a 'trivialError
+        err.asParseError shouldBe a [TrivialError]
+    }
+    it should "support fancy errors as not trivial" in {
+        val err = WithReason(ClassicFancyError(0, 0, 0, ""), "")
+        err shouldNot be a 'trivialError
+        err.asParseError shouldBe a [FailError]
+    }
+
+    "WithLabel" should "be trivial if its child is" in {
+        val err = WithLabel(ClassicExpectedError(0, 0, 0, None), "")
+        err should be a 'trivialError
+        err.asParseError shouldBe a [TrivialError]
+    }
+    it should "support fancy errors as not trivial" in {
+        val err = WithLabel(ClassicFancyError(0, 0, 0, ""), "")
+        err shouldNot be a 'trivialError
+        err.asParseError shouldBe a [FailError]
+    }
+
 }

--- a/src/test/scala/parsley/internal/machine/errors/DefuncErrorTests.scala
+++ b/src/test/scala/parsley/internal/machine/errors/DefuncErrorTests.scala
@@ -1,0 +1,11 @@
+package parsley.internal.machine.errors
+
+import parsley.ParsleyTest
+
+import scala.language.implicitConversions
+
+import MockedBuilders.mockedErrorItemBuilder
+
+class DefuncErrorTests extends ParsleyTest {
+    //TODO: Add tests to verify the defunc behaviours
+}

--- a/src/test/scala/parsley/internal/machine/errors/DefuncErrorTests.scala
+++ b/src/test/scala/parsley/internal/machine/errors/DefuncErrorTests.scala
@@ -15,11 +15,19 @@ class DefuncErrorTests extends ParsleyTest {
         err should be a 'trivialError
         err.asParseError shouldBe a [TrivialError]
     }
+    it should "only be empty when its label is" in {
+        ClassicExpectedError(0, 0, 0, None) shouldBe 'expectedEmpty
+        ClassicExpectedError(0, 0, 0, Some(EndOfInput)) should not be 'expectedEmpty
+    }
 
     "ClassicExpectedErrorWithReason" should "evaluate to TrivialError" in {
         val err = ClassicExpectedErrorWithReason(0, 0, 0, None, "")
         err should be a 'trivialError
         err.asParseError shouldBe a [TrivialError]
+    }
+    it should "only be empty when its label is" in {
+        ClassicExpectedErrorWithReason(0, 0, 0, None, "") shouldBe 'expectedEmpty
+        ClassicExpectedErrorWithReason(0, 0, 0, Some(EndOfInput), "") should not be 'expectedEmpty
     }
 
     "ClassicUnexpectedError" should "evaluate to TrivialError" in {
@@ -27,11 +35,18 @@ class DefuncErrorTests extends ParsleyTest {
         err should be a 'trivialError
         err.asParseError shouldBe a [TrivialError]
     }
+    it should "only be empty when its label is" in {
+        ClassicUnexpectedError(0, 0, 0, None, EndOfInput) shouldBe 'expectedEmpty
+        ClassicUnexpectedError(0, 0, 0, Some(EndOfInput), EndOfInput) should not be 'expectedEmpty
+    }
 
     "ClassicFancyError" should "evaluate to FancyError" in {
         val err = ClassicFancyError(0, 0, 0, "")
         err shouldNot be a 'trivialError
         err.asParseError shouldBe a [FailError]
+    }
+    it should "always be empty" in {
+        ClassicFancyError(0, 0, 0, "hi") shouldBe 'expectedEmpty
     }
 
     "EmptyError" should "evaluate to TrivialError" in {
@@ -39,11 +54,19 @@ class DefuncErrorTests extends ParsleyTest {
         err should be a 'trivialError
         err.asParseError shouldBe a [TrivialError]
     }
+    it should "only be empty when its label is" in {
+        EmptyError(0, 0, 0, None) shouldBe 'expectedEmpty
+        EmptyError(0, 0, 0, Some(EndOfInput)) should not be 'expectedEmpty
+    }
 
     "StringTokError" should "evaluate to TrivialError" in {
         val err = StringTokError(0, 0, 0, None, 1)
         err should be a 'trivialError
         err.asParseError shouldBe a [TrivialError]
+    }
+    it should "only be empty when its label is" in {
+        StringTokError(0, 0, 0, None, 1) shouldBe 'expectedEmpty
+        StringTokError(0, 0, 0, Some(EndOfInput), 1) should not be 'expectedEmpty
     }
 
     "EmptyErrorWithReason" should "evaluate to TrivialError" in {
@@ -51,11 +74,19 @@ class DefuncErrorTests extends ParsleyTest {
         err should be a 'trivialError
         err.asParseError shouldBe a [TrivialError]
     }
+    it should "only be empty when its label is" in {
+        EmptyErrorWithReason(0, 0, 0, None, "") shouldBe 'expectedEmpty
+        EmptyErrorWithReason(0, 0, 0, Some(EndOfInput), "") should not be 'expectedEmpty
+    }
 
     "MultiExpectedError" should "evaluate to TrivialError" in {
         val err = MultiExpectedError(0, 0, 0, Set.empty)
         err should be a 'trivialError
         err.asParseError shouldBe a [TrivialError]
+    }
+    it should "only be empty when its label is" in {
+        MultiExpectedError(0, 0, 0, Set.empty) shouldBe 'expectedEmpty
+        MultiExpectedError(0, 0, 0, Set(EndOfInput)) should not be 'expectedEmpty
     }
 
     "MergedErrors" should "be trivial if both children are" in {
@@ -97,6 +128,17 @@ class DefuncErrorTests extends ParsleyTest {
         err6 shouldNot be a 'trivialError
         err6.asParseError shouldBe a [FailError]
     }
+    they should "be empty when trivial and same offset only when both children are empty" in {
+        MergedErrors(EmptyError(0, 0, 0, None), EmptyError(0, 0, 0, None)) shouldBe 'expectedEmpty
+        MergedErrors(EmptyError(0, 0, 0, None), EmptyError(0, 0, 0, Some(EndOfInput))) should not be 'expectedEmpty
+        MergedErrors(EmptyError(0, 0, 0, Some(EndOfInput)), EmptyError(0, 0, 0, None)) should not be 'expectedEmpty
+        MergedErrors(EmptyError(0, 0, 0, Some(EndOfInput)), EmptyError(0, 0, 0, Some(EndOfInput))) should not be 'expectedEmpty
+    }
+    they should "contain all the expecteds from both branches when appropriate" in {
+        val err = MergedErrors(MultiExpectedError(0, 0, 0, Set(Raw("a"), Raw("b"))),
+                               MultiExpectedError(0, 0, 0, Set(Raw("b"), Raw("c"))))
+        err.asParseError.asInstanceOf[TrivialError].expecteds should contain only (Raw("a"), Raw("b"), Raw("c"))
+    }
 
     "WithHints" should "be trivial if its child is" in {
         val err = WithHints(ClassicExpectedError(0, 0, 0, None), EmptyHints)
@@ -107,6 +149,10 @@ class DefuncErrorTests extends ParsleyTest {
         val err = WithHints(ClassicFancyError(0, 0, 0, ""), EmptyHints)
         err shouldNot be a 'trivialError
         err.asParseError shouldBe a [FailError]
+    }
+    it should "only be empty when its label is" in {
+        WithHints(EmptyError(0, 0, 0, None), EmptyHints) shouldBe 'expectedEmpty
+        WithHints(EmptyError(0, 0, 0, Some(EndOfInput)), EmptyHints) should not be 'expectedEmpty
     }
 
     "WithReason" should "be trivial if its child is" in {
@@ -119,6 +165,10 @@ class DefuncErrorTests extends ParsleyTest {
         err shouldNot be a 'trivialError
         err.asParseError shouldBe a [FailError]
     }
+    it should "only be empty when its label is" in {
+        WithReason(EmptyError(0, 0, 0, None), "") shouldBe 'expectedEmpty
+        WithReason(EmptyError(0, 0, 0, Some(EndOfInput)), "") should not be 'expectedEmpty
+    }
 
     "WithLabel" should "be trivial if its child is" in {
         val err = WithLabel(ClassicExpectedError(0, 0, 0, None), "")
@@ -130,5 +180,16 @@ class DefuncErrorTests extends ParsleyTest {
         err shouldNot be a 'trivialError
         err.asParseError shouldBe a [FailError]
     }
-
+    it should "be empty if the label is empty and not otherwise" in {
+        WithLabel(EmptyError(0, 0, 0, None), "") shouldBe 'expectedEmpty
+        WithLabel(EmptyError(0, 0, 0, None), "a") should not be 'expectedEmpty
+        WithLabel(EmptyError(0, 0, 0, Some(Desc("x"))), "") shouldBe 'expectedEmpty
+        WithLabel(EmptyError(0, 0, 0, Some(Desc("x"))), "a") should not be 'expectedEmpty
+    }
+    it should "replace all expected" in {
+        val errShow = WithLabel(MultiExpectedError(0, 0, 0, Set(Raw("a"), Raw("b"))), "x")
+        val errHide = WithLabel(MultiExpectedError(0, 0, 0, Set(Raw("a"), Raw("b"))), "")
+        errShow.asParseError.asInstanceOf[TrivialError].expecteds should contain only (Desc("x"))
+        errHide.asParseError.asInstanceOf[TrivialError].expecteds shouldBe empty
+    }
 }

--- a/src/test/scala/parsley/internal/machine/errors/DefuncHintsTests.scala
+++ b/src/test/scala/parsley/internal/machine/errors/DefuncHintsTests.scala
@@ -2,10 +2,58 @@ package parsley.internal.machine.errors
 
 import parsley.ParsleyTest
 
+import parsley.internal.errors.Desc
 import scala.language.implicitConversions
 
 import MockedBuilders.mockedErrorItemBuilder
+import scala.annotation.nowarn
 
+@nowarn("msg=deprecated")
 class DefuncHintsTests extends ParsleyTest {
-    //TODO: Add tests to verify the defunc behaviours
+    def mkErr(labels: String*): DefuncError = {
+        assert(labels.nonEmpty)
+        MultiExpectedError(0, 0, 0, labels.map(Desc(_)).toSet)
+    }
+
+    "EmptyHints" should "have size 0" in {
+        EmptyHints shouldBe 'isEmpty
+    }
+    it should "yield an empty list" in {
+        EmptyHints.toList shouldBe empty
+    }
+
+    "AddError" should "should increase the size" in {
+        AddError(EmptyHints, mkErr("a")) should have size 1
+    }
+
+    "PopHints" should "have minimum size 0" in {
+        PopHints(EmptyHints) should have size 0
+    }
+    it should "otherwise ensure it is smaller than before" in {
+        val hints = AddError(AddError(EmptyHints, mkErr("a")), mkErr("b"))
+        val hints_ = PopHints(hints)
+        hints should have size 2
+        hints_ should have size 1
+        hints_.toList should contain only (Set(Desc("b")))
+        PopHints(hints_) shouldBe empty
+    }
+
+    "ReplaceHint" should "do nothing on empty" in {
+        ReplaceHint("hi", EmptyHints) shouldBe empty
+    }
+    it should "replace the first set otherwise" in {
+        val hints = ReplaceHint("hi", AddError(AddError(EmptyHints, mkErr("a", "c")), mkErr("b")))
+        hints.toList should contain inOrderOnly (Set(Desc("hi")), Set(Desc("b")))
+    }
+
+    "MergeHints" should "ensure all elements from both hints" in {
+        val hints1 = AddError(AddError(EmptyHints, mkErr("a")), mkErr("b"))
+        val hints2 = AddError(AddError(EmptyHints, mkErr("c")), mkErr("d"))
+        MergeHints(hints1, hints2).toSet should contain only (Desc("a"), Desc("b"), Desc("c"), Desc("d"))
+    }
+    it should "correct ensure pops on the right do not impact the left" in {
+        val hints1 = AddError(AddError(EmptyHints, mkErr("a")), mkErr("b"))
+        val hints2 = PopHints(AddError(AddError(EmptyHints, mkErr("c")), mkErr("d")))
+        MergeHints(hints1, hints2).toSet should contain only (Desc("a"), Desc("b"), Desc("d"))
+    }
 }

--- a/src/test/scala/parsley/internal/machine/errors/DefuncHintsTests.scala
+++ b/src/test/scala/parsley/internal/machine/errors/DefuncHintsTests.scala
@@ -1,0 +1,11 @@
+package parsley.internal.machine.errors
+
+import parsley.ParsleyTest
+
+import scala.language.implicitConversions
+
+import MockedBuilders.mockedErrorItemBuilder
+
+class DefuncHintsTests extends ParsleyTest {
+    //TODO: Add tests to verify the defunc behaviours
+}

--- a/src/test/scala/parsley/internal/machine/errors/DefuncHintsTests.scala
+++ b/src/test/scala/parsley/internal/machine/errors/DefuncHintsTests.scala
@@ -18,8 +18,8 @@ class DefuncHintsTests extends ParsleyTest {
     "EmptyHints" should "have size 0" in {
         EmptyHints shouldBe 'isEmpty
     }
-    it should "yield an empty list" in {
-        EmptyHints.toList shouldBe empty
+    it should "yield an empty set" in {
+        EmptyHints.toSet shouldBe empty
     }
 
     "AddError" should "should increase the size" in {
@@ -34,7 +34,7 @@ class DefuncHintsTests extends ParsleyTest {
         val hints_ = PopHints(hints)
         hints should have size 2
         hints_ should have size 1
-        hints_.toList should contain only (Set(Desc("b")))
+        hints_.toSet should contain only (Desc("b"))
         PopHints(hints_) shouldBe empty
     }
 
@@ -43,7 +43,7 @@ class DefuncHintsTests extends ParsleyTest {
     }
     it should "replace the first set otherwise" in {
         val hints = ReplaceHint("hi", AddError(AddError(EmptyHints, mkErr("a", "c")), mkErr("b")))
-        hints.toList should contain inOrderOnly (Set(Desc("hi")), Set(Desc("b")))
+        hints.toSet should contain only (Desc("hi"), Desc("b"))
     }
 
     "MergeHints" should "ensure all elements from both hints" in {

--- a/src/test/scala/parsley/internal/machine/errors/DefuncHintsTests.scala
+++ b/src/test/scala/parsley/internal/machine/errors/DefuncHintsTests.scala
@@ -57,8 +57,8 @@ class DefuncHintsTests extends ParsleyTest {
         MergeHints(hints1, hints2).toSet should contain only (Desc("a"), Desc("b"), Desc("d"))
     }
     it should "ensure that if the left needs complete popping that is ok" in {
-        val hints1 = AddError(AddError(EmptyHints, mkErr("a")), mkErr("b"))
-        val hints2 = AddError(AddError(EmptyHints, mkErr("c")), mkErr("d"))
+        def hints1 = AddError(AddError(EmptyHints, mkErr("a")), mkErr("b"))
+        def hints2 = AddError(AddError(EmptyHints, mkErr("c")), mkErr("d"))
         PopHints(PopHints(PopHints(MergeHints(hints1, hints2)))).toSet should contain only (Desc("d"))
         PopHints(PopHints(MergeHints(PopHints(hints1), hints2))).toSet should contain only (Desc("d"))
     }

--- a/src/test/scala/parsley/internal/machine/errors/DefuncHintsTests.scala
+++ b/src/test/scala/parsley/internal/machine/errors/DefuncHintsTests.scala
@@ -51,9 +51,15 @@ class DefuncHintsTests extends ParsleyTest {
         val hints2 = AddError(AddError(EmptyHints, mkErr("c")), mkErr("d"))
         MergeHints(hints1, hints2).toSet should contain only (Desc("a"), Desc("b"), Desc("c"), Desc("d"))
     }
-    it should "correct ensure pops on the right do not impact the left" in {
+    it should "ensure pops on the right do not impact the left" in {
         val hints1 = AddError(AddError(EmptyHints, mkErr("a")), mkErr("b"))
         val hints2 = PopHints(AddError(AddError(EmptyHints, mkErr("c")), mkErr("d")))
         MergeHints(hints1, hints2).toSet should contain only (Desc("a"), Desc("b"), Desc("d"))
+    }
+    it should "ensure that if the left needs complete popping that is ok" in {
+        val hints1 = AddError(AddError(EmptyHints, mkErr("a")), mkErr("b"))
+        val hints2 = AddError(AddError(EmptyHints, mkErr("c")), mkErr("d"))
+        PopHints(PopHints(PopHints(MergeHints(hints1, hints2)))).toSet should contain only (Desc("d"))
+        PopHints(PopHints(MergeHints(PopHints(hints1), hints2))).toSet should contain only (Desc("d"))
     }
 }

--- a/src/test/scala/parsley/internal/machine/errors/MockedBuilders.scala
+++ b/src/test/scala/parsley/internal/machine/errors/MockedBuilders.scala
@@ -1,0 +1,9 @@
+package parsley.internal.machine.errors
+
+object MockedBuilders {
+    implicit val mockedErrorItemBuilder: ErrorItemBuilder = new ErrorItemBuilder {
+      override def inRange(offset: Int): Boolean = true
+      override def charAt(offset: Int): Char = 'x'
+      override def substring(offset: Int, size: Int): String = "x" * size
+    }
+}


### PR DESCRIPTION
This pull request will implement a variety of optimisations purely concerning the evaluation of the defunctionalised forms for error messages and hints. As an example, indices of the components of the hints that have currently made it into the result of evaluation can be recorded to ensure that recomputation isn't done, as well as ensure that hints that will never make it to the final result are not computed.

This PR _may_ also introduce a CPS transformation to ensure stack-safe evaluation. But I'm not yet convinced this will be needed: most parsers seem to produce smaller defunctionalised terms purely based on the small pieces of information used to prune away the defunctionalised forms in the main machine.