### PR TITLE
Scala-JS CI + Publish

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,6 +70,61 @@ jobs:
         #if: needs.check-duplicate.outputs.should_skip != 'true'
         run: sbt ++$SCALA_VERSION doc
 
+  # This is largely temporary, we'll find a better way to do this...
+  validate-js:
+    name: Scala-JS ${{ matrix.scala }}, Node ${{ matrix.node }}
+    runs-on: ubuntu-20.04
+    needs: check-duplicate
+
+    env:
+      SCALA_VERSION: ${{ matrix.scala }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        node: [14, 15]
+        scala: [2.12.13, 2.13.5]
+
+    steps:
+      - name: Checkout repository
+        #if: needs.check-duplicate.outputs.should_skip != 'true'
+        uses: actions/checkout@v2.3.4
+
+      - name: Setup Node
+        #if: needs.check-duplicate.outputs.should_skip != 'true'
+        uses: actions/setup-node@v2.1.5
+        with:
+          node-version: ${{ matrix.node }}
+
+      - name: Setup Scala
+        #if: needs.check-duplicate.outputs.should_skip != 'true'
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: adopt@1.11
+
+      - name: Cache Coursier
+        #if: needs.check-duplicate.outputs.should_skip != 'true'
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/coursier
+          key: sbt-coursier-cache
+
+      - name: Cache SBT
+        #if: needs.check-duplicate.outputs.should_skip != 'true'
+        uses: actions/cache@v2
+        with:
+          path: ~/.sbt
+          key: sbt-${{ hashFiles('**/build.sbt') }}
+
+      - name: Test
+        #if: needs.check-duplicate.outputs.should_skip != 'true'
+        run: sbt ++$SCALA_VERSION parsleyJS/test
+
+      - name: Scaladoc
+        #if: needs.check-duplicate.outputs.should_skip != 'true'
+        run: sbt ++$SCALA_VERSION parsleyJS/doc
+  # End attrocity
+
   coverage:
     name: Test Coverage
     runs-on: ubuntu-20.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,8 +44,15 @@ jobs:
           path: ~/.sbt
           key: sbt-${{ hashFiles('**/build.sbt') }}
 
-      - name: Publish
+      - name: Publish JVM
         run: sbt ci-release
+        env:
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+
+      - name: Publish JS
         run: sbt parsleyJS/ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,6 +46,7 @@ jobs:
 
       - name: Publish
         run: sbt ci-release
+        run: sbt parsleyJS/ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - js-publish
     tags:
       - '*'
   workflow_dispatch:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - js-publish
     tags:
       - '*'
   workflow_dispatch:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,12 +9,6 @@ on:
       - '*'
   workflow_dispatch:
 
-#env:
-#  WARN: Updating sbt ci-release to any version past 1.5.4 changes the default (+publishSigned) to +publish
-#  CI_SNAPSHOT_RELEASE: +publishSigned
-#  Temp: testing if SCALA_VERSION is needed
-#  SCALA_VERSION: 2.12.13
-
 jobs:
   release:
     name: Release
@@ -47,14 +41,18 @@ jobs:
       - name: Publish JVM
         run: sbt ci-release
         env:
+          CI_RELEASE:          +publishSigned
+          CI_SNAPSHOT_RELEASE: +publishSigned
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
 
       - name: Publish JS
-        run: sbt parsleyJS/ci-release
+        run: sbt ci-release
         env:
+          CI_RELEASE:          +parsleyJS/publishSigned
+          CI_SNAPSHOT_RELEASE: +parsleyJS/publishSigned
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
           PGP_SECRET: ${{ secrets.PGP_SECRET }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/build.sbt
+++ b/build.sbt
@@ -67,7 +67,7 @@ lazy val parsley = crossProject(JSPlatform, JVMPlatform)
 
     libraryDependencies += "org.scalatest" %%% "scalatest" % scalaTestDependency(scalaVersion.value) % Test,
 
-    crossScalaVersions := List(scala212Version, scala213Version, scala3Version, dottyVersion),
+    //crossScalaVersions := List(scala212Version, scala213Version, scala3Version, dottyVersion),
     // temporary until Parsley 3.0
     Compile / unmanagedSourceDirectories += file(s"${baseDirectory.value.getParentFile.getPath}/src/main/deprecated"),
     Compile / unmanagedSourceDirectories ++= extraSources(baseDirectory.value.getParentFile, "main", scalaVersion.value),
@@ -83,4 +83,10 @@ lazy val parsley = crossProject(JSPlatform, JVMPlatform)
       val old = (Compile / doc / sources).value
       if (scalaVersion.value == dottyVersion) Seq() else old
     }
+  )
+  .jvmSettings(
+    crossScalaVersions := List(scala212Version, scala213Version, scala3Version, dottyVersion)
+  )
+  .jsSettings(
+    crossScalaVersions := List(scala212Version, scala213Version)
   )

--- a/build.sbt
+++ b/build.sbt
@@ -67,7 +67,6 @@ lazy val parsley = crossProject(JSPlatform, JVMPlatform)
 
     libraryDependencies += "org.scalatest" %%% "scalatest" % scalaTestDependency(scalaVersion.value) % Test,
 
-    //crossScalaVersions := List(scala212Version, scala213Version, scala3Version, dottyVersion),
     // temporary until Parsley 3.0
     Compile / unmanagedSourceDirectories += file(s"${baseDirectory.value.getParentFile.getPath}/src/main/deprecated"),
     Compile / unmanagedSourceDirectories ++= extraSources(baseDirectory.value.getParentFile, "main", scalaVersion.value),
@@ -85,7 +84,7 @@ lazy val parsley = crossProject(JSPlatform, JVMPlatform)
     }
   )
   .jvmSettings(
-    crossScalaVersions := List(scala212Version, scala213Version, scala3Version, dottyVersion)
+    crossScalaVersions := List(scala212Version, scala213Version, scala3Version, dottyVersion),
   )
   .jsSettings(
     crossScalaVersions := List(scala212Version, scala213Version)


### PR DESCRIPTION
The CI for the Scala-JS support is now up and running, and tests against node 14 LTS and 15. Scala 2.12 and Scala 2.13 now will have releases for Scala-JS Parsley.