### PR TITLE
Improvements to Lexer Errors and Errors in General

### DIFF
--- a/src/main/scala/parsley/internal/errors/Errors.scala
+++ b/src/main/scala/parsley/internal/errors/Errors.scala
@@ -81,7 +81,8 @@ private [internal] case class Raw(cs: String) extends ErrorItem {
         case "\t"            => "tab"
         case " "             => "space"
         case Unprintable(up) => f"unprintable character (\\u${up.head.toInt}%04X)"
-        case cs              => "\"" + cs.takeWhile(_ != '\n') + "\""
+        // Do we want this only in unexpecteds?
+        case cs              => "\"" + cs.takeWhile(c => c != '\n' && c != ' ') + "\""
     }
 }
 private [internal] object Raw {

--- a/src/main/scala/parsley/internal/machine/Context.scala
+++ b/src/main/scala/parsley/internal/machine/Context.scala
@@ -6,7 +6,7 @@ import parsley.{Failure, Result, Success}
 import parsley.internal.errors.{ErrorItem, LineBuilder}
 import parsley.internal.machine.errors.{
     ErrorItemBuilder,
-    DefuncError, ClassicExpectedError, ClassicExpectedErrorWithReason, ClassicFancyError, ClassicUnexpectedError, WithHints,
+    DefuncError, ClassicExpectedError, ClassicExpectedErrorWithReason, ClassicFancyError, ClassicUnexpectedError, WithHints, TokenError,
     DefuncHints, EmptyHints, MergeHints, ReplaceHint, PopHints, AddError
 }
 
@@ -181,6 +181,9 @@ private [parsley] final class Context(private [machine] var instrs: Array[Instr]
     }
     private [machine] def expectedFail(expected: Option[ErrorItem], reason: String): Unit = {
         this.fail(new ClassicExpectedErrorWithReason(offset, line, col, expected, reason))
+    }
+    private [machine] def expectedTokenFail(expected: Option[ErrorItem], size: Int): Unit = {
+        this.fail(new TokenError(offset, line, col, expected, size))
     }
     private [machine] def fail(error: DefuncError): Unit = {
         this.pushError(error)

--- a/src/main/scala/parsley/internal/machine/errors/DefuncError.scala
+++ b/src/main/scala/parsley/internal/machine/errors/DefuncError.scala
@@ -41,7 +41,7 @@ private [errors] object BaseError {
         case err: ClassicUnexpectedError => Some(err.expected)
         case err: EmptyError => Some(err.expected)
         case err: EmptyErrorWithReason => Some(err.expected)
-        case err: StringTokError => Some(err.expected)
+        case err: TokenError => Some(err.expected)
         case _ => None
     }
 }
@@ -82,7 +82,7 @@ private [machine] case class EmptyError(offset: Int, line: Int, col: Int, expect
         TrivialError(offset, line, col, None, expectedSet(expected), ParseError.NoReason)
     }
 }
-private [machine] case class StringTokError(offset: Int, line: Int, col: Int, expected: Option[ErrorItem], size: Int) extends DefuncError {
+private [machine] case class TokenError(offset: Int, line: Int, col: Int, expected: Option[ErrorItem], size: Int) extends DefuncError {
     val isTrivialError: Boolean = true
     val isExpectedEmpty: Boolean = expected.isEmpty
     override def asParseError(implicit builder: ErrorItemBuilder): ParseError = {
@@ -96,11 +96,11 @@ private [machine] case class EmptyErrorWithReason(offset: Int, line: Int, col: I
         TrivialError(offset, line, col, None, expectedSet(expected), Set(reason))
     }
 }
-private [machine] case class MultiExpectedError(offset: Int, line: Int, col: Int, expected: Set[ErrorItem]) extends DefuncError {
+private [machine] case class MultiExpectedError(offset: Int, line: Int, col: Int, expected: Set[ErrorItem], size: Int) extends DefuncError {
     val isTrivialError: Boolean = true
     val isExpectedEmpty: Boolean = expected.isEmpty
     override def asParseError(implicit builder: ErrorItemBuilder): ParseError = {
-        TrivialError(offset, line, col, Some(builder(offset)), expected, ParseError.NoReason)
+        TrivialError(offset, line, col, Some(builder(offset, size)), expected, ParseError.NoReason)
     }
 }
 

--- a/src/main/scala/parsley/internal/machine/instructions/IntrinsicInstrs.scala
+++ b/src/main/scala/parsley/internal/machine/instructions/IntrinsicInstrs.scala
@@ -2,7 +2,7 @@ package parsley.internal.machine.instructions
 
 import parsley.internal.errors.{Desc, Raw}
 import parsley.internal.machine.{Context, Good}
-import parsley.internal.machine.errors.{EmptyError, EmptyErrorWithReason, StringTokError}
+import parsley.internal.machine.errors.{EmptyError, EmptyErrorWithReason}
 
 import scala.annotation.tailrec
 
@@ -77,9 +77,8 @@ private [internal] final class StringTok private [instructions] (s: String, x: A
         if (j < sz && i < ctx.inputsz && ctx.input.charAt(i) == cs(j)) go(ctx, i + 1, j + 1)
         else if (j < sz) {
             // The offset, line and column haven't been edited yet, so are in the right place
-            val err = new StringTokError(ctx.offset, ctx.line, ctx.col, errorItem, sz)
+            ctx.expectedTokenFail(errorItem, sz)
             ctx.offset = i
-            ctx.fail(err)
         }
         else {
             ctx.col = colAdjust(ctx.col)

--- a/src/main/scala/parsley/internal/machine/instructions/OptInstrs.scala
+++ b/src/main/scala/parsley/internal/machine/instructions/OptInstrs.scala
@@ -104,10 +104,10 @@ private [internal] final class AlwaysRecoverWith[A](x: A) extends Instr {
 private [internal] final class JumpTable(prefixes: List[Char], labels: List[Int],
         private [this] var default: Int,
         private [this] var merge: Int,
-        _expecteds: Map[Char, Set[ErrorItem]]) extends Instr {
+        private [this] val size: Int,
+        private [this] val errorItems: Set[ErrorItem]) extends Instr {
     private [this] var defaultPreamble: Int = _
     private [this] val jumpTable = mutable.LongMap(prefixes.map(_.toLong).zip(labels): _*)
-    val errorItems = _expecteds.toSet[(Char, Set[ErrorItem])].flatMap(_._2)
 
     override def apply(ctx: Context): Unit = {
         if (ctx.moreInput) {
@@ -127,7 +127,7 @@ private [internal] final class JumpTable(prefixes: List[Char], labels: List[Int]
     }
 
     private def addErrors(ctx: Context): Unit = {
-        ctx.errs = new ErrorStack(new MultiExpectedError(ctx.offset, ctx.line, ctx.col, errorItems), ctx.errs)
+        ctx.errs = new ErrorStack(new MultiExpectedError(ctx.offset, ctx.line, ctx.col, errorItems, size), ctx.errs)
         ctx.pushHandler(merge)
     }
 

--- a/src/main/scala/parsley/internal/machine/instructions/TokenStringInstrs.scala
+++ b/src/main/scala/parsley/internal/machine/instructions/TokenStringInstrs.scala
@@ -11,7 +11,7 @@ private [internal] class TokenEscape(_expected: Option[String]) extends Instr wi
     override def apply(ctx: Context): Unit = escape(ctx) match {
         case TokenEscape.EscapeChar(escapeChar) =>ctx.pushAndContinue(escapeChar)
         case TokenEscape.BadCode => ctx.expectedFail(expected, reason = "invalid escape sequence")
-        case TokenEscape.NoParse => ctx.expectedFail(expected)
+        case TokenEscape.NoParse => ctx.expectedTokenFail(expected, 3)
     }
 
     private final def consumeAndReturn(ctx: Context, n: Int, c: Char) = {

--- a/src/test/scala/parsley/internal/machine/errors/DefuncErrorTests.scala
+++ b/src/test/scala/parsley/internal/machine/errors/DefuncErrorTests.scala
@@ -59,14 +59,14 @@ class DefuncErrorTests extends ParsleyTest {
         EmptyError(0, 0, 0, Some(EndOfInput)) should not be 'expectedEmpty
     }
 
-    "StringTokError" should "evaluate to TrivialError" in {
-        val err = StringTokError(0, 0, 0, None, 1)
+    "TokenError" should "evaluate to TrivialError" in {
+        val err = TokenError(0, 0, 0, None, 1)
         err should be a 'trivialError
         err.asParseError shouldBe a [TrivialError]
     }
     it should "only be empty when its label is" in {
-        StringTokError(0, 0, 0, None, 1) shouldBe 'expectedEmpty
-        StringTokError(0, 0, 0, Some(EndOfInput), 1) should not be 'expectedEmpty
+        TokenError(0, 0, 0, None, 1) shouldBe 'expectedEmpty
+        TokenError(0, 0, 0, Some(EndOfInput), 1) should not be 'expectedEmpty
     }
 
     "EmptyErrorWithReason" should "evaluate to TrivialError" in {
@@ -80,17 +80,17 @@ class DefuncErrorTests extends ParsleyTest {
     }
 
     "MultiExpectedError" should "evaluate to TrivialError" in {
-        val err = MultiExpectedError(0, 0, 0, Set.empty)
+        val err = MultiExpectedError(0, 0, 0, Set.empty, 1)
         err should be a 'trivialError
         err.asParseError shouldBe a [TrivialError]
     }
     it should "only be empty when its label is" in {
-        MultiExpectedError(0, 0, 0, Set.empty) shouldBe 'expectedEmpty
-        MultiExpectedError(0, 0, 0, Set(EndOfInput)) should not be 'expectedEmpty
+        MultiExpectedError(0, 0, 0, Set.empty, 1) shouldBe 'expectedEmpty
+        MultiExpectedError(0, 0, 0, Set(EndOfInput), 1) should not be 'expectedEmpty
     }
 
     "MergedErrors" should "be trivial if both children are" in {
-        val err = MergedErrors(EmptyError(0, 0, 0, None), MultiExpectedError(0, 0, 0, Set.empty))
+        val err = MergedErrors(EmptyError(0, 0, 0, None), MultiExpectedError(0, 0, 0, Set.empty, 1))
         err should be a 'trivialError
         err.asParseError shouldBe a [TrivialError]
     }
@@ -135,8 +135,8 @@ class DefuncErrorTests extends ParsleyTest {
         MergedErrors(EmptyError(0, 0, 0, Some(EndOfInput)), EmptyError(0, 0, 0, Some(EndOfInput))) should not be 'expectedEmpty
     }
     they should "contain all the expecteds from both branches when appropriate" in {
-        val err = MergedErrors(MultiExpectedError(0, 0, 0, Set(Raw("a"), Raw("b"))),
-                               MultiExpectedError(0, 0, 0, Set(Raw("b"), Raw("c"))))
+        val err = MergedErrors(MultiExpectedError(0, 0, 0, Set(Raw("a"), Raw("b")), 1),
+                               MultiExpectedError(0, 0, 0, Set(Raw("b"), Raw("c")), 1))
         err.asParseError.asInstanceOf[TrivialError].expecteds should contain only (Raw("a"), Raw("b"), Raw("c"))
     }
 
@@ -187,8 +187,8 @@ class DefuncErrorTests extends ParsleyTest {
         WithLabel(EmptyError(0, 0, 0, Some(Desc("x"))), "a") should not be 'expectedEmpty
     }
     it should "replace all expected" in {
-        val errShow = WithLabel(MultiExpectedError(0, 0, 0, Set(Raw("a"), Raw("b"))), "x")
-        val errHide = WithLabel(MultiExpectedError(0, 0, 0, Set(Raw("a"), Raw("b"))), "")
+        val errShow = WithLabel(MultiExpectedError(0, 0, 0, Set(Raw("a"), Raw("b")), 1), "x")
+        val errHide = WithLabel(MultiExpectedError(0, 0, 0, Set(Raw("a"), Raw("b")), 1), "")
         errShow.asParseError.asInstanceOf[TrivialError].expecteds should contain only (Desc("x"))
         errHide.asParseError.asInstanceOf[TrivialError].expecteds shouldBe empty
     }

--- a/src/test/scala/parsley/internal/machine/errors/DefuncHintsTests.scala
+++ b/src/test/scala/parsley/internal/machine/errors/DefuncHintsTests.scala
@@ -12,7 +12,7 @@ import scala.annotation.nowarn
 class DefuncHintsTests extends ParsleyTest {
     def mkErr(labels: String*): DefuncError = {
         assert(labels.nonEmpty)
-        MultiExpectedError(0, 0, 0, labels.map(Desc(_)).toSet)
+        MultiExpectedError(0, 0, 0, labels.map(Desc(_)).toSet, 1)
     }
 
     "EmptyHints" should "have size 0" in {


### PR DESCRIPTION
Added better unexpected messages to lexer instructions, allowed JumpTable to have better unexpected messages, cut unexpected messages short at first newline OR space