### PR TITLE
Parsley 3 expr

### DIFF
--- a/src/main/scala/parsley/expr/chain.scala
+++ b/src/main/scala/parsley/expr/chain.scala
@@ -61,4 +61,21 @@ object chain {
       * @since 2.2.0
       */
     def postfix[A](p: =>Parsley[A], op: =>Parsley[A => A]): Parsley[A] = new Parsley(new deepembedding.ChainPost(p.internal, op.internal))
+
+    /**`prefix(op, p)` parses one or more prefixed applications of `op` onto a single final result of `p`
+      * @since 3.0.0
+      */
+    def prefix1[A](p: =>Parsley[A], op: =>Parsley[A => A]): Parsley[A] = {
+        lazy val op_ = op
+        op_ <*> prefix(op_, p)
+    }
+
+    /**`postfix1(p, op)` parses one occurrence of `p`, followed by one or more postfix applications of `op`
+      * that associate to the left.
+      * @since 3.0.0
+      */
+    def postfix1[A](p: =>Parsley[A], op: =>Parsley[A => A]): Parsley[A] = {
+        lazy val op_ = op
+        postfix(p <**> op_, op_)
+    }
 }

--- a/src/main/scala/parsley/expr/chain.scala
+++ b/src/main/scala/parsley/expr/chain.scala
@@ -65,7 +65,7 @@ object chain {
     /**`prefix(op, p)` parses one or more prefixed applications of `op` onto a single final result of `p`
       * @since 3.0.0
       */
-    def prefix1[A](p: =>Parsley[A], op: =>Parsley[A => A]): Parsley[A] = {
+    def prefix1[A, B <: A](p: =>Parsley[A], op: =>Parsley[A => B]): Parsley[B] = {
         lazy val op_ = op
         op_ <*> prefix(op_, p)
     }
@@ -74,7 +74,7 @@ object chain {
       * that associate to the left.
       * @since 3.0.0
       */
-    def postfix1[A](p: =>Parsley[A], op: =>Parsley[A => A]): Parsley[A] = {
+    def postfix1[A, B <: A](p: =>Parsley[A], op: =>Parsley[A => B]): Parsley[B] = {
         lazy val op_ = op
         postfix(p <**> op_, op_)
     }

--- a/src/main/scala/parsley/expr/chain.scala
+++ b/src/main/scala/parsley/expr/chain.scala
@@ -65,7 +65,7 @@ object chain {
     /**`prefix(op, p)` parses one or more prefixed applications of `op` onto a single final result of `p`
       * @since 3.0.0
       */
-    def prefix1[A, B <: A](p: =>Parsley[A], op: =>Parsley[A => B]): Parsley[B] = {
+    def prefix1[A, B <: A](op: =>Parsley[A => B], p: =>Parsley[A]): Parsley[B] = {
         lazy val op_ = op
         op_ <*> prefix(op_, p)
     }

--- a/src/main/scala/parsley/expr/precedence.scala
+++ b/src/main/scala/parsley/expr/precedence.scala
@@ -28,13 +28,13 @@ object precedence {
     /** This is used to build an expression parser for a monolithic type. Levels are specified from strongest
      * to weakest.
      * @tparam A The type of the monolithic tree
-     * @param atom The atomic unit of the expression, for instance numbers/variables
+     * @param atoms The atomic units of the expression, for instance numbers/variables
      * @param table A table of operators. Table is ordered highest precedence to lowest precedence.
      *              Each list in the table corresponds to operators of the same precedence level.
      * @return A parser for the described expression language
-     * @since 2.2.0
+     * @since 3.0.0
      */
-    def apply[A](atom: =>Parsley[A], table: Ops[A, A]*): Parsley[A] = apply(atom, table.foldRight(Levels.empty[A])(Level.apply[A, A, A]))
+    def apply[A](atoms: Parsley[A]*)(table: Ops[A, A]*): Parsley[A] = apply(choice(atoms: _*), table.foldRight(Levels.empty[A])(Level.apply[A, A, A]))
 
     /** This is used to build an expression parser for a multi-layered expression tree type. Levels are specified
      * from strongest to weakest.
@@ -46,5 +46,5 @@ object precedence {
      * @return A parser for the described expression language
      * @since 2.2.0
      */
-    def apply[A, B](atom: =>Parsley[A], table: Levels[A, B]): Parsley[B] = crushLevels(atom, table)
+    def apply[A, B](atom: Parsley[A], table: Levels[A, B]): Parsley[B] = crushLevels(atom, table)
 }

--- a/src/test/scala/parsley/ExpressionParserTests.scala
+++ b/src/test/scala/parsley/ExpressionParserTests.scala
@@ -102,24 +102,24 @@ class ExpressionParserTests extends ParsleyTest {
     }
 
     "expression parsers" should "result in correct precedence" in {
-        val expr = precedence[Int](digit.map(_.asDigit), Ops(InfixL)('*' #> (_*_)),
+        val expr = precedence[Int](digit.map(_.asDigit))(Ops(InfixL)('*' #> (_*_)),
                                                          Ops(InfixL)('+' #> (_+_)))
         expr.parse("1+2*3+4") should be (Success(11))
         expr.parse("1*2+3*4") should be (Success(14))
     }
     they should "work for multiple operators at the same level" in {
-        val expr = precedence[Int](digit.map(_.asDigit), Ops(InfixL)('+' #> (_+_), '-' #> (_-_)))
+        val expr = precedence[Int](digit.map(_.asDigit))(Ops(InfixL)('+' #> (_+_), '-' #> (_-_)))
         expr.parse("1+2-3+4") should be (Success(4))
         expr.parse("1-2+3-4") should be (Success(-2))
     }
     they should "work for mixed associativity operators" in {
-        val expr = precedence[Int](digit.map(_.asDigit), Ops(InfixL)('*' #> (_*_)),
+        val expr = precedence[Int](digit.map(_.asDigit))(Ops(InfixL)('*' #> (_*_)),
                                                          Ops(InfixR)('+' #> (_+_)))
         expr.parse("1+2*3+4") should be (Success(11))
         expr.parse("1*2+3*4") should be (Success(14))
     }
     they should "parse mathematical expressions" in {
-        lazy val expr: Parsley[Int] = precedence[Int](atom,
+        lazy val expr: Parsley[Int] = precedence[Int](atom)(
             Ops(Prefix)('-' #> (x => -x)),
             Ops(InfixL)('/' #> (_/_)),
             Ops(InfixR)('*' #> (_*_)),
@@ -131,7 +131,7 @@ class ExpressionParserTests extends ParsleyTest {
         expr.parse("(3+-7)*(-2--4)/2") should be (Success(-4))
     }
     they should "parse prefix operators mixed with infix operators" in {
-        lazy val expr = precedence[Int](atom, Ops(Prefix)('-' #> (x => -x)),
+        lazy val expr = precedence[Int](atom)(Ops(Prefix)('-' #> (x => -x)),
                                               Ops(InfixL)('-' #> (_-_)))
         lazy val atom: Parsley[Int] = digit.map(_.asDigit) <|> ('(' *> expr <* ')')
         expr.parse("-1") should be (Success(-1))
@@ -145,7 +145,7 @@ class ExpressionParserTests extends ParsleyTest {
         case class Lt(x: Expr, y: Expr) extends Expr
         case class Inc(x: Expr) extends Expr
         case class Num(x: Int) extends Expr
-        val expr = precedence[Expr](digit.map(_.asDigit).map(Num), Ops(InfixL)('<' #> Lt),
+        val expr = precedence[Expr](digit.map(_.asDigit).map(Num))(Ops(InfixL)('<' #> Lt),
                                                                    Ops(Prefix)("++" #> Inc))
         expr.parse("++1<2") should be (Success(Inc(Lt(Num(1), Num(2)))))
     }
@@ -205,7 +205,7 @@ class ExpressionParserTests extends ParsleyTest {
         )
 
         lazy val atom: Parsley[Expr] = tok.identifier.map(Constant)
-        lazy val expr: Parsley[Expr] = precedence(atom, ops: _*)
+        lazy val expr: Parsley[Expr] = precedence(atom)(ops: _*)
 
         expr.parse("o.f()") shouldBe a [Success[_]]
         expr.parse("o.f(x,y)") shouldBe a [Success[_]]

--- a/src/test/scala/parsley/ExpressionParserTests.scala
+++ b/src/test/scala/parsley/ExpressionParserTests.scala
@@ -28,6 +28,20 @@ class ExpressionParserTests extends ParsleyTest {
         noException should be thrownBy q.parse("1+*1+")
     }
 
+    "chain.postfix1" must "require and initial value AND an initial operator" in {
+        chain.postfix1('1' #> 1, '+' #> ((x: Int) => x + 1)).parse("1") shouldBe a [Failure]
+        chain.postfix1('1' #> 1, '+' #> ((x: Int) => x + 1)).parse("1+") shouldBe Success(2)
+    }
+    it must "parse all operators that follow" in {
+        chain.postfix1('1' #> 1, '+' #> ((x: Int) => x + 1)).parse("1++++++++++++++") should not be a [Failure]
+    }
+    it must "apply the functions" in {
+        chain.postfix1('1' #> 1, '+' #> ((x: Int) => x + 1)).parse("1++++++++++++++") should be (Success(15))
+    }
+    it must "fail if an operator fails after consuming input" in {
+        chain.postfix1('1' #> 1, "++" #> ((x: Int) => x + 1)).parse("1+++++++++++++") shouldBe a [Failure]
+    }
+
     "chain.prefix" must "parse an operatorless value" in {
         chain.prefix('+' #> ((x: Int) => x + 1), '1' #> 1).parse("1") should be (Success(1))
     }
@@ -39,6 +53,19 @@ class ExpressionParserTests extends ParsleyTest {
     }
     it must "apply the functions" in {
         chain.prefix('+' #> ((x: Int) => x + 1), '1' #> 1).parse("+++++++++++1") should be (Success(12))
+    }
+
+    "chain.prefix1" must "not parse an operatorless value" in {
+        chain.prefix1('+' #> ((x: Int) => x + 1), '1' #> 1).parse("1") shouldBe a [Failure]
+    }
+    it must "parse all operators that precede a value" in {
+        chain.prefix1('+' #> ((x: Int) => x + 1), '1' #> 1).parse("+++++++++++1") should not be a [Failure]
+    }
+    it must "fail if the final value is absent" in {
+        chain.prefix1('+' #> ((x: Int) => x + 1), '1' #> 1).parse("+++++++++++") shouldBe a [Failure]
+    }
+    it must "apply the functions" in {
+        chain.prefix1('+' #> ((x: Int) => x + 1), '1' #> 1).parse("+++++++++++1") should be (Success(12))
     }
 
     "chain.right1" must "require an initial value" in {

--- a/src/test/scala/parsley/internal/InternalTests.scala
+++ b/src/test/scala/parsley/internal/InternalTests.scala
@@ -50,14 +50,14 @@ class InternalTests extends ParsleyTest {
 
     they should "work in the precedence parser with one op" in {
         val atom = some(digit).map(_.mkString.toInt)
-        val expr = precedence[Int](atom,
+        val expr = precedence[Int](atom)(
             Ops(InfixL)('+' #> (_ + _)))
         expr.internal.instrs.count(_ == instructions.Return) shouldBe 1
     }
 
     they should "appear frequently inside expression parsers" in {
         val atom = some(digit).map(_.mkString.toInt)
-        val expr = precedence[Int](atom,
+        val expr = precedence[Int](atom)(
             Ops(InfixL)('+' #> (_ + _)),
             Ops(InfixL)('*' #> (_ * _)),
             Ops(InfixL)('%' #> (_ % _)))


### PR DESCRIPTION
Adds in a new curried form of monolithic `precedence` and introduced `postfix1` and `prefix1` combinators to `chain`, which have a more general type as a result of how they work.