### PR TITLE
Parsley 3 Precedence Enhancements

### DIFF
--- a/src/main/scala-2.12/parsley/XCompat.scala
+++ b/src/main/scala-2.12/parsley/XCompat.scala
@@ -4,11 +4,18 @@ import scala.collection.mutable
 import scala.language.higherKinds
 
 private [parsley] object XCompat {
-    def isIdentityWrap[A, B](f: A => B): Boolean = f eq $conforms[A]
-
     def refl[A]: A =:= A = implicitly[A =:= A]
+    def applyWrap[A, B](f: A => B)(p: Parsley[A]): Parsley[B] = f match {
+        case refl: (A <:< B) => refl.substituteCo[Parsley](p)
+        case refl: (A =:= B) => refl.substituteCo[Parsley](p)
+        case wrap => p.map(wrap)
+    }
 
-    implicit class Subtitution[A, B](ev: A =:= B) {
+    implicit class SubtitutionEq[A, B](ev: A =:= B) {
+        def substituteCo[F[_]](fa: F[A]): F[B] = fa.asInstanceOf[F[B]]
+    }
+
+    implicit class SubtitutionSub[A, B](ev: A <:< B) {
         def substituteCo[F[_]](fa: F[A]): F[B] = fa.asInstanceOf[F[B]]
     }
 

--- a/src/main/scala-2.13+/parsley/XCompat.scala
+++ b/src/main/scala-2.13+/parsley/XCompat.scala
@@ -3,6 +3,9 @@ package parsley
 import scala.collection.mutable
 
 private[parsley] object XCompat {
-  def refl[A]: A =:= A = <:<.refl
-  def isIdentityWrap[A, B](f: A => B): Boolean = f eq refl
+    def refl[A]: A =:= A = <:<.refl
+    def applyWrap[A, B](f: A => B)(p: Parsley[A]): Parsley[B] = f match {
+        case refl: (A <:< B) => refl.substituteCo[Parsley](p)
+        case wrap => p.map(wrap)
+    }
 }

--- a/src/main/scala/parsley/expr/Fixity.scala
+++ b/src/main/scala/parsley/expr/Fixity.scala
@@ -4,12 +4,13 @@ import scala.language.higherKinds
 
 /**
   * Denotes the fixity and associativity of an operator. Importantly, it also specifies the type of the
-  * of the operations themselves. For non-monolithic structures this is described by `fixity.GOp` and
-  * for monolithic/subtyping based structures this is described by `fixity.Op`.
+  * of the operations themselves. For non-monolithic structures this is described by `fixity.GOp`, subtyped
+  * structures `fixity.SOp`, and for monolithic structures `fixity.Op`.
   * @since 2.2.0
   */
 sealed trait Fixity {
   type Op[A] = GOp[A, A]
+  type SOp[-A, B >: A] = GOp[A, B]
   type GOp[-A, B]
 }
 

--- a/src/main/scala/parsley/expr/Fixity.scala
+++ b/src/main/scala/parsley/expr/Fixity.scala
@@ -10,7 +10,7 @@ import scala.language.higherKinds
   */
 sealed trait Fixity {
   type Op[A] = GOp[A, A]
-  type SOp[-A, B >: A] = GOp[A, B]
+  type SOp[A, B >: A] <: GOp[A, B]
   type GOp[-A, B]
 }
 
@@ -20,6 +20,7 @@ sealed trait Fixity {
   */
 case object InfixL extends Fixity {
   override type GOp[-A, B] = (B, A) => B
+  override type SOp[-A, B >: A] = (B, A) => B
 }
 
 /**
@@ -28,6 +29,7 @@ case object InfixL extends Fixity {
   */
 case object InfixR extends Fixity {
   override type GOp[-A, B] = (A, B) => B
+  override type SOp[-A, B >: A] = (A, B) => B
 }
 
 /**
@@ -36,6 +38,7 @@ case object InfixR extends Fixity {
   */
 case object Prefix extends Fixity {
   override type GOp[-A, B] = B => B
+  override type SOp[A, B >: A] = B => B
 }
 
 /**
@@ -44,4 +47,5 @@ case object Prefix extends Fixity {
   */
 case object Postfix extends Fixity {
   override type GOp[-A, B] = B => B
+  override type SOp[A, B >: A] = B => B
 }

--- a/src/main/scala/parsley/expr/Fixity.scala
+++ b/src/main/scala/parsley/expr/Fixity.scala
@@ -9,9 +9,9 @@ import scala.language.higherKinds
   * @since 2.2.0
   */
 sealed trait Fixity {
-  type Op[A] = GOp[A, A]
-  type SOp[A, B >: A] <: GOp[A, B]
-  type GOp[-A, B]
+    type Op[A] = GOp[A, A]
+    type SOp[A, B >: A] <: GOp[A, B]
+    type GOp[-A, B]
 }
 
 /**
@@ -19,8 +19,8 @@ sealed trait Fixity {
   * @since 2.2.0
   */
 case object InfixL extends Fixity {
-  override type GOp[-A, B] = (B, A) => B
-  override type SOp[-A, B >: A] = (B, A) => B
+    override type GOp[-A, B] = (B, A) => B
+    override type SOp[-A, B >: A] = (B, A) => B
 }
 
 /**
@@ -28,8 +28,8 @@ case object InfixL extends Fixity {
   * @since 2.2.0
   */
 case object InfixR extends Fixity {
-  override type GOp[-A, B] = (A, B) => B
-  override type SOp[-A, B >: A] = (A, B) => B
+    override type GOp[-A, B] = (A, B) => B
+    override type SOp[-A, B >: A] = (A, B) => B
 }
 
 /**
@@ -37,8 +37,8 @@ case object InfixR extends Fixity {
   * @since 2.2.0
   */
 case object Prefix extends Fixity {
-  override type GOp[-A, B] = B => B
-  override type SOp[A, B >: A] = B => B
+    override type GOp[-A, B] = B => B
+    override type SOp[A, B >: A] = B => B
 }
 
 /**
@@ -46,6 +46,15 @@ case object Prefix extends Fixity {
   * @since 2.2.0
   */
 case object Postfix extends Fixity {
-  override type GOp[-A, B] = B => B
-  override type SOp[A, B >: A] = B => B
+    override type GOp[-A, B] = B => B
+    override type SOp[A, B >: A] = B => B
+}
+
+/**
+  * Describes non-associative operators
+  * @since 3.0.0
+  */
+case object NonAssoc extends Fixity {
+    override type GOp[-A, +B] = (A, A) => B
+    override type SOp[-A, B >: A] = (A, A) => B
 }

--- a/src/main/scala/parsley/expr/Levels.scala
+++ b/src/main/scala/parsley/expr/Levels.scala
@@ -25,9 +25,9 @@ sealed trait Levels[-A, +B]
  * @since 3.0.0
  */
 case class Level[-A, B, C](lvls: Levels[A, B], ops: Ops[B, C]) extends Levels[A, C]
-private [expr] case class Atoms[A, B](ev: A =:= B, atoms: Parsley[A]*) extends Levels[A, B]
+private [expr] case class Atoms_[A, B](ev: A =:= B, atoms: Parsley[A]*) extends Levels[A, B]
 object Atoms {
-    def apply[A](atoms: Parsley[A]*): Levels[A, A] = new Atoms(refl[A], atoms: _*)
+    def apply[A](atoms: Parsley[A]*): Levels[A, A] = new Atoms_(refl[A], atoms: _*)
 }
 object Levels {
     implicit class LevelBuilder[-A, +B](lvls: Levels[A, B]) {

--- a/src/main/scala/parsley/expr/Levels.scala
+++ b/src/main/scala/parsley/expr/Levels.scala
@@ -1,6 +1,7 @@
 package parsley.expr
 
 import parsley.XCompat._
+import parsley.Parsley
 
 /**
  * For more complex expression parser types `Levels` can be used to
@@ -8,33 +9,29 @@ import parsley.XCompat._
  * structure between each level.
  * @tparam A The base type accepted by this list of levels
  * @tparam B The type of structure produced by the list of levels
- * @since 2.2.0
+ * @since 3.0.0
  */
 sealed trait Levels[-A, +B]
 /**
  * This represents a single new level of the hierarchy, with stronger
  * precedence than its tail.
- * @tparam A The base type accepted by this layer
- * @tparam B The intermediate type that will be provided to the next layer
- * @tparam C The type of structure produced by the next layers
+ * @tparam A The base type accepted by the layer below
+ * @tparam B The intermediate type produced by the layer below to be fed into this level
+ * @tparam C The type of structure produced by this layer
  * @param ops The operators accepted at this level
- * @param lvls The next, weaker, levels in the precedence table
+ * @param lvls The next, stronger, levels in the precedence table
  * @return A larger precedence table transforming atoms of type `A` into
  *          a structure of type `C`.
- * @since 2.2.0
+ * @since 3.0.0
  */
-final case class Level[-A, B, +C](ops: Ops[A, B], lvls: Levels[B, C]) extends Levels[A, C]
-private [expr] final case class NoLevel[A, B](ev: A =:= B) extends Levels[A, B]
+case class Level[-A, B, C](lvls: Levels[A, B], ops: Ops[B, C]) extends Levels[A, C]
+private [expr] case class Atoms[A, B](ev: A =:= B, atoms: Parsley[A]*) extends Levels[A, B]
+object Atoms {
+    def apply[A](atoms: Parsley[A]*): Levels[A, A] = new Atoms(refl[A], atoms: _*)
+}
 object Levels {
-    /**
-     * This represents the end of a precedence table. It will not
-     * touch the structure in any way.
-     * @tparam A The type of the structure to be produced by the table.
-     * @since 2.2.0
-     */
-    def empty[A]: Levels[A, A] = NoLevel(refl[A])
-
-    implicit class LevelBuilder[B, +C](lvls: Levels[B, C]) {
-        def +:[A](lvl: Ops[A, B]): Levels[A, C] = Level(lvl, lvls)
+    implicit class LevelBuilder[-A, +B](lvls: Levels[A, B]) {
+        def :+[C](lvl: Ops[B, C]): Levels[A, C] = Level(lvls, lvl)
+        def +:[C](lvl: Ops[B, C]): Levels[A, C] = Level(lvls, lvl)
     }
 }

--- a/src/main/scala/parsley/expr/Levels.scala
+++ b/src/main/scala/parsley/expr/Levels.scala
@@ -4,34 +4,50 @@ import parsley.XCompat._
 import parsley.Parsley
 
 /**
- * For more complex expression parser types `Levels` can be used to
- * describe the precedence table whilst preserving the intermediate
- * structure between each level.
- * @tparam A The base type accepted by this list of levels
- * @tparam B The type of structure produced by the list of levels
- * @since 3.0.0
- */
-sealed trait Levels[-A, +B]
+  * For more complex expression parser types `Levels` can be used to
+  * describe the precedence table whilst preserving the intermediate
+  * structure between each level.
+  * @tparam A The base type accepted by this list of levels
+  * @tparam B The type of structure produced by the list of levels
+  * @since 3.0.0
+  */
+sealed trait Levels[-A, +B] {
+    /**
+      * Builds a larger precedence table from strongest to weakest
+      * @tparam C The new result type for the larger table
+      * @param ops The operators that transform the previous, stronger, layer into the new result
+      */
+    final def :+[C](ops: Ops[B, C]): Levels[A, C] = Level(this, ops)
+    /**
+      * Builds a larger parser precedence table from weakest to strongest
+      * @tparam C The new result type for the larger table
+      * @param ops The operators that transform the next, stronger, layer into the new result
+      */
+    final def +:[C](ops: Ops[B, C]): Levels[A, C] = Level(this, ops)
+}
 /**
- * This represents a single new level of the hierarchy, with stronger
- * precedence than its tail.
- * @tparam A The base type accepted by the layer below
- * @tparam B The intermediate type produced by the layer below to be fed into this level
- * @tparam C The type of structure produced by this layer
- * @param ops The operators accepted at this level
- * @param lvls The next, stronger, levels in the precedence table
- * @return A larger precedence table transforming atoms of type `A` into
- *          a structure of type `C`.
- * @since 3.0.0
- */
+  * This represents a single new level of the hierarchy, with stronger
+  * precedence than its tail.
+  * @tparam A The base type accepted by the layer below
+  * @tparam B The intermediate type produced by the layer below to be fed into this level
+  * @tparam C The type of structure produced by this layer
+  * @param ops The operators accepted at this level
+  * @param lvls The next, stronger, levels in the precedence table
+  * @return A larger precedence table transforming atoms of type `A` into
+  *          a structure of type `C`.
+  * @since 3.0.0
+  */
 case class Level[-A, B, C](lvls: Levels[A, B], ops: Ops[B, C]) extends Levels[A, C]
 private [expr] case class Atoms_[A, B](ev: A =:= B, atoms: Parsley[A]*) extends Levels[A, B]
+
+/**
+  * This represents the final level of the hierarchy, with the strongest binding.
+  */
 object Atoms {
+    /**
+      * Given some atoms, produces the base of the precedence hierarchy
+      * @tparam A The base type of the hierarchy
+      * @param atoms The atoms at the bottom of the precedence table
+      */
     def apply[A](atoms: Parsley[A]*): Levels[A, A] = new Atoms_(refl[A], atoms: _*)
-}
-object Levels {
-    implicit class LevelBuilder[-A, +B](lvls: Levels[A, B]) {
-        def :+[C](lvl: Ops[B, C]): Levels[A, C] = Level(lvls, lvl)
-        def +:[C](lvl: Ops[B, C]): Levels[A, C] = Level(lvls, lvl)
-    }
 }

--- a/src/main/scala/parsley/expr/Ops.scala
+++ b/src/main/scala/parsley/expr/Ops.scala
@@ -63,12 +63,7 @@ object SOps {
     * @param ops The operators themselves, in varargs
     * @since 3.0.0
     */
-    def apply[B, A <: B](fixity: Fixity)(ops: Parsley[fixity.SOp[A, B]]*): Ops[A, B] = fixity match {
-        case InfixL  => Lefts[A, B](ops.asInstanceOf[Seq[Parsley[InfixL.SOp[A, B]]]]: _*)
-        case InfixR  => Rights[A, B](ops.asInstanceOf[Seq[Parsley[InfixR.SOp[A, B]]]]: _*)
-        case Prefix  => Prefixes[A, B](ops.asInstanceOf[Seq[Parsley[Prefix.SOp[A, B]]]]: _*)
-        case Postfix => Postfixes[A, B](ops.asInstanceOf[Seq[Parsley[Postfix.SOp[A, B]]]]: _*)
-    }
+    def apply[B, A <: B](fixity: Fixity)(ops: Parsley[fixity.SOp[A, B]]*): Ops[A, B] = GOps(fixity)(ops: _*)
 }
 
 /**

--- a/src/main/scala/parsley/expr/Ops.scala
+++ b/src/main/scala/parsley/expr/Ops.scala
@@ -7,7 +7,7 @@ import parsley.Parsley
  * consume `B`s, possibly `A`s and produce `B`s: this depends on the [[Fixity]] of the operators.
  * @tparam A The base type consumed by the operators
  * @tparam B The type produced/consumed by the operators
- * @note For less complex types, such as those which use subtyping `Ops[A, A]` is sufficient
+ * @note For less complex types `Ops[A, A]` is sufficient
  * @since 2.2.0
  */
 trait Ops[-A, B] {

--- a/src/main/scala/parsley/expr/Ops.scala
+++ b/src/main/scala/parsley/expr/Ops.scala
@@ -13,10 +13,10 @@ import parsley.Parsley
 trait Ops[-A, B] {
     private [expr] val wrap: A => B
 }
-private [expr] case class Lefts[-A, B](ops: Parsley[(B, A) => B]*)(override val wrap: A => B) extends Ops[A, B]
-private [expr] case class Rights[-A, B](ops: Parsley[(A, B) => B]*)(override val wrap: A => B) extends Ops[A, B]
-private [expr] case class Prefixes[-A, B](ops: Parsley[B => B]*)(override val wrap: A => B) extends Ops[A, B]
-private [expr] case class Postfixes[-A, B](ops: Parsley[B => B]*)(override val wrap: A => B) extends Ops[A, B]
+private [expr] case class Lefts[-A, B](ops: Parsley[(B, A) => B]*)(implicit override val wrap: A => B) extends Ops[A, B]
+private [expr] case class Rights[-A, B](ops: Parsley[(A, B) => B]*)(implicit override val wrap: A => B) extends Ops[A, B]
+private [expr] case class Prefixes[-A, B](ops: Parsley[B => B]*)(implicit override val wrap: A => B) extends Ops[A, B]
+private [expr] case class Postfixes[-A, B](ops: Parsley[B => B]*)(implicit override val wrap: A => B) extends Ops[A, B]
 
 /**
  * Helper object to build values of `Ops[A, B]`, for generalised precedence parsing
@@ -39,10 +39,35 @@ object GOps {
     * @since 2.2.0
     */
     def apply[A, B](fixity: Fixity)(ops: Parsley[fixity.GOp[A, B]]*)(implicit wrap: A => B): Ops[A, B] = fixity match {
-        case InfixL  => Lefts[A, B](ops.asInstanceOf[Seq[Parsley[InfixL.GOp[A, B]]]]: _*)(wrap)
-        case InfixR  => Rights[A, B](ops.asInstanceOf[Seq[Parsley[InfixR.GOp[A, B]]]]: _*)(wrap)
-        case Prefix  => Prefixes[A, B](ops.asInstanceOf[Seq[Parsley[Prefix.GOp[A, B]]]]: _*)(wrap)
-        case Postfix => Postfixes[A, B](ops.asInstanceOf[Seq[Parsley[Postfix.GOp[A, B]]]]: _*)(wrap)
+        case InfixL  => Lefts[A, B](ops.asInstanceOf[Seq[Parsley[InfixL.GOp[A, B]]]]: _*)
+        case InfixR  => Rights[A, B](ops.asInstanceOf[Seq[Parsley[InfixR.GOp[A, B]]]]: _*)
+        case Prefix  => Prefixes[A, B](ops.asInstanceOf[Seq[Parsley[Prefix.GOp[A, B]]]]: _*)
+        case Postfix => Postfixes[A, B](ops.asInstanceOf[Seq[Parsley[Postfix.GOp[A, B]]]]: _*)
+    }
+}
+
+/**
+ * Helper object to build values of `Ops[A, B]`, for generalised precedence parsing
+ * @since 3.0.0
+ */
+object SOps {
+    /**
+    * '''NOTE''': Currently a bug in scaladoc incorrect displays this functions type, it should be:
+    * `fixity.SOp[A, B]`, NOT `SOp[A, B]`. Builds an `Ops` object which represents many operators
+    * which act at the same precedence level, with a given fixity. Using path-dependent typing,
+    * the given fixity describes the shape of the operators expected. For more information see
+    * [[https://github.com/j-mie6/Parsley/wiki/Building-Expression-Parsers the Parsley wiki]].
+    * @tparam B The type produced/consumed by the operators, must be a supertype of `A`
+    * @tparam A The base type consumed by the operators
+    * @param fixity The fixity of the operators described. See [[Fixity]]
+    * @param ops The operators themselves, in varargs
+    * @since 3.0.0
+    */
+    def apply[B, A <: B](fixity: Fixity)(ops: Parsley[fixity.SOp[A, B]]*): Ops[A, B] = fixity match {
+        case InfixL  => Lefts[A, B](ops.asInstanceOf[Seq[Parsley[InfixL.SOp[A, B]]]]: _*)
+        case InfixR  => Rights[A, B](ops.asInstanceOf[Seq[Parsley[InfixR.SOp[A, B]]]]: _*)
+        case Prefix  => Prefixes[A, B](ops.asInstanceOf[Seq[Parsley[Prefix.SOp[A, B]]]]: _*)
+        case Postfix => Postfixes[A, B](ops.asInstanceOf[Seq[Parsley[Postfix.SOp[A, B]]]]: _*)
     }
 }
 

--- a/src/main/scala/parsley/expr/Ops.scala
+++ b/src/main/scala/parsley/expr/Ops.scala
@@ -17,6 +17,7 @@ private [expr] case class Lefts[-A, B](ops: Parsley[(B, A) => B]*)(implicit over
 private [expr] case class Rights[-A, B](ops: Parsley[(A, B) => B]*)(implicit override val wrap: A => B) extends Ops[A, B]
 private [expr] case class Prefixes[-A, B](ops: Parsley[B => B]*)(implicit override val wrap: A => B) extends Ops[A, B]
 private [expr] case class Postfixes[-A, B](ops: Parsley[B => B]*)(implicit override val wrap: A => B) extends Ops[A, B]
+private [expr] case class NonAssocs[-A, B](ops: Parsley[(A, A) => B]*)(implicit override val wrap: A => B) extends Ops[A, B]
 
 /**
  * Helper object to build values of `Ops[A, B]`, for generalised precedence parsing
@@ -39,10 +40,11 @@ object GOps {
     * @since 2.2.0
     */
     def apply[A, B](fixity: Fixity)(ops: Parsley[fixity.GOp[A, B]]*)(implicit wrap: A => B): Ops[A, B] = fixity match {
-        case InfixL  => Lefts[A, B](ops.asInstanceOf[Seq[Parsley[InfixL.GOp[A, B]]]]: _*)
-        case InfixR  => Rights[A, B](ops.asInstanceOf[Seq[Parsley[InfixR.GOp[A, B]]]]: _*)
-        case Prefix  => Prefixes[A, B](ops.asInstanceOf[Seq[Parsley[Prefix.GOp[A, B]]]]: _*)
-        case Postfix => Postfixes[A, B](ops.asInstanceOf[Seq[Parsley[Postfix.GOp[A, B]]]]: _*)
+        case InfixL   => Lefts[A, B](ops.asInstanceOf[Seq[Parsley[InfixL.GOp[A, B]]]]: _*)
+        case InfixR   => Rights[A, B](ops.asInstanceOf[Seq[Parsley[InfixR.GOp[A, B]]]]: _*)
+        case Prefix   => Prefixes[A, B](ops.asInstanceOf[Seq[Parsley[Prefix.GOp[A, B]]]]: _*)
+        case Postfix  => Postfixes[A, B](ops.asInstanceOf[Seq[Parsley[Postfix.GOp[A, B]]]]: _*)
+        case NonAssoc => NonAssocs[A, B](ops.asInstanceOf[Seq[Parsley[NonAssoc.GOp[A, B]]]]: _*)
     }
 }
 

--- a/src/main/scala/parsley/expr/chain.scala
+++ b/src/main/scala/parsley/expr/chain.scala
@@ -47,8 +47,7 @@ object chain {
                    (implicit @implicitNotFound("Please provide a wrapper function from ${A} to ${B}") wrap: A => B): Parsley[B] = {
         lazy val _p = p
         // a sneaky sneaky trick :) If we know that A =:= B because refl was provided, then we can skip the wrapping
-        lazy val init = if (parsley.XCompat.isIdentityWrap(wrap)) _p.asInstanceOf[Parsley[B]] else _p.map(wrap)
-        new Parsley(new deepembedding.Chainl(init.internal, _p.internal, op.internal))
+        new Parsley(new deepembedding.Chainl(parsley.XCompat.applyWrap(wrap)(_p).internal, _p.internal, op.internal))
     }
 
     /**`prefix(op, p)` parses many prefixed applications of `op` onto a single final result of `p`

--- a/src/main/scala/parsley/expr/precedence.scala
+++ b/src/main/scala/parsley/expr/precedence.scala
@@ -31,17 +31,26 @@ object precedence {
     }
 
     /** This is used to build an expression parser for a monolithic type. Levels are specified from strongest
-     * to weakest.
-     * @tparam A The type of the monolithic tree
-     * @param atoms The atomic units of the expression, for instance numbers/variables
-     * @param table A table of operators. Table is ordered highest precedence to lowest precedence.
-     *              Each list in the table corresponds to operators of the same precedence level.
-     * @return A parser for the described expression language
-     * @since 3.0.0
-     */
+      * to weakest.
+      * @tparam A The type of the monolithic result
+      * @param atoms The atomic units of the expression, for instance numbers/variables
+      * @param table A table of operators. Table is ordered highest precedence to lowest precedence.
+      *              Each list in the table corresponds to operators of the same precedence level.
+      * @return A parser for the described expression language
+      * @since 3.0.0
+      */
     def apply[A](atoms: Parsley[A]*)(table: Ops[A, A]*): Parsley[A] = apply(table.foldLeft(Atoms(atoms: _*))(Level.apply[A, A, A]))
 
-    //def apply[A](atoms: Parsley[A]*)(table: Ops[A, A]*): Parsley[A] = apply(table.foldLeft(Atoms(atoms: _*))(Lvl.apply[A, A, A]))
+    /** This is used to build an expression parser for a monolithic type. Levels are specified from weakest
+      * to strongest.
+      * @tparam A The type of the monolithic result
+      * @param atom The atomic unit of the expression, for instance numbers/variables
+      * @param table A table of operators. Table is ordered highest precedence to lowest precedence.
+      *              Each list in the table corresponds to operators of the same precedence level.
+      * @return A parser for the described expression language
+      * @since 3.0.0
+      */
+    def apply[A](table: Ops[A, A]*)(atom: Parsley[A]): Parsley[A] = apply(atom)(table.reverse: _*)
 
     /** This is used to build an expression parser for a multi-layered expression tree type. Levels can be
       * either tightest to loosest binding (using `:+`) or loosest to tightest (using `+:`)

--- a/src/main/scala/parsley/expr/precedence.scala
+++ b/src/main/scala/parsley/expr/precedence.scala
@@ -20,7 +20,7 @@ object precedence {
     }
 
     private def crushLevels[A, B](lvls: Levels[A, B]): Parsley[B] = lvls match {
-        case Atoms(ev, atoms@_*) => ev.substituteCo[Parsley](choice(atoms: _*))
+        case Atoms_(ev, atoms@_*) => ev.substituteCo[Parsley](choice(atoms: _*))
         case Level(lvls, ops) => convertOperators(crushLevels(lvls), ops)(ops.wrap)
     }
 

--- a/src/main/scala/parsley/expr/precedence.scala
+++ b/src/main/scala/parsley/expr/precedence.scala
@@ -1,7 +1,5 @@
 package parsley.expr
 
-import scala.annotation.tailrec
-
 import parsley.Parsley
 import parsley.combinator.choice
 import parsley.XCompat._
@@ -14,9 +12,9 @@ object precedence {
     {
         case Lefts(ops @ _*) => chain.left1(atom, choice(ops: _*))
         case Rights(ops @ _*) => chain.right1(atom, choice(ops: _*))
-        case Prefixes(ops @ _*) => chain.prefix(choice(ops: _*), atom.map(wrap))
+        case Prefixes(ops @ _*) => chain.prefix(choice(ops: _*), parsley.XCompat.applyWrap(wrap)(atom))
         // FIXME: Postfix operators which are similar to binary ops may fail, how can we work around this?
-        case Postfixes(ops @ _*) => chain.postfix(atom.map(wrap), choice(ops: _*))
+        case Postfixes(ops @ _*) => chain.postfix(parsley.XCompat.applyWrap(wrap)(atom), choice(ops: _*))
     }
 
     private def crushLevels[A, B](lvls: Levels[A, B]): Parsley[B] = lvls match {

--- a/src/test/scala/parsley/ExpressionParserTests.scala
+++ b/src/test/scala/parsley/ExpressionParserTests.scala
@@ -3,7 +3,7 @@ package parsley
 import parsley.character.digit
 import parsley.implicits.character.{charLift, stringLift}
 import parsley.expr.chain
-import parsley.expr.{precedence, Ops, GOps, InfixL, InfixR, Prefix, Postfix, Atoms}
+import parsley.expr.{precedence, Ops, GOps, SOps, InfixL, InfixR, Prefix, Postfix, Atoms}
 import parsley.Parsley._
 import parsley._
 
@@ -185,8 +185,8 @@ class ExpressionParserTests extends ParsleyTest {
         case class Parens(x: Expr) extends Atom
         case class Num(x: Int) extends Atom
         lazy val expr: Parsley[Expr] = precedence(
-            GOps[Term, Expr](InfixL)('+' #> Add) +:
-            GOps[Atom, Term](InfixR)('*' #> Mul) +:
+            SOps(InfixL)('+' #> Add) +:
+            SOps(InfixR)('*' #> Mul) +:
             Atoms(digit.map(_.asDigit).map(Num), '(' *> expr.map(Parens) <* ')'))
         expr.parse("(7+8)*2+3+6*2") should be (Success(Add(Add(Mul(Parens(Add(Num(7), Num(8))), Num(2)), Num(3)), Mul(Num(6), Num(2)))))
     }

--- a/src/test/scala/parsley/ExpressionParserTests.scala
+++ b/src/test/scala/parsley/ExpressionParserTests.scala
@@ -257,15 +257,15 @@ class ExpressionParserTests extends ParsleyTest {
 
         val tok = new token.Lexer(lang)
 
-        lazy val ops: List[Ops[Expr, Expr]] = List(
-            Ops(Postfix)(tok.parens(expr </> Constant("")).map(e1 => (e2: Expr) => Binary(e2, e1))),
-            Ops(InfixL)('.' #> Binary),
+        lazy val ops: Seq[Ops[Expr, Expr]] = Seq(
+            Ops(InfixR)(',' #> Binary),
             Ops(InfixR)(".=" #> Binary),
-            Ops(InfixR)(',' #> Binary)
+            Ops(InfixL)('.' #> Binary),
+            Ops(Postfix)(tok.parens(expr </> Constant("")).map(e1 => Binary(_, e1)))
         )
 
         lazy val atom: Parsley[Expr] = tok.identifier.map(Constant)
-        lazy val expr: Parsley[Expr] = precedence(atom)(ops: _*)
+        lazy val expr: Parsley[Expr] = precedence(ops: _*)(atom)
 
         expr.parse("o.f()") shouldBe a [Success[_]]
         expr.parse("o.f(x,y)") shouldBe a [Success[_]]

--- a/src/test/scala/parsley/ExpressionParserTests.scala
+++ b/src/test/scala/parsley/ExpressionParserTests.scala
@@ -180,13 +180,16 @@ class ExpressionParserTests extends ParsleyTest {
         sealed trait Expr
         case class Add(x: Expr, y: Term) extends Expr
         sealed trait Term extends Expr
-        case class Mul(x: Atom, y: Term) extends Term
-        sealed trait Atom extends Term
+        case class Mul(x: Factor, y: Term) extends Term
+        sealed trait Factor extends Term
+        case class Neg(x: Factor) extends Factor
+        sealed trait Atom extends Factor
         case class Parens(x: Expr) extends Atom
         case class Num(x: Int) extends Atom
         lazy val expr: Parsley[Expr] = precedence(
             SOps(InfixL)('+' #> Add) +:
             SOps(InfixR)('*' #> Mul) +:
+            SOps[Factor, Atom](Prefix)('-' #> Neg) +:
             Atoms(digit.map(_.asDigit).map(Num), '(' *> expr.map(Parens) <* ')'))
         expr.parse("(7+8)*2+3+6*2") should be (Success(Add(Add(Mul(Parens(Add(Num(7), Num(8))), Num(2)), Num(3)), Mul(Num(6), Num(2)))))
     }


### PR DESCRIPTION
This introduces some improvements to the `GOps` mechanism, making the precedence table reversible, and removing the redundant empty level. Additionally, I've added in an `SOps` object, which improves the inference for subtyped ASTs previously making use of `GOps`. Operators using `Prefix` and `Postfix` now avoid wrapping when only an upcast is required. 

Added `NonAssoc` fixity, which allows for non-chain precedence table.