### PR TITLE
Parsley 3 errors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -62,6 +62,10 @@ jobs:
           path: ~/.sbt
           key: sbt-${{ hashFiles('**/build.sbt') }}
 
+      - name: Build
+        #if: needs.check-duplicate.outputs.should_skip != 'true'
+        run: sbt ++$SCALA_VERSION compile
+
       - name: Test
         #if: needs.check-duplicate.outputs.should_skip != 'true'
         run: sbt ++$SCALA_VERSION test
@@ -113,6 +117,10 @@ jobs:
         with:
           path: ~/.sbt
           key: sbt-${{ hashFiles('**/build.sbt') }}
+
+      - name: Build
+        #if: needs.check-duplicate.outputs.should_skip != 'true'
+        run: sbt ++$SCALA_VERSION parsleyJS/compile
 
       - name: Test
         #if: needs.check-duplicate.outputs.should_skip != 'true'
@@ -173,6 +181,10 @@ jobs:
         with:
           path: ~/.sbt
           key: sbt-${{ hashFiles('**/build.sbt') }}
+
+      - name: Build
+        #if: needs.check-duplicate.outputs.should_skip != 'true'
+        run: sbt ++$SCALA_VERSION parsleyNative/compile
 
       - name: Test
         #if: needs.check-duplicate.outputs.should_skip != 'true'

--- a/build.sbt
+++ b/build.sbt
@@ -58,7 +58,10 @@ val PureVisible: CrossType = new CrossType {
 Global / onChangedBuildSource := ReloadOnSourceChanges
 
 // See https://github.com/sbt/sbt/issues/1224
-onLoad in Global ~= (_ andThen ("project parsley" :: _))
+Global / onLoad ~= (_ andThen ("project parsley" :: _))
+
+Compile / bloopGenerate := None
+Test / bloopGenerate := None
 
 lazy val parsley = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .withoutSuffixFor(JVMPlatform)
@@ -71,7 +74,9 @@ lazy val parsley = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     libraryDependencies += "org.scalatest" %%% "scalatest" % scalaTestDependency(scalaVersion.value) % Test,
 
     Compile / unmanagedSourceDirectories ++= extraSources(baseDirectory.value.getParentFile, "main", scalaVersion.value),
+    Compile / unmanagedSourceDirectories ++= extraSources(baseDirectory.value, "main", scalaVersion.value),
     Test / unmanagedSourceDirectories ++= extraSources(baseDirectory.value.getParentFile, "test", scalaVersion.value),
+    Test / unmanagedSourceDirectories ++= extraSources(baseDirectory.value, "test", scalaVersion.value),
 
     scalacOptions ++= Seq("-deprecation", "-unchecked", "-feature"),
     scalacOptions ++= (if (isDotty.value) Seq("-source:3.0-migration") else Seq.empty),
@@ -88,8 +93,12 @@ lazy val parsley = crossProject(JSPlatform, JVMPlatform, NativePlatform)
     crossScalaVersions := List(scala212Version, scala213Version, scala3Version, dottyVersion),
   )
   .jsSettings(
-    crossScalaVersions := List(scala212Version, scala213Version)
+    crossScalaVersions := List(scala212Version, scala213Version),
+    Compile / bloopGenerate := None,
+    Test / bloopGenerate := None
   )
   .nativeSettings(
-    crossScalaVersions := List(scala212Version, scala213Version)
+    crossScalaVersions := List(scala212Version, scala213Version),
+    Compile / bloopGenerate := None,
+    Test / bloopGenerate := None
   )

--- a/jvm/src/main/scala/parsley/io.scala
+++ b/jvm/src/main/scala/parsley/io.scala
@@ -33,7 +33,7 @@ object io {
                 }
             } yield {
                 src.close()
-                new Context(p.internal.threadSafeInstrs, input, Some(file)).runParser()
+                new Context(p.internal.threadSafeInstrs, input, Some(file.getName)).runParser()
             }
         }
     }

--- a/jvm/src/main/scala/parsley/io.scala
+++ b/jvm/src/main/scala/parsley/io.scala
@@ -7,6 +7,7 @@ import java.io.File
 import parsley.internal.machine.Context
 
 import scala.language.{higherKinds, implicitConversions}
+import parsley.errors.ErrorBuilder
 
 /** This module contains utilities to have parsers interact with IO, including the very useful `parseFromFile` method (exposed by `ParseFromIO`)
   * @since 3.0.0
@@ -22,7 +23,7 @@ object io {
          *         and a failure if an IOException occured
          * @since 3.0.0
          */
-        def parseFromFile(file: File)(implicit codec: Codec): Try[Result[A]] = {
+        def parseFromFile[Err: ErrorBuilder](file: File)(implicit codec: Codec): Try[Result[Err, A]] = {
             for {
                 src <- Try(Source.fromFile(file))
                 input <- Try(src.mkString).recoverWith {
@@ -32,7 +33,7 @@ object io {
                 }
             } yield {
                 src.close()
-                new Context(p.internal.threadSafeInstrs, input, Some(file.getName)).runParser()
+                new Context(p.internal.threadSafeInstrs, input, Some(file)).runParser()
             }
         }
     }

--- a/native/src/main/scala/parsley/io.scala
+++ b/native/src/main/scala/parsley/io.scala
@@ -33,7 +33,7 @@ object io {
                 }
             } yield {
                 src.close()
-                new Context(p.internal.threadSafeInstrs, input, Some(file)).runParser()
+                new Context(p.internal.threadSafeInstrs, input, Some(file.getName)).runParser()
             }
         }
     }

--- a/native/src/main/scala/parsley/io.scala
+++ b/native/src/main/scala/parsley/io.scala
@@ -7,6 +7,7 @@ import java.io.File
 import parsley.internal.machine.Context
 
 import scala.language.{higherKinds, implicitConversions}
+import parsley.errors.ErrorBuilder
 
 /** This module contains utilities to have parsers interact with IO, including the very useful `parseFromFile` method (exposed by `ParseFromIO`)
   * @since 3.0.0
@@ -22,7 +23,7 @@ object io {
          *         and a failure if an IOException occured
          * @since 3.0.0
          */
-        def parseFromFile(file: File)(implicit codec: Codec): Try[Result[A]] = {
+        def parseFromFile[Err: ErrorBuilder](file: File)(implicit codec: Codec): Try[Result[Err, A]] = {
             for {
                 src <- Try(Source.fromFile(file))
                 input <- Try(src.mkString).recoverWith {
@@ -32,7 +33,7 @@ object io {
                 }
             } yield {
                 src.close()
-                new Context(p.internal.threadSafeInstrs, input, Some(file.getName)).runParser()
+                new Context(p.internal.threadSafeInstrs, input, Some(file)).runParser()
             }
         }
     }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,3 +5,4 @@ addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.5.0")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.0.0")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.0")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.0.0")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.4.8") // This is here purely to enable the niceness settings

--- a/src/main/rootdoc.md
+++ b/src/main/rootdoc.md
@@ -33,6 +33,10 @@ is defined as being an object which mocks a package):
        lift where the function appears on the right and is applied on a tuple (useful when type
        inference has failed) as well as a `.zipped` method for building tuples out of several
        combinators.
+  - [[parsley.errors `parsley.errors`]] contains modules to deal with error messages, their refinement
+    and generation.
+     - [[parsley.errors.combinator$ `parsley.errors.combinator`]] provides combinators that can be
+       used to either produce more detailed errors as well as refine existing errors.
   - [[parsley.lift$ `parsley.lift`]] contains functions which lift functions that work on regular
     types to those which now combine the results of parsers returning those same types. these are
     ubiquitous.

--- a/src/main/scala/parsley/Parsley.scala
+++ b/src/main/scala/parsley/Parsley.scala
@@ -173,14 +173,6 @@ object Parsley
           * @return The result of the invokee if it fails the predicate
           */
         def filterNot(pred: A => Boolean): Parsley[A] = this.filter(!pred(_))
-        /** Filter the value of a parser; if the value returned by the parser is defined for the given partial function, then
-          * the `filterOut` fails, using the result of the function as the ''reason'' (see [[explain]]), otherwise the parser
-          * succeeds
-          * @param pred The predicate that is tested against the parser result
-          * @return The result of the invokee if the value failed the predicate
-          * @since 2.8.0
-          */
-        def filterOut(pred: PartialFunction[A, String]): Parsley[A] = new Parsley(new deepembedding.FilterOut(p.internal, pred))
         /** Attempts to first filter the parser to ensure that `pf` is defined over it. If it is, then the function `pf`
           * is mapped over its result. Roughly the same as a `filter` then a `map`.
           * @param pf The partial function
@@ -188,57 +180,6 @@ object Parsley
           * @since 2.0.0
           */
         def collect[B](pf: PartialFunction[A, B]): Parsley[B] = this.filter(pf.isDefinedAt).map(pf)
-        /** Attempts to first filter the parser to ensure that `pf` is defined over it. If it is, then the function `pf`
-          * is mapped over its result. Roughly the same as a `guard` then a `map`.
-          * @param pf The partial function
-          * @param msg The message used for the error if the input failed the check
-          * @return The result of applying `pf` to this parsers value (if possible), or fails
-          * @since 2.4.0
-          */
-        def collectMsg[B](msg: String)(pf: PartialFunction[A, B]): Parsley[B] = this.guardAgainst{case x if !pf.isDefinedAt(x) => msg}.map(pf)
-        /** Attempts to first filter the parser to ensure that `pf` is defined over it. If it is, then the function `pf`
-          * is mapped over its result. Roughly the same as a `guard` then a `map`.
-          * @param pf The partial function
-          * @param msggen Generator function for error message, generating a message based on the result of the parser
-          * @return The result of applying `pf` to this parsers value (if possible), or fails
-          * @since 2.4.0
-          */
-        def collectMsg[B](msggen: A => String)(pf: PartialFunction[A, B]): Parsley[B] = this.guardAgainst{case x if !pf.isDefinedAt(x) => msggen(x)}.map(pf)
-        /** Similar to `filterOut`, except the error message generated yields a ''true failure''. This means that it will
-          * uses the same mechanism as [[Parsley.fail]], as opposed to the reason provided by [[filterOut]]
-          * @param pred The predicate that is tested against the parser result and produces error messages
-          * @return The result of the invokee if it fails the predicate
-          * @since 2.8.0
-          */
-        def guardAgainst(pred: PartialFunction[A, String]): Parsley[A] = new Parsley(new deepembedding.GuardAgainst(p.internal, pred))
-        /**Alias for `label`*/
-        def ?(msg: String): Parsley[A] = this.label(msg)
-        /**Sets the expected message for a parser. If the parser fails then `expected msg` will added to the error
-          * @since 2.6.0 */
-        def label(msg: String): Parsley[A] = new Parsley(new deepembedding.ErrorLabel(p.internal, msg))
-        /** Similar to `label`, except instead of providing an expected message replacing the original tag, this combinator
-          * adds a ''reason'' that the error occurred. This is in complement to the label. The `reason` is only added when
-          * the parser fails, and will disappear if any further progress in the parser is made (unlike labels, which may
-          * reappear as "hints").
-          * @param reason The reason why a parser failed
-          * @since 2.7.0
-          */
-        def explain(reason: String): Parsley[A] = new Parsley(new deepembedding.ErrorExplain(p.internal, reason))
-        /**Hides the "expected" error message for a parser.*/
-        def hide: Parsley[A] = this.label("")
-        /** Same as `fail`, except allows for a message generated from the result of the failed parser. In essence, this
-          * is equivalent to `p >>= (x => fail(msggen(x))` but requires no expensive computations from the use of `>>=`.
-          * @param msggen The generator function for error message, creating a message based on the result of invokee
-          * @return A parser that fails if it succeeds, with the given generator used to produce the error message
-          */
-        def !(msggen: A => String): Parsley[Nothing] = new Parsley(new deepembedding.FastFail(p.internal, msggen))
-        /** Same as `unexpected`, except allows for a message generated from the result of the failed parser. In essence,
-          * this is equivalent to `p >>= (x => unexpected(x))` but requires no expensive computations from the use of
-          * `>>=`
-          * @param msggen The generator function for error message, creating a message based on the result of invokee
-          * @return A parser that fails if it succeeds, with the given generator used to produce an unexpected message
-          */
-        def unexpected(msggen: A => String): Parsley[Nothing] = new Parsley(new deepembedding.FastUnexpected(p.internal, msggen))
         /**
           * A fold for a parser: `p.foldRight(k)(f)` will try executing `p` many times until it fails, combining the
           * results with right-associative application of `f` with a `k` at the right-most position
@@ -410,12 +351,8 @@ object Parsley
       * in which case the keyword is actually an identifier. We can program this behaviour as follows:
       * {{{attempt(kw *> notFollowedBy(alphaNum))}}}*/
     def notFollowedBy(p: Parsley[_]): Parsley[Unit] = new Parsley(new deepembedding.NotFollowedBy(p.internal))
-    /** The `fail(msg)` parser consumes no input and fails with `msg` as the error message */
-    def fail(msg: String): Parsley[Nothing] = new Parsley(new deepembedding.Fail(msg))
     /** The `empty` parser consumes no input and fails softly (that is to say, no error message) */
     val empty: Parsley[Nothing] = new Parsley(new deepembedding.Empty)
-    /** The `unexpected(msg)` parser consumes no input and fails with `msg` as an unexpected error */
-    def unexpected(msg: String): Parsley[Nothing] = new Parsley(new deepembedding.Unexpected(msg))
     /** Returns `()`. Defined as `pure(())` but aliased for sugar*/
     val unit: Parsley[Unit] = pure(())
     /** converts a parser's result to () */

--- a/src/main/scala/parsley/Parsley.scala
+++ b/src/main/scala/parsley/Parsley.scala
@@ -9,6 +9,7 @@ import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.reflect.ClassTag
 import scala.language.{higherKinds, implicitConversions}
+import parsley.errors.ErrorBuilder
 
 // User API
 /**
@@ -45,7 +46,7 @@ final class Parsley[+A] private [parsley] (private [parsley] val internal: deepe
       * @return Either a success with a value of type `A` or a failure with error message
       * @since 3.0.0
       */
-    def parse(input: String): Result[A] = new Context(internal.threadSafeInstrs, input).runParser()
+    def parse[Err: ErrorBuilder](input: String): Result[Err, A] = new Context(internal.threadSafeInstrs, input).runParser()
 }
 /** This object contains the core "function-style" combinators as well as the implicit classes which provide
   * the "method-style" combinators. All parsers will likely require something from within! */

--- a/src/main/scala/parsley/Result.scala
+++ b/src/main/scala/parsley/Result.scala
@@ -7,7 +7,7 @@ import scala.util.hashing.MurmurHash3
 * Result of a parser. Either a `Success[A]` or a `Failure`
 * @tparam A The type of expected success result
 */
-sealed trait Result[+A]
+sealed trait Result[+Err, +A]
 {
     /** Applies `fa` if this is a `Failure` or `fb` if this is a `Success`.
       *
@@ -16,7 +16,7 @@ sealed trait Result[+A]
       * @return the results of applying the function
       * @since 1.7.0
       */
-    def fold[B](ferr: String => B, fa: A => B): B = this match {
+    def fold[B](ferr: Err => B, fa: A => B): B = this match {
         case Success(x)   => fa(x)
         case Failure(msg) => ferr(msg)
     }
@@ -47,7 +47,7 @@ sealed trait Result[+A]
     /** Returns this `Success` or the given argument if this is a `Failure`.
       * @since 1.7.0
       */
-    def orElse[B >: A](or: =>Result[B]): Result[B] = this match {
+    def orElse[B >: A, Err_ >: Err](or: =>Result[Err_, B]): Result[Err_, B] = this match {
         case Success(_) => this
         case _          => or
     }
@@ -84,9 +84,9 @@ sealed trait Result[+A]
       * @param f The function to bind across `Success`.
       * @since 1.7.0
       */
-    def flatMap[B](f: A => Result[B]): Result[B] = this match {
+    def flatMap[B, Err_ >: Err](f: A => Result[Err_, B]): Result[Err_, B] = this match {
         case Success(x) => f(x)
-        case _          => this.asInstanceOf[Result[B]]
+        case _          => this.asInstanceOf[Result[Err, B]]
     }
 
     /** Returns the right value if this is right
@@ -95,14 +95,14 @@ sealed trait Result[+A]
       * Equivalent to `flatMap(id => id)`
       * @since 1.7.0
       */
-    def flatten[B](implicit ev: A <:< Result[B]): Result[B] = flatMap(ev)
+    def flatten[B, Err_ >: Err](implicit ev: A <:< Result[Err_, B]): Result[Err_, B] = flatMap(ev)
 
     /** The given function is applied if this is a `Success`.
       * @since 1.7.0
       */
-    def map[B](f: A => B): Result[B] = this match {
+    def map[B](f: A => B): Result[Err, B] = this match {
         case Success(x) => Success(f(x))
-        case _          => this.asInstanceOf[Result[B]]
+        case _          => this.asInstanceOf[Result[Err, B]]
     }
 
     /** Returns `Success` with the existing value of `Success` if this is a `Success`
@@ -111,7 +111,7 @@ sealed trait Result[+A]
       * or `Failure` with the existing value of `Failure` if this is a `Failure`.
       * @since 1.7.0
       */
-    def filterOrElse(p: A => Boolean, msg: =>String): Result[A] = this match {
+    def filterOrElse[Err_ >: Err](p: A => Boolean, msg: =>Err_): Result[Err_, A] = this match {
         case Success(x) if !p(x) => Failure(msg)
         case _                   => this
     }
@@ -142,10 +142,10 @@ sealed trait Result[+A]
         case Failure(msg) => TFailure(new Exception(s"ParseError: $msg"))
     }
 
-    /** Converts the `Result` into a `Either` where `Failure` maps to a `Left[String]`
+    /** Converts the `Result` into a `Either` where `Failure` maps to a `Left[Err]`
       * @since 1.7.0
       */
-    def toEither: Either[String, A] = this match {
+    def toEither: Either[Err, A] = this match {
         case Success(x)   => Right(x)
         case Failure(msg) => Left(msg)
     }
@@ -166,7 +166,7 @@ sealed trait Result[+A]
   * @param x The result value of the successful parse
   * @tparam A The type of expected success result
   */
-case class Success[A] private [parsley] (x: A) extends Result[A]
+case class Success[A] private [parsley] (x: A) extends Result[Nothing, A]
 {
     override def isSuccess: Boolean = true
     override def isFailure: Boolean = false
@@ -178,9 +178,9 @@ case class Success[A] private [parsley] (x: A) extends Result[A]
   * @param msg The error message reported by the parser
   */
 //case class Failure private [parsley] (msg: String) extends Result[Nothing]
-class Failure private [parsley] (_msg: =>String) extends Result[Nothing] with Product with Serializable
+class Failure[Err] private [parsley] (_msg: =>Err) extends Result[Err, Nothing] with Product with Serializable
 {
-    lazy val msg: String = _msg
+    lazy val msg: Err = _msg
     override def isSuccess: Boolean = false
     override def isFailure: Boolean = true
     override def get: Nothing = throw new NoSuchElementException("get called on Failure")
@@ -188,23 +188,23 @@ class Failure private [parsley] (_msg: =>String) extends Result[Nothing] with Pr
     // $COVERAGE-OFF$
     override def toString: String = s"Failure($msg)"
     override def hashCode: Int = MurmurHash3.productHash(this)
-    override def canEqual(x: Any): Boolean = x.isInstanceOf[Failure]
+    override def canEqual(x: Any): Boolean = x.isInstanceOf[Failure[_]]
     override def productPrefix: String = "Failure"
     override def productArity: Int = 1
     override def productElement(idx: Int): Any = {
         if (idx != 0) throw new IndexOutOfBoundsException("Failure only has arity 1") else msg
     }
     override def equals(x: Any): Boolean = x != null && (x match {
-        case x: Failure => x.msg == msg
+        case x: Failure[_] => x.msg == msg
     })
-    def copy(msg: =>String = this.msg): Failure = new Failure(msg)
+    def copy(msg: =>Err = this.msg): Failure[Err] = new Failure(msg)
     // $COVERAGE-ON$
 }
 // $COVERAGE-OFF$
 object Failure {
-    def apply(msg: =>String): Failure = new Failure(msg)
-    def unapply(x: Failure): Some[String] = Some(x.msg)
-    def andThen[A](f: Failure => A): String => A = msg => f(Failure(msg))
-    def compose[A](f: A => String): A => Failure = msg => Failure(f(msg))
+    def apply[Err](msg: =>Err): Failure[Err] = new Failure(msg)
+    def unapply[Err](x: Failure[Err]): Some[Err] = Some(x.msg)
+    def andThen[A, Err](f: Failure[Err] => A): Err => A = msg => f(Failure(msg))
+    def compose[A, Err](f: A => Err): A => Failure[Err] = msg => Failure(f(msg))
 }
 // $COVERAGE-ON$

--- a/src/main/scala/parsley/errors/ErrorBuilder.scala
+++ b/src/main/scala/parsley/errors/ErrorBuilder.scala
@@ -1,0 +1,136 @@
+package parsley.errors
+
+import java.io.File
+import scala.util.matching.Regex
+
+trait ErrorBuilder[Err] {
+    private [errors] final type _Err = Err
+
+    def format(pos: Position, source: Context, ctxs: NestedContexts, lines: ErrorInfoLines): Err
+
+    type Position
+    type Context
+    def pos(line: Int, col: Int): Position
+    def source(sourceName: Option[File]): Context
+    def contexualScope(context: String): Context
+
+    type NestedContexts
+    def nestContexts(contexts: List[Context]): NestedContexts
+
+    type ErrorInfoLines
+    def vanillaError(unexpected: UnexpectedLine, expected: ExpectedLine, reasons: Messages, line: LineInfo): ErrorInfoLines
+    def specialisedError(msgs: Messages, line: LineInfo): ErrorInfoLines
+
+    type ExpectedItems
+    type Messages
+    def combineExpectedItems(alts: Set[Item]): ExpectedItems
+    def combineMessages(alts: Set[Message]): Messages
+
+    type UnexpectedLine
+    type ExpectedLine
+    type Message
+    type LineInfo
+    def unexpected(item: Option[Item]): UnexpectedLine
+    def expected(alts: ExpectedItems): ExpectedLine
+    def reason(reason: String): Message
+    def message(msg: String): Message
+    def lineInfo(line: String, errorPointsAt: Int): LineInfo
+
+    type Item
+    type Raw <: Item
+    type Named <: Item
+    type EndOfInput <: Item
+    def raw(item: String): Raw
+    def named(item: String): Named
+    val endOfInput: EndOfInput
+}
+
+object ErrorBuilder {
+    implicit val stringError: ErrorBuilder[String] = new ErrorBuilder[String] {
+
+        override def format(pos: Position, source: Context, ctxs: NestedContexts, lines: ErrorInfoLines): String = {
+            s"${mergeScopes(source, ctxs)}$pos:\n${lines.mkString("  ", "\n  ", "")}"
+        }
+
+        protected def mergeScopes(source: Context, ctxs: NestedContexts): String = (source, ctxs) match {
+            case (None, None) => ""
+            case (Some(name), None) => s"In $name"
+            case (None, Some(ctxs)) => s"In $ctxs"
+            case (Some(name), Some(ctxs)) => s"In $name, $ctxs"
+        }
+
+        type Position = String
+        type Context = Option[String]
+        override def pos(line: Int, col: Int): Position = s"(line $line, column $col)"
+        override def source(sourceName: Option[File]): Context = sourceName.map(name => s"file '${name.getName}' ")
+        override def contexualScope(context: String): Context = Some(context)
+
+        type NestedContexts = Option[String]
+        override def nestContexts(contexts: List[Context]): NestedContexts = {
+            val nonEmptyContexts = contexts.flatten
+            if (nonEmptyContexts.nonEmpty) Some(nonEmptyContexts.mkString(", "))
+            else None
+        }
+
+        type ErrorInfoLines = List[String]
+        override def vanillaError(unexpected: UnexpectedLine, expected: ExpectedLine, reasons: Messages, line: LineInfo): ErrorInfoLines = {
+            val (src, caret) = line
+            val reasons_ = reasons.collect {
+                case reason if reason.nonEmpty => Some(reason)
+            }
+            combineOrUnknown((unexpected :: expected :: reasons_).flatten, src, caret)
+        }
+        override def specialisedError(msgs: Messages, line: LineInfo): ErrorInfoLines = {
+            val (src, caret) = line
+            combineOrUnknown(msgs, src, caret)
+        }
+
+        private def combineOrUnknown(info: List[String], line: String, caret: String): ErrorInfoLines = {
+            if (info.isEmpty) List(Unknown, line, caret)
+            else info ++ List(line, caret)
+        }
+
+        type ExpectedItems = Option[String]
+        type Messages = List[Message]
+        override def combineExpectedItems(alts: Set[Item]): ExpectedItems = alts.toList.sorted.reverse.filter(_.nonEmpty) match {
+            case Nil => None
+            case List(alt) => Some(alt)
+            case List(alt1, alt2) => Some(s"$alt2 or $alt1")
+            // If the result would contains "," then it's probably nicer to preserve any potential grouping using ";"
+            case any@(alt::alts) if any.exists(_.contains(",")) => Some(s"${alts.reverse.mkString("; ")}; or $alt")
+            case alt::alts => Some(s"${alts.reverse.mkString(", ")}, or $alt")
+        }
+        override def combineMessages(alts: Set[Message]): Messages = alts.filter(_.nonEmpty).toList
+
+        type UnexpectedLine = Option[String]
+        type ExpectedLine = Option[String]
+        type Message = String
+        type LineInfo = (String, String)
+        override def unexpected(item: Option[Item]): UnexpectedLine = item.map("unexpected " + _)
+        override def expected(alts: ExpectedItems): ExpectedLine = alts.map("expected " + _)
+        override def reason(reason: String): Message = reason
+        override def message(msg: String): Message = msg
+        override def lineInfo(line: String, errorPointsAt: Int): LineInfo = (s"$errorLineStart$line", s"$errorLineStart${errorPointer(errorPointsAt)}")
+
+        private val errorLineStart = ">"
+        private def errorPointer(caretAt: Int) = s"${" " * caretAt}^"
+
+        type Item = String
+        type Raw = String
+        type Named = String
+        type EndOfInput = String
+        override def raw(item: String): Raw = item match {
+            case "\n"            => "newline"
+            case "\t"            => "tab"
+            case " "             => "space"
+            case Unprintable(up) => f"unprintable character (\\u${up.head.toInt}%04X)"
+            // Do we want this only in unexpecteds?
+            case cs              => "\"" + cs.takeWhile(c => c != '\n' && c != ' ') + "\""
+        }
+        override def named(item: String): Named = item
+        override val endOfInput: EndOfInput = "end of input"
+
+        private val Unprintable: Regex = "(\\p{C})".r
+        private val Unknown = "unknown parse error"
+    }
+}

--- a/src/main/scala/parsley/errors/ErrorBuilder.scala
+++ b/src/main/scala/parsley/errors/ErrorBuilder.scala
@@ -1,6 +1,5 @@
 package parsley.errors
 
-import java.io.File
 import scala.util.matching.Regex
 
 trait ErrorBuilder[Err] {
@@ -11,7 +10,7 @@ trait ErrorBuilder[Err] {
     type Position
     type Context
     def pos(line: Int, col: Int): Position
-    def source(sourceName: Option[File]): Context
+    def source(sourceName: Option[String]): Context
     def contexualScope(context: String): Context
 
     type NestedContexts
@@ -54,15 +53,15 @@ object ErrorBuilder {
 
         protected def mergeScopes(source: Context, ctxs: NestedContexts): String = (source, ctxs) match {
             case (None, None) => ""
-            case (Some(name), None) => s"In $name"
-            case (None, Some(ctxs)) => s"In $ctxs"
-            case (Some(name), Some(ctxs)) => s"In $name, $ctxs"
+            case (Some(name), None) => s"In $name "
+            case (None, Some(ctxs)) => s"In $ctxs "
+            case (Some(name), Some(ctxs)) => s"In $name, $ctxs "
         }
 
         type Position = String
         type Context = Option[String]
         override def pos(line: Int, col: Int): Position = s"(line $line, column $col)"
-        override def source(sourceName: Option[File]): Context = sourceName.map(name => s"file '${name.getName}' ")
+        override def source(sourceName: Option[String]): Context = sourceName.map(name => s"file '$name'")
         override def contexualScope(context: String): Context = Some(context)
 
         type NestedContexts = Option[String]

--- a/src/main/scala/parsley/errors/combinator.scala
+++ b/src/main/scala/parsley/errors/combinator.scala
@@ -1,0 +1,87 @@
+package parsley.errors
+
+import parsley.Parsley
+import parsley.internal.deepembedding
+
+import parsley.combinator.choice
+
+/** This module contains combinators that can be used to directly influence error messages of parsers.
+  * @since 3.0.0
+  */
+object combinator {
+    /**
+      * The `fail(msgs)` parser consumes no input and fails with `msg` as the error message
+      * @since 3.0.0
+      */
+    def fail(msgs: String*): Parsley[Nothing] = choice(msgs.map(msg => new Parsley(new deepembedding.Fail(msg))): _*)
+
+    /**
+      * The `unexpected(msg)` parser consumes no input and fails with `msg` as an unexpected error
+      * @since 3.0.0
+      */
+    def unexpected(msg: String): Parsley[Nothing] = new Parsley(new deepembedding.Unexpected(msg))
+
+    implicit final class ErrorMethods[P, +A](p: =>P)(implicit con: P => Parsley[A]) {
+        /** Filter the value of a parser; if the value returned by the parser is defined for the given partial function, then
+          * the `filterOut` fails, using the result of the function as the ''reason'' (see [[explain]]), otherwise the parser
+          * succeeds
+          * @param pred The predicate that is tested against the parser result
+          * @return The result of the invokee if the value failed the predicate
+          * @since 3.0.0
+          */
+        def filterOut(pred: PartialFunction[A, String]): Parsley[A] = new Parsley(new deepembedding.FilterOut(p.internal, pred))
+        /** Attempts to first filter the parser to ensure that `pf` is defined over it. If it is, then the function `pf`
+          * is mapped over its result. Roughly the same as a `guard` then a `map`.
+          * @param pf The partial function
+          * @param msg The message used for the error if the input failed the check
+          * @return The result of applying `pf` to this parsers value (if possible), or fails
+          * @since 3.0.0
+          */
+        def collectMsg[B](msg: String)(pf: PartialFunction[A, B]): Parsley[B] = this.guardAgainst{case x if !pf.isDefinedAt(x) => msg}.map(pf)
+        /** Attempts to first filter the parser to ensure that `pf` is defined over it. If it is, then the function `pf`
+          * is mapped over its result. Roughly the same as a `guard` then a `map`.
+          * @param pf The partial function
+          * @param msggen Generator function for error message, generating a message based on the result of the parser
+          * @return The result of applying `pf` to this parsers value (if possible), or fails
+          * @since 3.0.0
+          */
+        def collectMsg[B](msggen: A => String)(pf: PartialFunction[A, B]): Parsley[B] = this.guardAgainst{case x if !pf.isDefinedAt(x) => msggen(x)}.map(pf)
+        /** Similar to `filterOut`, except the error message generated yields a ''true failure''. This means that it will
+          * uses the same mechanism as [[Parsley.fail]], as opposed to the reason provided by [[filterOut]]
+          * @param pred The predicate that is tested against the parser result and produces error messages
+          * @return The result of the invokee if it fails the predicate
+          * @since 2.8.0
+          */
+        def guardAgainst(pred: PartialFunction[A, String]): Parsley[A] = new Parsley(new deepembedding.GuardAgainst(p.internal, pred))
+        /** Alias for `label`
+          * @since 3.0.0 */
+        def ?(msg: String): Parsley[A] = this.label(msg)
+        /** Sets the expected message for a parser. If the parser fails then `expected msg` will added to the error
+          * @since 3.0.0 */
+        def label(msg: String): Parsley[A] = new Parsley(new deepembedding.ErrorLabel(p.internal, msg))
+        /** Similar to `label`, except instead of providing an expected message replacing the original tag, this combinator
+          * adds a ''reason'' that the error occurred. This is in complement to the label. The `reason` is only added when
+          * the parser fails, and will disappear if any further progress in the parser is made (unlike labels, which may
+          * reappear as "hints").
+          * @param reason The reason why a parser failed
+          * @since 3.0.0
+          */
+        def explain(reason: String): Parsley[A] = new Parsley(new deepembedding.ErrorExplain(p.internal, reason))
+        /** Hides the "expected" error message for a parser.
+          * @since 3.0.0 */
+        def hide: Parsley[A] = this.label("")
+        /** Same as `fail`, except allows for a message generated from the result of the failed parser. In essence, this
+          * is equivalent to `p >>= (x => fail(msggen(x))` but requires no expensive computations from the use of `>>=`.
+          * @param msggen The generator function for error message, creating a message based on the result of invokee
+          * @return A parser that fails if it succeeds, with the given generator used to produce the error message
+          */
+        def !(msggen: A => String): Parsley[Nothing] = new Parsley(new deepembedding.FastFail(p.internal, msggen))
+        /** Same as `unexpected`, except allows for a message generated from the result of the failed parser. In essence,
+          * this is equivalent to `p >>= (x => unexpected(x))` but requires no expensive computations from the use of
+          * `>>=`
+          * @param msggen The generator function for error message, creating a message based on the result of invokee
+          * @return A parser that fails if it succeeds, with the given generator used to produce an unexpected message
+          */
+        def unexpected(msggen: A => String): Parsley[Nothing] = new Parsley(new deepembedding.FastUnexpected(p.internal, msggen))
+    }
+}

--- a/src/main/scala/parsley/errors/revisions.scala
+++ b/src/main/scala/parsley/errors/revisions.scala
@@ -1,0 +1,15 @@
+package parsley.errors
+
+/** Revisions help to ensure backwards-compatibility when the `ErrorBuilder` API changes.
+  * By mixing in a `Revision` to your instances, you are advertising that you want to remain
+  * compatible with that version of the API. If the API changes with ''minor'' version
+  * increases, then the revision mixed in will implement a compatiblity layer to ensure
+  * that your code should still compile. If you want to opt into a more recent revision,
+  * you just change the mixin. A ''major'' version bump will clear the revisions back to
+  * `Revision0` again.
+  * @since 3.0.0
+  */
+object revisions {
+    /** @since 3.0.0 */
+    trait Revision0 { this: ErrorBuilder[_] => }
+}

--- a/src/main/scala/parsley/internal/errors/Builders.scala
+++ b/src/main/scala/parsley/internal/errors/Builders.scala
@@ -1,14 +1,13 @@
 package parsley.internal.errors
 
-private [internal] abstract class LineBuilder {
-    final private [errors] def getLineWithCaret(offset: Int): (String, String) = {
+private [parsley] abstract class LineBuilder {
+    final def getLineWithCaret(offset: Int): (String, Int) = {
         // FIXME: Tabs man... tabs
         val startOffset = nearestNewlineBefore(offset)
         val endOffset = nearestNewlineAfter(offset)
         val segment = segmentBetween(startOffset, endOffset)
         val caretAt = offset - startOffset
-        val caretPad = " " * caretAt
-        (segment.replace('\t', ' '), s"$caretPad^")
+        (segment.replace('\t', ' '), caretAt)
     }
 
     protected def nearestNewlineBefore(off: Int): Int

--- a/src/main/scala/parsley/internal/errors/ErrorItem.scala
+++ b/src/main/scala/parsley/internal/errors/ErrorItem.scala
@@ -1,0 +1,36 @@
+package parsley.internal.errors
+
+import Raw.Unprintable
+import scala.util.matching.Regex
+
+private [internal] sealed trait ErrorItem {
+    val msg: String
+}
+private [internal] object ErrorItem {
+    def higherPriority(e1: ErrorItem, e2: ErrorItem): ErrorItem = (e1, e2) match {
+        case (EndOfInput, _) => EndOfInput
+        case (_, EndOfInput) => EndOfInput
+        case (e: Desc, _) => e
+        case (_, e: Desc) => e
+        case (Raw(r1), Raw(r2)) => if (r1.length >= r2.length) e1 else e2
+    }
+}
+private [internal] case class Raw(cs: String) extends ErrorItem {
+    // This could be marked threadUnsafe in Scala 3?
+    override lazy val msg = cs match {
+        case "\n"            => "newline"
+        case "\t"            => "tab"
+        case " "             => "space"
+        case Unprintable(up) => f"unprintable character (\\u${up.head.toInt}%04X)"
+        // Do we want this only in unexpecteds?
+        case cs              => "\"" + cs.takeWhile(c => c != '\n' && c != ' ') + "\""
+    }
+}
+private [internal] object Raw {
+    val Unprintable: Regex = "(\\p{C})".r
+    def apply(c: Char): Raw = new Raw(s"$c")
+}
+private [internal] case class Desc(msg: String) extends ErrorItem
+private [internal] case object EndOfInput extends ErrorItem {
+    override val msg = "end of input"
+}

--- a/src/main/scala/parsley/internal/errors/ErrorItem.scala
+++ b/src/main/scala/parsley/internal/errors/ErrorItem.scala
@@ -1,10 +1,9 @@
 package parsley.internal.errors
 
-import Raw.Unprintable
-import scala.util.matching.Regex
+import parsley.errors.ErrorBuilder
 
 private [internal] sealed trait ErrorItem {
-    val msg: String
+    def format[Err](implicit builder: ErrorBuilder[Err]): builder.Item
 }
 private [internal] object ErrorItem {
     def higherPriority(e1: ErrorItem, e2: ErrorItem): ErrorItem = (e1, e2) match {
@@ -16,21 +15,14 @@ private [internal] object ErrorItem {
     }
 }
 private [internal] case class Raw(cs: String) extends ErrorItem {
-    // This could be marked threadUnsafe in Scala 3?
-    override lazy val msg = cs match {
-        case "\n"            => "newline"
-        case "\t"            => "tab"
-        case " "             => "space"
-        case Unprintable(up) => f"unprintable character (\\u${up.head.toInt}%04X)"
-        // Do we want this only in unexpecteds?
-        case cs              => "\"" + cs.takeWhile(c => c != '\n' && c != ' ') + "\""
-    }
+    def format[Err](implicit builder: ErrorBuilder[Err]): builder.Item = builder.raw(cs)
 }
 private [internal] object Raw {
-    val Unprintable: Regex = "(\\p{C})".r
     def apply(c: Char): Raw = new Raw(s"$c")
 }
-private [internal] case class Desc(msg: String) extends ErrorItem
+private [internal] case class Desc(msg: String) extends ErrorItem {
+    def format[Err](implicit builder: ErrorBuilder[Err]): builder.Item = builder.named(msg)
+}
 private [internal] case object EndOfInput extends ErrorItem {
-    override val msg = "end of input"
+    def format[Err](implicit builder: ErrorBuilder[Err]): builder.Item = builder.endOfInput
 }

--- a/src/main/scala/parsley/internal/errors/ParseError.scala
+++ b/src/main/scala/parsley/internal/errors/ParseError.scala
@@ -1,17 +1,15 @@
 package parsley.internal.errors
 
 import ParseError.Unknown
-import Raw.Unprintable
-import scala.util.matching.Regex
 
-private [internal] sealed abstract class ParseError {
+private [internal] sealed trait ParseError {
     val offset: Int
     val col: Int
     val line: Int
 
     def withHints(hints: Set[ErrorItem]): ParseError
     def giveReason(reason: String): ParseError
-    def pretty(sourceName: Option[String])(implicit helper: LineBuilder): String
+    private [internal] def pretty(sourceName: Option[String])(implicit helper: LineBuilder): String
 
     protected final def posStr(sourceName: Option[String]): String = {
         val scopeName = sourceName.fold("")(name => s"In file '$name' ")
@@ -31,7 +29,7 @@ private [internal] sealed abstract class ParseError {
         val topStr = posStr(sourceName)
         val (line, caret) = helper.getLineWithCaret(offset)
         val info = infoLines.filter(_.nonEmpty).mkString("\n  ")
-        s"$topStr:\n  ${if (info.isEmpty) Unknown else info}\n  >${line}\n  >${caret}"
+        s"$topStr:\n  ${if (info.isEmpty) Unknown else info}\n  >${line}\n  >${" " * caret}^"
     }
 }
 // The reasons here are lightweight, two errors can merge their messages, but messages do not get converted to hints
@@ -60,36 +58,4 @@ private [internal] object ParseError {
     val Unknown = "unknown parse error"
     val NoReason = Set.empty[String]
     val NoItems = Set.empty[ErrorItem]
-}
-
-private [internal] sealed trait ErrorItem {
-    val msg: String
-}
-private [internal] object ErrorItem {
-    def higherPriority(e1: ErrorItem, e2: ErrorItem): ErrorItem = (e1, e2) match {
-        case (EndOfInput, _) => EndOfInput
-        case (_, EndOfInput) => EndOfInput
-        case (e: Desc, _) => e
-        case (_, e: Desc) => e
-        case (Raw(r1), Raw(r2)) => if (r1.length >= r2.length) e1 else e2
-    }
-}
-private [internal] case class Raw(cs: String) extends ErrorItem {
-    // This could be marked threadUnsafe in Scala 3?
-    override lazy val msg = cs match {
-        case "\n"            => "newline"
-        case "\t"            => "tab"
-        case " "             => "space"
-        case Unprintable(up) => f"unprintable character (\\u${up.head.toInt}%04X)"
-        // Do we want this only in unexpecteds?
-        case cs              => "\"" + cs.takeWhile(c => c != '\n' && c != ' ') + "\""
-    }
-}
-private [internal] object Raw {
-    val Unprintable: Regex = "(\\p{C})".r
-    def apply(c: Char): Raw = new Raw(s"$c")
-}
-private [internal] case class Desc(msg: String) extends ErrorItem
-private [internal] case object EndOfInput extends ErrorItem {
-    override val msg = "end of input"
 }

--- a/src/main/scala/parsley/internal/errors/ParseError.scala
+++ b/src/main/scala/parsley/internal/errors/ParseError.scala
@@ -1,6 +1,7 @@
 package parsley.internal.errors
 
-import ParseError.Unknown
+import parsley.errors.ErrorBuilder
+import java.io.File
 
 private [internal] sealed trait ParseError {
     val offset: Int
@@ -9,27 +10,11 @@ private [internal] sealed trait ParseError {
 
     def withHints(hints: Set[ErrorItem]): ParseError
     def giveReason(reason: String): ParseError
-    private [internal] def pretty(sourceName: Option[String])(implicit helper: LineBuilder): String
-
-    protected final def posStr(sourceName: Option[String]): String = {
-        val scopeName = sourceName.fold("")(name => s"In file '$name' ")
-        s"$scopeName(line $line, column $col)"
-    }
-
-    protected final def disjunct(alts: List[String]): Option[String] = alts.sorted.reverse.filter(_.nonEmpty) match {
-        case Nil => None
-        case List(alt) => Some(alt)
-        case List(alt1, alt2) => Some(s"$alt2 or $alt1")
-        // If the result would contains "," then it's probably nicer to preserve any potential grouping using ";"
-        case any@(alt::alts) if any.exists(_.contains(",")) => Some(s"${alts.reverse.mkString("; ")}; or $alt")
-        case alt::alts => Some(s"${alts.reverse.mkString(", ")}, or $alt")
-    }
-
-    protected final def assemble(sourceName: Option[String], infoLines: List[String])(implicit helper: LineBuilder): String = {
-        val topStr = posStr(sourceName)
-        val (line, caret) = helper.getLineWithCaret(offset)
-        val info = infoLines.filter(_.nonEmpty).mkString("\n  ")
-        s"$topStr:\n  ${if (info.isEmpty) Unknown else info}\n  >${line}\n  >${" " * caret}^"
+    protected def format[Err](line: String, caret: Int)(implicit builder: ErrorBuilder[Err]): builder.ErrorInfoLines
+    private [internal] final def format[Err](sourceName: Option[File])(implicit helper: LineBuilder, builder: ErrorBuilder[Err]): Err = {
+        val (errLine, caret) = helper.getLineWithCaret(offset)
+        val lines = format(errLine, caret)
+        builder.format(builder.pos(line, col), builder.source(sourceName), builder.nestContexts(Nil), lines)
     }
 }
 // The reasons here are lightweight, two errors can merge their messages, but messages do not get converted to hints
@@ -39,23 +24,25 @@ private [internal] case class TrivialError(offset: Int, line: Int, col: Int,
     def withHints(hints: Set[ErrorItem]): ParseError = copy(expecteds = expecteds union hints)
     def giveReason(reason: String): ParseError = copy(reasons = reasons + reason)
 
-    def pretty(sourceName: Option[String])(implicit helper: LineBuilder): String = {
-        assemble(sourceName, List(unexpectedInfo, expectedInfo).flatten ::: reasons.toList)
+    def format[Err](line: String, caret: Int)(implicit builder: ErrorBuilder[Err]): builder.ErrorInfoLines = {
+        builder.vanillaError(
+            builder.unexpected(unexpected.map(_.format)),
+            builder.expected(builder.combineExpectedItems(expecteds.map(_.format))),
+            builder.combineMessages(reasons.map(builder.reason(_))),
+            builder.lineInfo(line, caret))
     }
-
-    private def unexpectedInfo: Option[String] = unexpected.map(u => s"unexpected ${u.msg}")
-    private def expectedInfo: Option[String] = disjunct(expecteds.map(_.msg).toList).map(es => s"expected $es")
 }
 private [internal] case class FailError(offset: Int, line: Int, col: Int, msgs: Set[String]) extends ParseError {
     def withHints(hints: Set[ErrorItem]): ParseError = this
     def giveReason(reason: String): ParseError = this
-    def pretty(sourceName: Option[String])(implicit helper: LineBuilder): String = {
-        assemble(sourceName, msgs.toList)
+    def format[Err](line: String, caret: Int)(implicit builder: ErrorBuilder[Err]): builder.ErrorInfoLines = {
+        builder.specialisedError(
+            builder.combineMessages(msgs.map(builder.message(_))),
+            builder.lineInfo(line, caret))
     }
 }
 
 private [internal] object ParseError {
-    val Unknown = "unknown parse error"
     val NoReason = Set.empty[String]
     val NoItems = Set.empty[ErrorItem]
 }

--- a/src/main/scala/parsley/internal/errors/ParseError.scala
+++ b/src/main/scala/parsley/internal/errors/ParseError.scala
@@ -1,7 +1,6 @@
 package parsley.internal.errors
 
 import parsley.errors.ErrorBuilder
-import java.io.File
 
 private [internal] sealed trait ParseError {
     val offset: Int
@@ -11,7 +10,7 @@ private [internal] sealed trait ParseError {
     def withHints(hints: Set[ErrorItem]): ParseError
     def giveReason(reason: String): ParseError
     protected def format[Err](line: String, caret: Int)(implicit builder: ErrorBuilder[Err]): builder.ErrorInfoLines
-    private [internal] final def format[Err](sourceName: Option[File])(implicit helper: LineBuilder, builder: ErrorBuilder[Err]): Err = {
+    private [internal] final def format[Err](sourceName: Option[String])(implicit helper: LineBuilder, builder: ErrorBuilder[Err]): Err = {
         val (errLine, caret) = helper.getLineWithCaret(offset)
         val lines = format(errLine, caret)
         builder.format(builder.pos(line, col), builder.source(sourceName), builder.nestContexts(Nil), lines)

--- a/src/main/scala/parsley/internal/machine/Context.scala
+++ b/src/main/scala/parsley/internal/machine/Context.scala
@@ -12,7 +12,6 @@ import parsley.internal.machine.errors.{
 
 import scala.annotation.tailrec
 import scala.collection.mutable
-import java.io.File
 import parsley.errors.ErrorBuilder
 
 private [parsley] object Context {
@@ -22,7 +21,7 @@ private [parsley] object Context {
 
 private [parsley] final class Context(private [machine] var instrs: Array[Instr],
                                       private [machine] var input: String,
-                                      private val sourceFile: Option[File] = None) {
+                                      private val sourceFile: Option[String] = None) {
     /** This is the operand stack, where results go to live  */
     private [machine] val stack: ArrayStack[Any] = new ArrayStack()
     /** Current offset into the input */

--- a/src/main/scala/parsley/internal/machine/Context.scala
+++ b/src/main/scala/parsley/internal/machine/Context.scala
@@ -12,6 +12,8 @@ import parsley.internal.machine.errors.{
 
 import scala.annotation.tailrec
 import scala.collection.mutable
+import java.io.File
+import parsley.errors.ErrorBuilder
 
 private [parsley] object Context {
     private [Context] val NumRegs = 4
@@ -20,7 +22,7 @@ private [parsley] object Context {
 
 private [parsley] final class Context(private [machine] var instrs: Array[Instr],
                                       private [machine] var input: String,
-                                      private val sourceName: Option[String] = None) {
+                                      private val sourceFile: Option[File] = None) {
     /** This is the operand stack, where results go to live  */
     private [machine] val stack: ArrayStack[Any] = new ArrayStack()
     /** Current offset into the input */
@@ -123,17 +125,17 @@ private [parsley] final class Context(private [machine] var instrs: Array[Instr]
     }
     // $COVERAGE-ON$
 
-    @tailrec @inline private [parsley] def runParser[A](): Result[A] = {
+    @tailrec @inline private [parsley] def runParser[Err: ErrorBuilder, A](): Result[Err, A] = {
         //println(pretty)
-        if (status eq Failed) Failure(errs.error.asParseError.pretty(sourceName))
+        if (status eq Failed) Failure(errs.error.asParseError.format(sourceFile))
         else if (pc < instrs.length) {
             instrs(pc)(this)
-            runParser[A]()
+            runParser[Err, A]()
         }
         else if (calls.isEmpty) Success(stack.peek[A])
         else {
             ret()
-            runParser[A]()
+            runParser[Err, A]()
         }
     }
 

--- a/src/main/scala/parsley/registers.scala
+++ b/src/main/scala/parsley/registers.scala
@@ -93,6 +93,15 @@ object registers {
       */
     def put[S](r: Reg[S], p: =>Parsley[S]): Parsley[Unit] = new Parsley(new deepembedding.Put(r, p.internal))
     /**
+      * Places the result of running `p` into register `r`.
+      * @note There are only 4 registers at present.
+      * @param r The index of the register to place the value in
+      * @param p The parser to derive the value from
+      * @param f A function which adapts the result of `p` so that it can fit in `r`
+      * @since 3.0.0
+      */
+    def puts[A, S](r: Reg[S], p: =>Parsley[A], f: A => S): Parsley[Unit] = put(r.asInstanceOf[Reg[A]], p) *> modify(r, f.asInstanceOf[S => S])
+    /**
       * Modifies the value contained in register `r` using function `f`.
       * @note There are only 4 registers at present.
       * @param r The index of the register to modify
@@ -133,7 +142,7 @@ object registers {
       * @return The parser that performs `p` with the modified state
       * @since 2.2.0
       */
-    def local[R, A](r: Reg[R], f: R => R, p: =>Parsley[A]): Parsley[A] = local(r, get[R](r).map(f), p)
+    def local[R, A](r: Reg[R], f: R => R, p: =>Parsley[A]): Parsley[A] = local(r, gets(r, f), p)
 
     /** `rollback(reg, p)` will perform `p`, but if it fails without consuming input, any changes to the register `reg` will
       * be reverted.

--- a/src/main/scala/parsley/token/Lexer.scala
+++ b/src/main/scala/parsley/token/Lexer.scala
@@ -275,8 +275,7 @@ class Lexer(lang: LanguageDef)
 
     private def enclosing[A](p: =>Parsley[A], open: Char, close: Char, singular: String, plural: String) =
         between(lexeme(open.unsafeLabel(s"open $singular")),
-                //TODO: This use of fail is probably inappropriate with the new error message model
-                lexeme(close.unsafeLabel(s"matching closing $singular")) <|> fail(s"unclosed $plural"),
+                lexeme(close.unsafeLabel(s"matching closing $singular").explain(s"unclosed $plural")),
                 p)
 
     // Bracketing

--- a/src/main/scala/parsley/token/Lexer.scala
+++ b/src/main/scala/parsley/token/Lexer.scala
@@ -4,7 +4,8 @@ import parsley.character.{digit, hexDigit, octDigit, satisfy}
 import parsley.combinator.{sepBy, sepBy1, between, many, skipMany, some, skipSome}
 import parsley.lift.lift2
 import parsley.internal.deepembedding.Sign.{DoubleType, IntType, SignType}
-import parsley.Parsley, Parsley.{void, unit, fail, attempt, pure, empty, notFollowedBy, LazyParsley}
+import parsley.Parsley, Parsley.{void, unit, attempt, pure, empty, notFollowedBy, LazyParsley}
+import parsley.errors.combinator.{fail, ErrorMethods}
 import parsley.token.TokenSet
 import parsley.implicits.character.{charLift, stringLift}
 import parsley.internal.deepembedding

--- a/src/main/scala/parsley/unsafe.scala
+++ b/src/main/scala/parsley/unsafe.scala
@@ -2,6 +2,7 @@ package parsley
 
 import parsley.internal.machine
 import parsley.internal.deepembedding
+import parsley.errors.ErrorBuilder
 
 /** This module contains various things that shouldn't be used without care and caution
   * @since 1.6.0
@@ -31,7 +32,7 @@ object unsafe {
           * implicit for convenience.
           * @since 3.0.0
           */
-        def parseFastUnsafe(input: String): Result[A] = ctx.internal(p.internal.instrs, input).runParser()
+        def parseFastUnsafe[Err: ErrorBuilder](input: String): Result[Err, A] = ctx.internal(p.internal.instrs, input).runParser()
     }
 
     final class Context private [parsley] (private [parsley] val internal: machine.Context)

--- a/src/test/scala/parsley/CharTests.scala
+++ b/src/test/scala/parsley/CharTests.scala
@@ -8,105 +8,105 @@ import scala.language.implicitConversions
 
 class CharTests extends ParsleyTest {
     "string" should "consume succeed if it is found at head" in {
-        "abc".parse("abc") should not be a [Failure]
+        "abc".parse("abc") should not be a [Failure[_]]
     }
     it should "not consume input if it fails on first character" in {
-        ("abc" <|> 'b').parse("b") should not be a [Failure]
+        ("abc" <|> 'b').parse("b") should not be a [Failure[_]]
     }
     it should "consume input if it fails mid-string" in {
-        ("abc" <|> "ab").parse("ab") shouldBe a [Failure]
+        ("abc" <|> "ab").parse("ab") shouldBe a [Failure[_]]
     }
     it should "not consume input if it fails mid-string when combined with attempt" in {
-        ("abc" <\> "ab").parse("ab") should not be a [Failure]
+        ("abc" <\> "ab").parse("ab") should not be a [Failure[_]]
     }
 
     "anyChar" should "accept any character" in {
-        for (i <- 0 to 65535) anyChar.parse(i.toChar.toString) should not be a [Failure]
+        for (i <- 0 to 65535) anyChar.parse(i.toChar.toString) should not be a [Failure[_]]
     }
     it should "fail if the input has run out, expecting any character" in {
         anyChar.parse("") should be (Failure("(line 1, column 1):\n  unexpected end of input\n  expected any character\n  >\n  >^"))
     }
 
     "space" should "consume ' ' or '\t'" in {
-        space.parse(" ") should not be a [Failure]
-        space.parse("\t") should not be a [Failure]
+        space.parse(" ") should not be a [Failure[_]]
+        space.parse("\t") should not be a [Failure[_]]
     }
     it should "expect space/tab otherwise" in {
-        for (i <- 0 to 65535; if i != ' ' && i != '\t') space.parse(i.toChar.toString) shouldBe a [Failure]
+        for (i <- 0 to 65535; if i != ' ' && i != '\t') space.parse(i.toChar.toString) shouldBe a [Failure[_]]
     }
 
     "spaces" should "consume lots of spaces" in {
-        (spaces *> 'a').parse(" \t" * 100 + 'a') should not be a [Failure]
+        (spaces *> 'a').parse(" \t" * 100 + 'a') should not be a [Failure[_]]
     }
     it should "never fail" in {
-        (spaces *> 'a').parse("a") should not be a [Failure]
+        (spaces *> 'a').parse("a") should not be a [Failure[_]]
     }
 
     "whitespace" should "consume any whitespace chars" in {
-        (whitespaces *> 'a').parse(" \t\n\r\f\u000b" * 100 + 'a') should not be a [Failure]
+        (whitespaces *> 'a').parse(" \t\n\r\f\u000b" * 100 + 'a') should not be a [Failure[_]]
     }
     it should "fail otherwise" in {
         val cs = " \t\n\r\f\u000b".toSet
-        for (i <- 0 to 65535; if !cs.contains(i.toChar)) whitespace.parse(i.toChar.toString) shouldBe a [Failure]
+        for (i <- 0 to 65535; if !cs.contains(i.toChar)) whitespace.parse(i.toChar.toString) shouldBe a [Failure[_]]
     }
 
     "endOfLine" should "consume windows or unix line endings" in {
-        endOfLine.parse("\n") should not be a [Failure]
-        endOfLine.parse("\r\n") should not be a [Failure]
+        endOfLine.parse("\n") should not be a [Failure[_]]
+        endOfLine.parse("\r\n") should not be a [Failure[_]]
     }
     it should "fail otherwise" in {
-        for (i <- 0 to 65535; if i != 10) endOfLine.parse(i.toChar.toString) shouldBe a [Failure]
+        for (i <- 0 to 65535; if i != 10) endOfLine.parse(i.toChar.toString) shouldBe a [Failure[_]]
     }
 
     "upper" should "only accept uppercase characters" in {
-        for (c <- 'A' to 'Z') upper.parse(c.toString) should not be a [Failure]
+        for (c <- 'A' to 'Z') upper.parse(c.toString) should not be a [Failure[_]]
     }
     it should "fail otherwise" in {
-        for (c <- 'a' to 'z') upper.parse(c.toString) shouldBe a [Failure]
+        for (c <- 'a' to 'z') upper.parse(c.toString) shouldBe a [Failure[_]]
     }
 
     "lower" should "only accept lowercase characters" in {
-        for (c <- 'a' to 'z') lower.parse(c.toString) should not be a [Failure]
+        for (c <- 'a' to 'z') lower.parse(c.toString) should not be a [Failure[_]]
     }
     it should "fail otherwise" in {
-        for (c <- 'A' to 'Z') lower.parse(c.toString) shouldBe a [Failure]
+        for (c <- 'A' to 'Z') lower.parse(c.toString) shouldBe a [Failure[_]]
     }
 
     "digit parsers" should "accept the appropriate characters" in {
         for (c <- '0' to '9') {
-            digit.parse(c.toString) should not be a [Failure]
-            hexDigit.parse(c.toString) should not be a [Failure]
-            if (c < '8') octDigit.parse(c.toString) should not be a [Failure]
+            digit.parse(c.toString) should not be a [Failure[_]]
+            hexDigit.parse(c.toString) should not be a [Failure[_]]
+            if (c < '8') octDigit.parse(c.toString) should not be a [Failure[_]]
         }
-        for (c <- 'a' to 'f') hexDigit.parse(c.toString) should not be a [Failure]
-        for (c <- 'A' to 'F') hexDigit.parse(c.toString) should not be a [Failure]
+        for (c <- 'a' to 'f') hexDigit.parse(c.toString) should not be a [Failure[_]]
+        for (c <- 'A' to 'F') hexDigit.parse(c.toString) should not be a [Failure[_]]
     }
     they should "fail otherwise" in {
         for (c <- 'a' to 'f') {
-            digit.parse(c.toString) shouldBe a [Failure]
-            octDigit.parse(c.toString) shouldBe a [Failure]
+            digit.parse(c.toString) shouldBe a [Failure[_]]
+            octDigit.parse(c.toString) shouldBe a [Failure[_]]
         }
         for (c <- 'A' to 'F') {
-            digit.parse(c.toString) shouldBe a [Failure]
-            octDigit.parse(c.toString) shouldBe a [Failure]
+            digit.parse(c.toString) shouldBe a [Failure[_]]
+            octDigit.parse(c.toString) shouldBe a [Failure[_]]
         }
-        octDigit.parse("8") shouldBe a [Failure]
-        octDigit.parse("9") shouldBe a [Failure]
+        octDigit.parse("8") shouldBe a [Failure[_]]
+        octDigit.parse("9") shouldBe a [Failure[_]]
     }
 
     "oneOf" should "match any of the characters provided" in {
         val p = character.oneOf('a', 'b', 'c')
-        p.parse("a") should not be a [Failure]
-        p.parse("b") should not be a [Failure]
-        p.parse("c") should not be a [Failure]
-        p.parse("d") shouldBe a [Failure]
+        p.parse("a") should not be a [Failure[_]]
+        p.parse("b") should not be a [Failure[_]]
+        p.parse("c") should not be a [Failure[_]]
+        p.parse("d") shouldBe a [Failure[_]]
     }
 
     "noneOf" should "match none of the characters provided" in {
         val p = character.noneOf('a', 'b', 'c')
-        p.parse("a") shouldBe a [Failure]
-        p.parse("b") shouldBe a [Failure]
-        p.parse("c") shouldBe a [Failure]
-        p.parse("d") should not be a [Failure]
+        p.parse("a") shouldBe a [Failure[_]]
+        p.parse("b") shouldBe a [Failure[_]]
+        p.parse("c") shouldBe a [Failure[_]]
+        p.parse("d") should not be a [Failure[_]]
     }
 }

--- a/src/test/scala/parsley/CombinatorTests.scala
+++ b/src/test/scala/parsley/CombinatorTests.scala
@@ -8,7 +8,7 @@ import scala.language.implicitConversions
 
 class CombinatorTests extends ParsleyTest {
     "choice" should "fail if given the empty list" in {
-        choice().parse("") shouldBe a [Failure]
+        choice().parse("") shouldBe a [Failure[_]]
     }
     it should "behave like p for List(p)" in {
         choice('a').parse("") should equal ('a'.parse(""))
@@ -18,7 +18,7 @@ class CombinatorTests extends ParsleyTest {
         choice("a", "b", "bc", "bcd").parse("bcd") should be (Success("b"))
     }
     it should "fail if none of the parsers succeed" in {
-        choice("a", "b", "bc", "bcd").parse("c") shouldBe a [Failure]
+        choice("a", "b", "bc", "bcd").parse("c") shouldBe a [Failure[_]]
     }
 
     "attemptChoice" should "correctly ensure the subparsers backtrack" in {
@@ -33,7 +33,7 @@ class CombinatorTests extends ParsleyTest {
         for (n <- 0 to 100) repeat(n, 'a').parse("a"*n) should be (Success(("a" * n).toList))
     }
     it must "fail if n inputs are not present" in {
-        repeat(2, 'a').parse("a") shouldBe a [Failure]
+        repeat(2, 'a').parse("a") shouldBe a [Failure[_]]
     }
 
     "option" should "succeed with Some if p succeeds" in {
@@ -43,24 +43,24 @@ class CombinatorTests extends ParsleyTest {
         option('a').parse("") should be (Success(None))
     }
     it should "fail if p fails with consumption" in {
-        option("ab").parse("a") shouldBe a [Failure]
+        option("ab").parse("a") shouldBe a [Failure[_]]
     }
 
     "decide" must "succeed for Some" in {
         decide('a'.map(Option(_))).parse("a") should be (Success('a'))
     }
     it must "fail for None" in {
-        decide(pure(None)).parse("") shouldBe a [Failure]
+        decide(pure(None)).parse("") shouldBe a [Failure[_]]
     }
     it must "succeed for None with an alternative" in {
         decide(pure(None), pure(7)).parse("") shouldBe Success(7)
     }
     it must "compose with option to become identity" in {
         decide(option(pure(7))).parse("") should be (pure(7).parse(""))
-        decide(option('a')).parse("") shouldBe a [Failure]
-        'a'.parse("") shouldBe a [Failure]
-        decide(option("ab")).parse("a") shouldBe a [Failure]
-        "ab".parse("a") shouldBe a [Failure]
+        decide(option('a')).parse("") shouldBe a [Failure[_]]
+        'a'.parse("") shouldBe a [Failure[_]]
+        decide(option("ab")).parse("a") shouldBe a [Failure[_]]
+        "ab".parse("a") shouldBe a [Failure[_]]
     }
 
     "optional" must "succeed if p succeeds" in {
@@ -70,12 +70,12 @@ class CombinatorTests extends ParsleyTest {
         optional('a').parse("b") should be (Success(()))
     }
     it must "fail if p failed with consumption" in {
-        optional("ab").parse("a") shouldBe a [Failure]
+        optional("ab").parse("a") shouldBe a [Failure[_]]
     }
 
     "manyN" must "ensure that n are parsed" in {
         for (n <- 0 to 10) manyN(n, 'a').parse("a"*n) should be (Success(("a"*n).toList))
-        for (n <- 0 to 10) manyN(n+1, 'a').parse("a"*n) shouldBe a [Failure]
+        for (n <- 0 to 10) manyN(n+1, 'a').parse("a"*n) shouldBe a [Failure[_]]
     }
     it should "not care if more are present" in {
         for (n <- 0 to 10) manyN(n/2, 'a').parse("a"*n) should be (Success(("a"*n).toList))
@@ -83,7 +83,7 @@ class CombinatorTests extends ParsleyTest {
 
     "skipManyN" must "ensure that n are parsed" in {
         for (n <- 0 to 10) skipManyN(n, 'a').parse("a"*n) should be (Success(()))
-        for (n <- 0 to 10) skipManyN(n+1, 'a').parse("a"*n) shouldBe a [Failure]
+        for (n <- 0 to 10) skipManyN(n+1, 'a').parse("a"*n) shouldBe a [Failure[_]]
     }
     it should "not care if more are present" in {
         for (n <- 0 to 10) skipManyN(n/2, 'a').parse("a"*n) should be (Success(()))
@@ -93,7 +93,7 @@ class CombinatorTests extends ParsleyTest {
         sepBy('a', 'b').parse("") should be (Success(Nil))
     }
     it must "not allow sep at the end of chain" in {
-        sepBy('a', 'b').parse("ab") shouldBe a [Failure]
+        sepBy('a', 'b').parse("ab") shouldBe a [Failure[_]]
     }
     it should "be able to parse 2 or more p" in {
         sepBy('a', 'b').parse("aba") should be (Success(List('a', 'a')))
@@ -102,8 +102,8 @@ class CombinatorTests extends ParsleyTest {
     }
 
     "sepBy1" must "require a p" in {
-        sepBy1('a', 'b').parse("a") should not be a [Failure]
-        sepBy1('a', 'b').parse(input = "") shouldBe a [Failure]
+        sepBy1('a', 'b').parse("a") should not be a [Failure[_]]
+        sepBy1('a', 'b').parse(input = "") shouldBe a [Failure[_]]
     }
 
     "sepEndBy" must "accept empty input" in {
@@ -122,25 +122,25 @@ class CombinatorTests extends ParsleyTest {
         sepEndBy('a', 'b').parse("ababab") should be (Success(List('a', 'a', 'a')))
     }
     it should "fail if p fails after consuming input" in {
-        sepEndBy("aa", 'b').parse("ab") shouldBe a [Failure]
+        sepEndBy("aa", 'b').parse("ab") shouldBe a [Failure[_]]
     }
     it should "fail if sep fails after consuming input" in {
-        sepEndBy('a', "bb").parse("ab") shouldBe a [Failure]
+        sepEndBy('a', "bb").parse("ab") shouldBe a [Failure[_]]
     }
     it must "not corrupt the stack on sep hard-fail" in {
         ('c' <::> attempt(sepEndBy('a', "bb")).getOrElse(List('d'))).parse("cab") should be (Success(List('c', 'd')))
     }
 
     "sepEndBy1" must "require a p" in {
-        sepEndBy1('a', 'b').parse("a") should not be a [Failure]
-        sepEndBy1('a', 'b').parse(input = "") shouldBe a [Failure]
+        sepEndBy1('a', 'b').parse("a") should not be a [Failure[_]]
+        sepEndBy1('a', 'b').parse(input = "") shouldBe a [Failure[_]]
     }
 
     "endBy" must "accept empty input" in {
         endBy('a', 'b').parse("") should be (Success(Nil))
     }
     it must "require sep at end of chain" in {
-        endBy('a', 'b').parse("a") shouldBe a [Failure]
+        endBy('a', 'b').parse("a") shouldBe a [Failure[_]]
         endBy('a', 'b').parse("ab") should be (Success(List('a')))
     }
     it should "be able to parse 2 or more p" in {
@@ -149,15 +149,15 @@ class CombinatorTests extends ParsleyTest {
     }
 
     "endBy1" must "require a p" in {
-        endBy1('a', 'b').parse("ab") should not be a [Failure]
-        endBy1('a', 'b').parse(input = "") shouldBe a [Failure]
+        endBy1('a', 'b').parse("ab") should not be a [Failure[_]]
+        endBy1('a', 'b').parse(input = "") shouldBe a [Failure[_]]
     }
 
     "eof" must "succeed at the end of input" in {
-        eof.parse("") should not be a [Failure]
+        eof.parse("") should not be a [Failure[_]]
     }
     it must "fail if input remains" in {
-        eof.parse("a") shouldBe a [Failure]
+        eof.parse("a") shouldBe a [Failure[_]]
     }
 
     "notFollowedBy" must "succeed if p fails" in {
@@ -167,24 +167,24 @@ class CombinatorTests extends ParsleyTest {
         notFollowedBy("aa").parse("a") should be (Success(()))
     }
     it must "fail if p succeeds" in {
-        notFollowedBy('a').parse("a") shouldBe a [Failure]
+        notFollowedBy('a').parse("a") shouldBe a [Failure[_]]
     }
 
     "manyUntil" must "require an end" in {
-        manyUntil('a', 'b').parse("aa") shouldBe a [Failure]
+        manyUntil('a', 'b').parse("aa") shouldBe a [Failure[_]]
         manyUntil('a', 'b').parse("ab") should be (Success(List('a')))
     }
     it should "parse the end without result" in {
         manyUntil('a', 'b').parse("b") should be (Success(Nil))
     }
     it should "parse p until that end is found" in {
-        manyUntil('a', 'b').parse("aaaaaaaaaaaab") should not be a [Failure]
-        manyUntil("aa", 'b').parse("ab") shouldBe a [Failure]
+        manyUntil('a', 'b').parse("aaaaaaaaaaaab") should not be a [Failure[_]]
+        manyUntil("aa", 'b').parse("ab") shouldBe a [Failure[_]]
     }
 
     "someUntil" must "parse at least 1 p" in {
         someUntil('a', 'b').parse("ab") should be (Success(List('a')))
-        someUntil('a', 'b').parse("b") shouldBe a [Failure]
+        someUntil('a', 'b').parse("b") shouldBe a [Failure[_]]
     }
 
     /*"forP" should "be able to parse context-sensitive grammars" in {
@@ -195,6 +195,6 @@ class CombinatorTests extends ParsleyTest {
                   forP[Int](r2, get(r1), pure(_ != 0), pure(_ - 1), 'b') *>
                   forP[Int](r2, get(r1), pure(_ != 0), pure(_ - 1), 'c')
         abc.parse("aaabbbccc") should be (Success(()))
-        abc.parse("aaaabc") shouldBe a [Failure]
+        abc.parse("aaaabc") shouldBe a [Failure[_]]
     }*/
 }

--- a/src/test/scala/parsley/CoreTests.scala
+++ b/src/test/scala/parsley/CoreTests.scala
@@ -31,13 +31,13 @@ class CoreTests extends ParsleyTest {
 
     they must "only consume a single character of input at most" in {
         var res = (satisfy(_ == 'a') *> 'b').parse("aaaaaa")
-        res shouldBe a [Failure]
+        res shouldBe a [Failure[_]]
         res match {
             case Failure(err) => err should startWith ("(line 1, column 2)")
             case _ =>
         }
         res = ('a' ~> 'b').parse("bc")
-        res shouldBe a [Failure]
+        res shouldBe a [Failure[_]]
         res match {
             case Failure(err) => err should startWith ("(line 1, column 1)")
             case _ =>
@@ -45,7 +45,7 @@ class CoreTests extends ParsleyTest {
     }
 
     "Pure parsers" should "not require input" in {
-        unit.parse("") should not be a [Failure]
+        unit.parse("") should not be a [Failure[_]]
     }
 
     they must "result in their correct value" in {
@@ -116,32 +116,32 @@ class CoreTests extends ParsleyTest {
     }
     they must "allow for flattening" in {
         join(pure(char('a'))).parse("a") shouldBe Success('a')
-        join(Parsley.empty).parse("") shouldBe a [Failure]
+        join(Parsley.empty).parse("") shouldBe a [Failure[_]]
     }
 
     "<|>" should "not try the second alternative if the first succeeded" in {
-        ('a' <|> pfail("wrong!")).parse("a") should not be a [Failure]
+        ('a' <|> pfail("wrong!")).parse("a") should not be a [Failure[_]]
     }
     it should "only try second alternative if the first failed without consuming input" in {
-        ('a' <|> 'b').parse("b") should not be a [Failure]
+        ('a' <|> 'b').parse("b") should not be a [Failure[_]]
     }
     it should "not try the second alternative if the first failed after consuming input" in {
-        ("ab" <|> "ac").parse("ac") shouldBe a [Failure]
+        ("ab" <|> "ac").parse("ac") shouldBe a [Failure[_]]
     }
     it should "not be affected by an empty on the left" in {
         (Parsley.empty <|> 'a').parse("b") shouldBe Failure("(line 1, column 1):\n  unexpected \"b\"\n  expected \"a\"\n  >b\n  >^")
     }
 
     "attempt" should "cause <|> to try second alternative even if input consumed" in {
-        attempt("ab").orElse("ac").parse("ac") should not be a [Failure]
+        attempt("ab").orElse("ac").parse("ac") should not be a [Failure[_]]
     }
 
     "lookAhead" should "consume no input on success" in {
-        lookAhead('a').parse("a") should not be a [Failure]
+        lookAhead('a').parse("a") should not be a [Failure[_]]
         (lookAhead('a') *> 'b').parse("ab") should be (Failure("(line 1, column 1):\n  unexpected \"a\"\n  expected \"b\"\n  >ab\n  >^"))
     }
     it must "fail when input is consumed, and input is consumed" in {
-        lookAhead("ab").parse("ac") shouldBe a [Failure]
+        lookAhead("ab").parse("ac") shouldBe a [Failure[_]]
     }
     /*it should "not affect the state of the registers on success" in {
         val r1 = Reg.make[Int]
@@ -232,7 +232,7 @@ class CoreTests extends ParsleyTest {
 
     "filtered parsers" should "function correctly" in {
         val p = anyChar.filterNot(_.isLower)
-        p.parse("a") shouldBe a [Failure]
+        p.parse("a") shouldBe a [Failure[_]]
         p.parse("A") shouldBe Success('A')
     }
 
@@ -243,7 +243,7 @@ class CoreTests extends ParsleyTest {
         }
         p.parse("+") shouldBe Success(0)
         p.parse("C") shouldBe Success(3)
-        p.parse("a") shouldBe a [Failure]
+        p.parse("a") shouldBe a [Failure[_]]
     }
 
     "the cast combinator" should "allow for casts to valid types" in {
@@ -252,7 +252,7 @@ class CoreTests extends ParsleyTest {
     }
     it should "reject invalid casts by failing" in {
         val p = pure[Any](7)
-        p.cast[String].parse("") shouldBe a [Failure]
+        p.cast[String].parse("") shouldBe a [Failure[_]]
     }
 
     "foldRight" should "work correctly" in {
@@ -263,7 +263,7 @@ class CoreTests extends ParsleyTest {
     }
     "foldRight1" should "work correctly" in {
         val p = 'a'.foldRight1[List[Char]](Nil)(_::_)
-        p.parse("") shouldBe a [Failure]
+        p.parse("") shouldBe a [Failure[_]]
         p.parse("aaa") should be (Success(List('a', 'a', 'a')))
     }
 
@@ -275,7 +275,7 @@ class CoreTests extends ParsleyTest {
     }
     "foldLeft1" should "work correctly" in {
         val p = digit.foldLeft1(0)((x, d) => x * 10 + d.asDigit)
-        p.parse("") shouldBe a [Failure]
+        p.parse("") shouldBe a [Failure[_]]
         p.parse("123") should be (Success(123))
     }
     "reduceRightOption" should "return Some on success" in {

--- a/src/test/scala/parsley/ErrorTests.scala
+++ b/src/test/scala/parsley/ErrorTests.scala
@@ -11,11 +11,11 @@ import scala.language.implicitConversions
 
 class ErrorTests extends ParsleyTest {
     "mzero parsers" should "always fail" in {
-        (Parsley.empty ~> 'a').parse("a") shouldBe a [Failure]
-        (pfail("") ~> 'a').parse("a") shouldBe a [Failure]
-        (unexpected("") *> 'a').parse("a") shouldBe a [Failure]
-        (('a' ! (_ => "")) *> 'b').parse("ab") shouldBe a [Failure]
-        ('a'.unexpected(_ => "") *> 'b').parse("ab") shouldBe a [Failure]
+        (Parsley.empty ~> 'a').parse("a") shouldBe a [Failure[_]]
+        (pfail("") ~> 'a').parse("a") shouldBe a [Failure[_]]
+        (unexpected("") *> 'a').parse("a") shouldBe a [Failure[_]]
+        (('a' ! (_ => "")) *> 'b').parse("ab") shouldBe a [Failure[_]]
+        ('a'.unexpected(_ => "") *> 'b').parse("ab") shouldBe a [Failure[_]]
     }
 
     "filtering parsers" should "function correctly" in {
@@ -55,7 +55,7 @@ class ErrorTests extends ParsleyTest {
         val p = attempt(anyChar.filterOut {
             case c if c.isLower => "no lowercase!"
         })
-        p.parse("a") shouldBe a [Failure]
+        p.parse("a") shouldBe a [Failure[_]]
     }
 
     lazy val r: Parsley[List[String]] = "correct error message" <::> r

--- a/src/test/scala/parsley/ErrorTests.scala
+++ b/src/test/scala/parsley/ErrorTests.scala
@@ -5,10 +5,59 @@ import parsley.Parsley._
 import parsley.implicits.character.{charLift, stringLift}
 import parsley.character.{anyChar, digit}
 import parsley.unsafe.ErrorLabel
+import parsley.errors.combinator.{fail => pfail, unexpected, ErrorMethods}
 
 import scala.language.implicitConversions
 
-class ErrorMessageTests extends ParsleyTest {
+class ErrorTests extends ParsleyTest {
+    "mzero parsers" should "always fail" in {
+        (Parsley.empty ~> 'a').parse("a") shouldBe a [Failure]
+        (pfail("") ~> 'a').parse("a") shouldBe a [Failure]
+        (unexpected("") *> 'a').parse("a") shouldBe a [Failure]
+        (('a' ! (_ => "")) *> 'b').parse("ab") shouldBe a [Failure]
+        ('a'.unexpected(_ => "") *> 'b').parse("ab") shouldBe a [Failure]
+    }
+
+    "filtering parsers" should "function correctly" in {
+        val p = anyChar.filterOut {
+            case c if c.isLower => s"'$c' should have been uppercase"
+        }
+        p.parse("a") shouldBe Failure("(line 1, column 2):\n  'a' should have been uppercase\n  >a\n  > ^")
+        p.parse("A") shouldBe Success('A')
+
+        val q = anyChar.guardAgainst {
+            case c if c.isLower => s"'$c' is not uppercase"
+        }
+        q.parse("a") shouldBe Failure("(line 1, column 2):\n  'a' is not uppercase\n  >a\n  > ^")
+        q.parse("A") shouldBe Success('A')
+    }
+
+    "the collectMsg combinator" should "act like a filter then a map" in {
+        val p = anyChar.collectMsg("oops") {
+            case '+' => 0
+            case c if c.isUpper => c - 'A' + 1
+        }
+        p.parse("+") shouldBe Success(0)
+        p.parse("C") shouldBe Success(3)
+        p.parse("a") shouldBe Failure("(line 1, column 2):\n  oops\n  >a\n  > ^")
+
+        val q = anyChar.collectMsg(c => s"$c is not appropriate") {
+            case '+' => 0
+            case c if c.isUpper => c - 'A' + 1
+        }
+        q.parse("+") shouldBe Success(0)
+        q.parse("C") shouldBe Success(3)
+        q.parse("a") shouldBe Failure("(line 1, column 2):\n  a is not appropriate\n  >a\n  > ^")
+    }
+
+    // Issue #70
+    "filterOut" should "not corrupt the stack under a handler" in {
+        val p = attempt(anyChar.filterOut {
+            case c if c.isLower => "no lowercase!"
+        })
+        p.parse("a") shouldBe a [Failure]
+    }
+
     lazy val r: Parsley[List[String]] = "correct error message" <::> r
     "label" should "affect base error messages" in {
         ('a' ? "ay!").parse("b") should be (Failure("(line 1, column 1):\n  unexpected \"b\"\n  expected ay!\n  >b\n  >^"))
@@ -69,7 +118,7 @@ class ErrorMessageTests extends ParsleyTest {
     }
 
     "fail" should "yield a raw message" in {
-        Parsley.fail("hi").parse("b") should be {
+        pfail("hi").parse("b") should be {
             Failure("(line 1, column 1):\n  hi\n  >b\n  >^")
         }
     }

--- a/src/test/scala/parsley/ExpressionParserTests.scala
+++ b/src/test/scala/parsley/ExpressionParserTests.scala
@@ -14,13 +14,13 @@ class ExpressionParserTests extends ParsleyTest {
         chain.postfix('1' #> 1, '+' #> ((x: Int) => x + 1)).parse("1") should be (Success(1))
     }
     it must "parse all operators that follow" in {
-        chain.postfix('1' #> 1, '+' #> ((x: Int) => x + 1)).parse("1++++++++++++++") should not be a [Failure]
+        chain.postfix('1' #> 1, '+' #> ((x: Int) => x + 1)).parse("1++++++++++++++") should not be a [Failure[_]]
     }
     it must "apply the functions" in {
         chain.postfix('1' #> 1, '+' #> ((x: Int) => x + 1)).parse("1++++++++++++++") should be (Success(15))
     }
     it must "fail if an operator fails after consuming input" in {
-        chain.postfix('1' #> 1, "++" #> ((x: Int) => x + 1)).parse("1+++++++++++++") shouldBe a [Failure]
+        chain.postfix('1' #> 1, "++" #> ((x: Int) => x + 1)).parse("1+++++++++++++") shouldBe a [Failure[_]]
     }
     it must "not leave the stack in an inconsistent state on failure" in {
         val p = chain.postfix[Int]('1' #> 1, (col.#>[Int => Int](_ + 1)) <* '+')
@@ -29,40 +29,40 @@ class ExpressionParserTests extends ParsleyTest {
     }
 
     "chain.postfix1" must "require and initial value AND an initial operator" in {
-        chain.postfix1('1' #> 1, '+' #> ((x: Int) => x + 1)).parse("1") shouldBe a [Failure]
+        chain.postfix1('1' #> 1, '+' #> ((x: Int) => x + 1)).parse("1") shouldBe a [Failure[_]]
         chain.postfix1('1' #> 1, '+' #> ((x: Int) => x + 1)).parse("1+") shouldBe Success(2)
     }
     it must "parse all operators that follow" in {
-        chain.postfix1('1' #> 1, '+' #> ((x: Int) => x + 1)).parse("1++++++++++++++") should not be a [Failure]
+        chain.postfix1('1' #> 1, '+' #> ((x: Int) => x + 1)).parse("1++++++++++++++") should not be a [Failure[_]]
     }
     it must "apply the functions" in {
         chain.postfix1('1' #> 1, '+' #> ((x: Int) => x + 1)).parse("1++++++++++++++") should be (Success(15))
     }
     it must "fail if an operator fails after consuming input" in {
-        chain.postfix1('1' #> 1, "++" #> ((x: Int) => x + 1)).parse("1+++++++++++++") shouldBe a [Failure]
+        chain.postfix1('1' #> 1, "++" #> ((x: Int) => x + 1)).parse("1+++++++++++++") shouldBe a [Failure[_]]
     }
 
     "chain.prefix" must "parse an operatorless value" in {
         chain.prefix('+' #> ((x: Int) => x + 1), '1' #> 1).parse("1") should be (Success(1))
     }
     it must "parse all operators that precede a value" in {
-        chain.prefix('+' #> ((x: Int) => x + 1), '1' #> 1).parse("+++++++++++1") should not be a [Failure]
+        chain.prefix('+' #> ((x: Int) => x + 1), '1' #> 1).parse("+++++++++++1") should not be a [Failure[_]]
     }
     it must "fail if the final value is absent" in {
-        chain.prefix('+' #> ((x: Int) => x + 1), '1' #> 1).parse("+++++++++++") shouldBe a [Failure]
+        chain.prefix('+' #> ((x: Int) => x + 1), '1' #> 1).parse("+++++++++++") shouldBe a [Failure[_]]
     }
     it must "apply the functions" in {
         chain.prefix('+' #> ((x: Int) => x + 1), '1' #> 1).parse("+++++++++++1") should be (Success(12))
     }
 
     "chain.prefix1" must "not parse an operatorless value" in {
-        chain.prefix1('+' #> ((x: Int) => x + 1), '1' #> 1).parse("1") shouldBe a [Failure]
+        chain.prefix1('+' #> ((x: Int) => x + 1), '1' #> 1).parse("1") shouldBe a [Failure[_]]
     }
     it must "parse all operators that precede a value" in {
-        chain.prefix1('+' #> ((x: Int) => x + 1), '1' #> 1).parse("+++++++++++1") should not be a [Failure]
+        chain.prefix1('+' #> ((x: Int) => x + 1), '1' #> 1).parse("+++++++++++1") should not be a [Failure[_]]
     }
     it must "fail if the final value is absent" in {
-        chain.prefix1('+' #> ((x: Int) => x + 1), '1' #> 1).parse("+++++++++++") shouldBe a [Failure]
+        chain.prefix1('+' #> ((x: Int) => x + 1), '1' #> 1).parse("+++++++++++") shouldBe a [Failure[_]]
     }
     it must "apply the functions" in {
         chain.prefix1('+' #> ((x: Int) => x + 1), '1' #> 1).parse("+++++++++++1") should be (Success(12))
@@ -70,8 +70,8 @@ class ExpressionParserTests extends ParsleyTest {
 
     "chain.right1" must "require an initial value" in {
         chain.right1("11" #> 1, '+' #> ((x: Int, y: Int) => x + y)).parse("11") should be (Success(1))
-        chain.right1("11" #> 1, '+' #> ((x: Int, y: Int) => x + y)).parse("1") shouldBe a [Failure]
-        chain.right1("11" #> 1, '+' #> ((x: Int, y: Int) => x + y)).parse("2") shouldBe a [Failure]
+        chain.right1("11" #> 1, '+' #> ((x: Int, y: Int) => x + y)).parse("1") shouldBe a [Failure[_]]
+        chain.right1("11" #> 1, '+' #> ((x: Int, y: Int) => x + y)).parse("2") shouldBe a [Failure[_]]
     }
     it must "parse all operators and values that follow" in {
         chain.right1("11" #> 1, '+' #> ((x: Int, y: Int) => x + y)).parse("11+11+11+11+11") should be (Success(5))
@@ -80,8 +80,8 @@ class ExpressionParserTests extends ParsleyTest {
         chain.right1(digit.map(_.asDigit), '%' #> ((x: Int, y: Int) => x % y)).parse("6%5%2%7") should be (Success(0))
     }
     it must "fail if an operator or p fails after consuming input" in {
-        chain.right1("11" #> 1, "++" #> ((x: Int, y: Int) => x + y)).parse("11+11+11+11+11") shouldBe a [Failure]
-        chain.right1("11" #> 1, "++" #> ((x: Int, y: Int) => x + y)).parse("11++11++11++1++11") shouldBe a [Failure]
+        chain.right1("11" #> 1, "++" #> ((x: Int, y: Int) => x + y)).parse("11+11+11+11+11") shouldBe a [Failure[_]]
+        chain.right1("11" #> 1, "++" #> ((x: Int, y: Int) => x + y)).parse("11++11++11++1++11") shouldBe a [Failure[_]]
     }
     it must "correctly accept the use of a wrapping function" in {
         sealed trait Expr
@@ -93,13 +93,13 @@ class ExpressionParserTests extends ParsleyTest {
     }
     "chain.right" must "allow for no initial value" in {
         chain.right("11" #> 1, '+' #> ((x: Int, y: Int) => x + y), 0).parse("2") shouldBe Success(0)
-        chain.right("11" #> 1, '+' #> ((x: Int, y: Int) => x + y), 0).parse("1") shouldBe a [Failure]
+        chain.right("11" #> 1, '+' #> ((x: Int, y: Int) => x + y), 0).parse("1") shouldBe a [Failure[_]]
     }
 
     "chain.left1" must "require an initial value" in {
         chain.left1("11" #> 1, '+' #> ((x: Int, y: Int) => x + y)).parse("11") should be (Success(1))
-        chain.left1("11" #> 1, '+' #> ((x: Int, y: Int) => x + y)).parse("1") shouldBe a [Failure]
-        chain.left1("11" #> 1, '+' #> ((x: Int, y: Int) => x + y)).parse("2") shouldBe a [Failure]
+        chain.left1("11" #> 1, '+' #> ((x: Int, y: Int) => x + y)).parse("1") shouldBe a [Failure[_]]
+        chain.left1("11" #> 1, '+' #> ((x: Int, y: Int) => x + y)).parse("2") shouldBe a [Failure[_]]
     }
     it must "parse all operators and values that follow" in {
         chain.left1("11" #> 1, '+' #> ((x: Int, y: Int) => x + y)).parse("11+11+11+11+11") should be (Success(5))
@@ -108,8 +108,8 @@ class ExpressionParserTests extends ParsleyTest {
         chain.left1(digit.map(_.asDigit), '%' #> ((x: Int, y: Int) => x % y)).parse("6%5%2%7") should be (Success(1))
     }
     it must "fail if an operator fails after consuming input" in {
-        chain.left1("11" #> 1, "++" #> ((x: Int, y: Int) => x + y)).parse("11+11+11+11+11") shouldBe a [Failure]
-        chain.left1("11" #> 1, "++" #> ((x: Int, y: Int) => x + y)).parse("11++11++11++1++11") shouldBe a [Failure]
+        chain.left1("11" #> 1, "++" #> ((x: Int, y: Int) => x + y)).parse("11+11+11+11+11") shouldBe a [Failure[_]]
+        chain.left1("11" #> 1, "++" #> ((x: Int, y: Int) => x + y)).parse("11++11++11++1++11") shouldBe a [Failure[_]]
     }
     it must "not leave the stack in an inconsistent state on failure" in {
         val p = chain.left1[Int, Int]('1' #> 1, (col.#>[(Int, Int) => Int](_ + _)) <* '+')
@@ -124,7 +124,7 @@ class ExpressionParserTests extends ParsleyTest {
     }
     "chain.left" must "allow for no initial value" in {
         chain.left("11" #> 1, '+' #> ((x: Int, y: Int) => x + y), 0).parse("11") should be (Success(1))
-        chain.left("11" #> 1, '+' #> ((x: Int, y: Int) => x + y), 0).parse("1") shouldBe a [Failure]
+        chain.left("11" #> 1, '+' #> ((x: Int, y: Int) => x + y), 0).parse("1") shouldBe a [Failure[_]]
         chain.left("11" #> 1, '+' #> ((x: Int, y: Int) => x + y), 0).parse("2") shouldBe Success(0)
     }
 

--- a/src/test/scala/parsley/TokeniserTests.scala
+++ b/src/test/scala/parsley/TokeniserTests.scala
@@ -48,10 +48,10 @@ class TokeniserTests extends ParsleyTest {
         (tokeniser.identifier <* eof).parse("foo123 ") should be (Success("foo123"))
         (tokeniser.identifier <* eof).parse("_bar") should be (Success("_bar"))
         (tokeniser.identifier <* eof).parse("iffy") should be (Success("iffy"))
-        (tokeniser.identifier <* eof).parse("1_bar") shouldBe a [Failure]
+        (tokeniser.identifier <* eof).parse("1_bar") shouldBe a [Failure[_]]
     }
     it should "fail if the result is a keyword" in {
-        (tokeniser.identifier <* eof).parse("class") shouldBe a [Failure]
+        (tokeniser.identifier <* eof).parse("class") shouldBe a [Failure[_]]
     }
     it must "be the same regardless of the intrinsic" in {
         (tokeniser_.identifier <* eof).parse("foo123 ") should be (Success("foo123"))
@@ -60,7 +60,7 @@ class TokeniserTests extends ParsleyTest {
         (tokeniser_.identifier <* eof).parse("1_bar") should equal {
             (tokeniser.identifier <* eof).parse("1_bar")
         }
-        (tokeniser_.identifier <* eof).parse("class") shouldBe a [Failure]
+        (tokeniser_.identifier <* eof).parse("class") shouldBe a [Failure[_]]
     }
 
     "keyword" should "match valid keywords" in {
@@ -68,8 +68,8 @@ class TokeniserTests extends ParsleyTest {
         tokeniser.keyword("volatile").parse("volatile") should be (Success(()))
     }
     it should "fail if the input has more identifier letters" in {
-        tokeniser.keyword("if").parse("ifthen") shouldBe a [Failure]
-        tokeniser.keyword("volatile").parse("volatilev") shouldBe a [Failure]
+        tokeniser.keyword("if").parse("ifthen") shouldBe a [Failure[_]]
+        tokeniser.keyword("volatile").parse("volatilev") shouldBe a [Failure[_]]
     }
     it must "be the same regardless of the intrinsic" in {
         tokeniser_.keyword("if").parse("if then") should be (Success(()))
@@ -87,15 +87,15 @@ class TokeniserTests extends ParsleyTest {
 
     "userOp" should "read valid operator" in {
         (tokeniser.userOp <* eof).parse(":+:") should be (Success(":+:"))
-        (tokeniser.userOp <* eof).parse(":+:h") shouldBe a [Failure]
+        (tokeniser.userOp <* eof).parse(":+:h") shouldBe a [Failure[_]]
     }
     it should "fail if the result is reserved" in {
-        (tokeniser.userOp <* eof).parse(":") shouldBe a [Failure]
+        (tokeniser.userOp <* eof).parse(":") shouldBe a [Failure[_]]
     }
     it must "be the same regardless of the intrinsic" in {
         (tokeniser_.userOp <* eof).parse(":+:") should be (Success(":+:"))
-        (tokeniser_.userOp <* eof).parse(":+:h") shouldBe a [Failure]
-        (tokeniser_.userOp <* eof).parse(":") shouldBe a [Failure]
+        (tokeniser_.userOp <* eof).parse(":+:h") shouldBe a [Failure[_]]
+        (tokeniser_.userOp <* eof).parse(":") shouldBe a [Failure[_]]
     }
 
     "reservedOp" should "match valid reserved operators" in {
@@ -103,14 +103,14 @@ class TokeniserTests extends ParsleyTest {
         (tokeniser.reservedOp <* eof).parse(":") should be (Success(":"))
     }
     it should "fail if the result isn't reserved" in {
-        (tokeniser.reservedOp <* eof).parse("+") shouldBe a [Failure]
-        (tokeniser.reservedOp <* eof).parse("::=") shouldBe a [Failure]
+        (tokeniser.reservedOp <* eof).parse("+") shouldBe a [Failure[_]]
+        (tokeniser.reservedOp <* eof).parse("::=") shouldBe a [Failure[_]]
     }
     it must "be the same regardless of the intrinsic" in {
         (tokeniser_.reservedOp <* eof).parse("=") should be (Success("="))
         (tokeniser_.reservedOp <* eof).parse(":") should be (Success(":"))
-        (tokeniser_.reservedOp <* eof).parse("+") shouldBe a [Failure]
-        (tokeniser_.reservedOp <* eof).parse("::=") shouldBe a [Failure]
+        (tokeniser_.reservedOp <* eof).parse("+") shouldBe a [Failure[_]]
+        (tokeniser_.reservedOp <* eof).parse("::=") shouldBe a [Failure[_]]
     }
 
     "operator" should "match valid operators" in {
@@ -119,9 +119,9 @@ class TokeniserTests extends ParsleyTest {
         (tokeniser.operator("++") <* eof).parse("++") should be (Success(()))
     }
     it should "fail if the input has more operator letters" in {
-        (tokeniser.operator("=") <* eof).parse("=+") shouldBe a [Failure]
-        (tokeniser.operator(":") <* eof).parse("::") shouldBe a [Failure]
-        (tokeniser.operator("++") <* eof).parse("++=") shouldBe a [Failure]
+        (tokeniser.operator("=") <* eof).parse("=+") shouldBe a [Failure[_]]
+        (tokeniser.operator(":") <* eof).parse("::") shouldBe a [Failure[_]]
+        (tokeniser.operator("++") <* eof).parse("++=") shouldBe a [Failure[_]]
     }
     it must "be the same regardless of the intrinsic" in {
         (tokeniser_.operator("=") <* eof).parse("=") should equal {
@@ -155,8 +155,8 @@ class TokeniserTests extends ParsleyTest {
         (tokeniser_.maxOp("=") <* '=' <* eof).parse("==") should be (Success(()))
     }
     it must "fail if the operator is a valid prefix of another operator and that operator is parsable" in {
-        (tokeniser_.maxOp(":") <* '=' <* eof).parse(":=") shouldBe a [Failure]
-        (tokeniser_.maxOp(":") <* ':' <* eof).parse("::") shouldBe a [Failure]
+        (tokeniser_.maxOp(":") <* '=' <* eof).parse(":=") shouldBe a [Failure[_]]
+        (tokeniser_.maxOp(":") <* ':' <* eof).parse("::") shouldBe a [Failure[_]]
     }
 
     "charLiteral" should "parse valid haskell characters" in {
@@ -236,16 +236,16 @@ class TokeniserTests extends ParsleyTest {
         tokeniser.decimal.parse("123") should be (Success(123))
     }
     it should "not succeed when given no input" in {
-        tokeniser.decimal.parse("") shouldBe a [Failure]
+        tokeniser.decimal.parse("") shouldBe a [Failure[_]]
     }
 
     "hexadecimal" should "parse unsigned hexadecimal integers" in {
         tokeniser.hexadecimal.parse("0xff") should be (Success(255))
     }
     it should "require at least one digit" in {
-        tokeniser.hexadecimal.parse("") shouldBe a [Failure]
-        tokeniser.hexadecimal.parse("0") shouldBe a [Failure]
-        tokeniser.hexadecimal.parse("0x") shouldBe a [Failure]
+        tokeniser.hexadecimal.parse("") shouldBe a [Failure[_]]
+        tokeniser.hexadecimal.parse("0") shouldBe a [Failure[_]]
+        tokeniser.hexadecimal.parse("0x") shouldBe a [Failure[_]]
     }
 
     "unsignedFloat" should "parse unsigned fractional floats" in {
@@ -263,11 +263,11 @@ class TokeniserTests extends ParsleyTest {
         tokeniser.unsignedFloat.parse("10.0e-5") should be (Success(10.0e-5))
     }
     it should "not parse integers" in {
-        tokeniser.unsignedFloat.parse("3") shouldBe a [Failure]
+        tokeniser.unsignedFloat.parse("3") shouldBe a [Failure[_]]
     }
     it should "not allow .1 or 1." in {
-        tokeniser.unsignedFloat.parse(".0") shouldBe a [Failure]
-        tokeniser.unsignedFloat.parse("0.") shouldBe a [Failure]
+        tokeniser.unsignedFloat.parse(".0") shouldBe a [Failure[_]]
+        tokeniser.unsignedFloat.parse("0.") shouldBe a [Failure[_]]
     }
 
     "float" should "parse signed floats" in {
@@ -292,10 +292,10 @@ class TokeniserTests extends ParsleyTest {
         tokeniser.naturalOrFloat.parse("0o201 //ooh, octal") should be (Success(Left(129)))
     }
     it should "not allow hexadecimal floats" in {
-        (tokeniser.naturalOrFloat <* eof).parse("0x340.0") shouldBe a [Failure]
+        (tokeniser.naturalOrFloat <* eof).parse("0x340.0") shouldBe a [Failure[_]]
     }
     it should "not allow octal floats" in {
-        (tokeniser.naturalOrFloat <* eof).parse("0o201.0") shouldBe a [Failure]
+        (tokeniser.naturalOrFloat <* eof).parse("0o201.0") shouldBe a [Failure[_]]
     }
 
     "number" should "parse integers or floats" in {
@@ -324,18 +324,18 @@ class TokeniserTests extends ParsleyTest {
     }
     it should "parse nested comments when applicable" in {
         (tokeniser.skipComments <* eof).parse("/*/*hello world*/ this /*comment*/ is nested*/") should be (Success(()))
-        (tokeniser.skipComments <* eof).parse("/*/*hello world*/ this /*comment is nested*/") shouldBe a [Failure]
+        (tokeniser.skipComments <* eof).parse("/*/*hello world*/ this /*comment is nested*/") shouldBe a [Failure[_]]
     }
     it should "not parse nested comments when applicable" in {
-        (tokeniser_.skipComments <* eof).parse("/*/*hello world*/ this /*comment*/ is nested*/") shouldBe a [Failure]
+        (tokeniser_.skipComments <* eof).parse("/*/*hello world*/ this /*comment*/ is nested*/") shouldBe a [Failure[_]]
         (tokeniser_.skipComments <* eof).parse("/*/*hello world this /*comment is nested*/") should be (Success(()))
     }
 
     "whiteSpace" should "parse all whitespace" in {
-        (tokeniser.whiteSpace <* eof).parse(" \n\t \r\n ") should not be a [Failure]
+        (tokeniser.whiteSpace <* eof).parse(" \n\t \r\n ") should not be a [Failure[_]]
     }
     it should "parse comments interleaved with spaces" in {
-        (tokeniser.whiteSpace <* eof).parse("/*this comment*/ /*is spaced out*/\n//by whitespace!\n ") should not be a [Failure]
+        (tokeniser.whiteSpace <* eof).parse("/*this comment*/ /*is spaced out*/\n//by whitespace!\n ") should not be a [Failure[_]]
     }
     it must "be the same regardless of the intrinsic" in {
         (tokeniser.whiteSpace <* eof).parse(" \n\t \r\n ") should equal {


### PR DESCRIPTION
This PR introduces a new package for errors in the base, as well as a new error builder so that users can change the formatting of the errors in a uniform way. This functionality is currently subject to alterations, as I want to make the API a little easier to extend and use.