### PR TITLE
Error offset correctors

### DIFF
--- a/js/src/test/scala/parsley/internal/machine/errors/DefuncErrorTests.scala
+++ b/js/src/test/scala/parsley/internal/machine/errors/DefuncErrorTests.scala
@@ -182,4 +182,34 @@ class DefuncErrorTests extends ParsleyTest {
         errShow.asParseError.asInstanceOf[TrivialError].expecteds should contain only (Desc("x"))
         errHide.asParseError.asInstanceOf[TrivialError].expecteds shouldBe empty
     }
+
+    "Amended" should "Change the error position information" in {
+        val err = Amended(10, 10, 10, EmptyError(0, 0, 0))
+        val errOut = err.asParseError
+        errOut.col shouldBe 10
+        errOut.line shouldBe 10
+        errOut.offset shouldBe 10
+    }
+    it should "work for fancy errors too" in {
+        val err = Amended(10, 10, 10, ClassicFancyError(0, 0, 0, ""))
+        val errOut = err.asParseError
+        errOut.col shouldBe 10
+        errOut.line shouldBe 10
+        errOut.offset shouldBe 10
+    }
+
+    "Entrenched" should "guard against amendment" in {
+        val err = Amended(10, 10, 10, Entrenched(EmptyError(0, 0, 0)))
+        val errOut = err.asParseError
+        errOut.col shouldBe 0
+        errOut.line shouldBe 0
+        errOut.offset shouldBe 0
+    }
+    it should "work for fancy errors too" in {
+        val err = Amended(10, 10, 10, Entrenched(ClassicFancyError(0, 0, 0, "")))
+        val errOut = err.asParseError
+        errOut.col shouldBe 0
+        errOut.line shouldBe 0
+        errOut.offset shouldBe 0
+    }
 }

--- a/jvm/src/test/scala/parsley/internal/machine/errors/DefuncErrorTests.scala
+++ b/jvm/src/test/scala/parsley/internal/machine/errors/DefuncErrorTests.scala
@@ -182,4 +182,34 @@ class DefuncErrorTests extends ParsleyTest {
         errShow.asParseError.asInstanceOf[TrivialError].expecteds should contain only (Desc("x"))
         errHide.asParseError.asInstanceOf[TrivialError].expecteds shouldBe empty
     }
+
+    "Amended" should "Change the error position information" in {
+        val err = Amended(10, 10, 10, EmptyError(0, 0, 0))
+        val errOut = err.asParseError
+        errOut.col shouldBe 10
+        errOut.line shouldBe 10
+        errOut.offset shouldBe 10
+    }
+    it should "work for fancy errors too" in {
+        val err = Amended(10, 10, 10, ClassicFancyError(0, 0, 0, ""))
+        val errOut = err.asParseError
+        errOut.col shouldBe 10
+        errOut.line shouldBe 10
+        errOut.offset shouldBe 10
+    }
+
+    "Entrenched" should "guard against amendment" in {
+        val err = Amended(10, 10, 10, Entrenched(EmptyError(0, 0, 0)))
+        val errOut = err.asParseError
+        errOut.col shouldBe 0
+        errOut.line shouldBe 0
+        errOut.offset shouldBe 0
+    }
+    it should "work for fancy errors too" in {
+        val err = Amended(10, 10, 10, Entrenched(ClassicFancyError(0, 0, 0, "")))
+        val errOut = err.asParseError
+        errOut.col shouldBe 0
+        errOut.line shouldBe 0
+        errOut.offset shouldBe 0
+    }
 }

--- a/native/src/test/scala/parsley/internal/machine/errors/DefuncErrorTests.scala
+++ b/native/src/test/scala/parsley/internal/machine/errors/DefuncErrorTests.scala
@@ -182,4 +182,34 @@ class DefuncErrorTests extends ParsleyTest {
         errShow.asParseError.asInstanceOf[TrivialError].expecteds should contain only (Desc("x"))
         errHide.asParseError.asInstanceOf[TrivialError].expecteds shouldBe empty
     }
+
+    "Amended" should "Change the error position information" in {
+        val err = Amended(10, 10, 10, EmptyError(0, 0, 0))
+        val errOut = err.asParseError
+        errOut.col shouldBe 10
+        errOut.line shouldBe 10
+        errOut.offset shouldBe 10
+    }
+    it should "work for fancy errors too" in {
+        val err = Amended(10, 10, 10, ClassicFancyError(0, 0, 0, ""))
+        val errOut = err.asParseError
+        errOut.col shouldBe 10
+        errOut.line shouldBe 10
+        errOut.offset shouldBe 10
+    }
+
+    "Entrenched" should "guard against amendment" in {
+        val err = Amended(10, 10, 10, Entrenched(EmptyError(0, 0, 0)))
+        val errOut = err.asParseError
+        errOut.col shouldBe 0
+        errOut.line shouldBe 0
+        errOut.offset shouldBe 0
+    }
+    it should "work for fancy errors too" in {
+        val err = Amended(10, 10, 10, Entrenched(ClassicFancyError(0, 0, 0, "")))
+        val errOut = err.asParseError
+        errOut.col shouldBe 0
+        errOut.line shouldBe 0
+        errOut.offset shouldBe 0
+    }
 }

--- a/src/main/scala/parsley/errors/DefaultErrorBuilder.scala
+++ b/src/main/scala/parsley/errors/DefaultErrorBuilder.scala
@@ -53,7 +53,7 @@ class DefaultErrorBuilder extends ErrorBuilder[String] with revisions.Revision1 
 
     private def combineOrUnknown(info: List[String], lines: List[String]): ErrorInfoLines = {
         if (info.isEmpty) Unknown :: lines
-        else info ++ lines
+        else info ::: lines
     }
 
     type ExpectedItems = Option[String]

--- a/src/main/scala/parsley/errors/combinator.scala
+++ b/src/main/scala/parsley/errors/combinator.scala
@@ -22,6 +22,28 @@ object combinator {
     def unexpected(msg: String): Parsley[Nothing] = new Parsley(new deepembedding.Unexpected(msg))
 
     /**
+      * This combinator adjusts the error messages that are generated within its scope so that they
+      * happen at the position on entry to the combinator. This is useful if validation work is done
+      * on the output of a parser that may render it invalid, but the error should point to the
+      * beginning of the structure. This combinators effect can be cancelled with `[[entrench]]`
+      *
+      * @param p A parser whose error messages should be adjusted
+      * @since 3.1.0
+      */
+    def amend[A](p: =>Parsley[A]): Parsley[A] = new Parsley(new deepembedding.ErrorAmend(p.internal))
+
+    /**
+      * Sometimes, the error adjustments performed by `[[amend]]` should only affect errors generated
+      * within a certain part of a parser and not the whole thing. In this case, `entrench` can be used
+      * to protect sub-parsers from having their errors adjusted, providing a much more fine-grained
+      * scope for error adjustment.
+      *
+      * @param p A parser whose error messages should not be adjusted by any surrounding `[[amend]]`
+      * @since 3.1.0
+      */
+    def entrench[A](p: =>Parsley[A]): Parsley[A] = new Parsley(new deepembedding.ErrorEntrench(p.internal))
+
+    /**
       * This class exposes helpful combinators that are specialised for generating more helpful errors messages.
       * For a description of why the library is designed in this way,
       * see: [[https://github.com/j-mie6/Parsley/wiki/Understanding-the-API the Parsley wiki]]

--- a/src/main/scala/parsley/errors/combinator.scala
+++ b/src/main/scala/parsley/errors/combinator.scala
@@ -13,7 +13,7 @@ object combinator {
       * The `fail(msgs)` parser consumes no input and fails with `msg` as the error message
       * @since 3.0.0
       */
-    def fail(msgs: String*): Parsley[Nothing] = choice(msgs.map(msg => new Parsley(new deepembedding.Fail(msg))): _*)
+    def fail(msgs: String*): Parsley[Nothing] = new Parsley(new deepembedding.Fail(msgs: _*))
 
     /**
       * The `unexpected(msg)` parser consumes no input and fails with `msg` as an unexpected error

--- a/src/main/scala/parsley/internal/deepembedding/ErrorEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/ErrorEmbedding.scala
@@ -1,0 +1,63 @@
+package parsley.internal.deepembedding
+
+import ContOps.{result, ContAdapter}
+import parsley.internal.machine.instructions
+
+private [parsley] final class Fail(private [Fail] val msg: String)
+    extends Singleton[Nothing](s"fail($msg)", new instructions.Fail(msg)) with MZero
+
+private [parsley] final class Unexpected(private [Unexpected] val msg: String)
+    extends Singleton[Nothing](s"unexpected($msg)", new instructions.Unexpected(msg)) with MZero
+
+private [parsley] final class ErrorLabel[A](_p: =>Parsley[A], private [ErrorLabel] val label: String)
+    extends Unary[A, A](_p)(c => s"$c.label($label)", ErrorLabel.empty(label)) {
+    final override val numInstrs = 2
+    final override def optimise: Parsley[A] = p match {
+        case ct@CharTok(c) if !ct.expected.contains("") => new CharTok(c, Some(label)).asInstanceOf[Parsley[A]]
+        case st@StringTok(s) if !st.expected.contains("") => new StringTok(s, Some(label)).asInstanceOf[Parsley[A]]
+        case sat@Satisfy(f) if !sat.expected.contains("") => new Satisfy(f, Some(label)).asInstanceOf[Parsley[A]]
+        case ErrorLabel(p, label2) if label2 != "" => ErrorLabel(p, label)
+        case _ => this
+    }
+    final override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont, R], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
+        val handler = state.freshLabel()
+        instrs += new instructions.InputCheck(handler, true)
+        p.codeGen |> {
+            instrs += new instructions.Label(handler)
+            instrs += new instructions.ApplyError(label)
+        }
+    }
+}
+private [parsley] final class ErrorExplain[A](_p: =>Parsley[A], reason: String)
+    extends Unary[A, A](_p)(c => s"$c.explain($reason)", ErrorExplain.empty(reason)) {
+    final override val numInstrs = 2
+    final override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont, R], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
+        val handler = state.freshLabel()
+        instrs += new instructions.InputCheck(handler)
+        p.codeGen |> {
+            instrs += new instructions.Label(handler)
+            instrs += new instructions.ApplyReason(reason)
+        }
+    }
+}
+
+private [parsley] final class ErrorAmend[A](_p: =>Parsley[A]) extends ScopedUnaryWithState[A, A](_p, "amend", false, ErrorAmend.empty, instructions.Amend)
+private [parsley] final class ErrorEntrench[A](_p: =>Parsley[A])
+    extends ScopedUnary[A, A](_p, "entrench", ErrorEntrench.empty, new instructions.PushHandler(_), instructions.Entrench)
+
+
+private [deepembedding] object ErrorLabel {
+    def empty[A](label: String): ErrorLabel[A] = new ErrorLabel(???, label)
+    def apply[A](p: Parsley[A], label: String): ErrorLabel[A] = empty(label).ready(p)
+    def unapply[A](self: ErrorLabel[A]): Some[(Parsley[A], String)] = Some((self.p, self.label))
+}
+private [deepembedding] object ErrorExplain {
+    def empty[A](reason: String): ErrorExplain[A] = new ErrorExplain(???, reason)
+    def apply[A](p: Parsley[A], reason: String): ErrorExplain[A] = empty(reason).ready(p)
+}
+private [deepembedding] object ErrorAmend {
+    def empty[A]: ErrorAmend[A] = new ErrorAmend(???)
+}
+private [deepembedding] object ErrorEntrench {
+    def empty[A]: ErrorEntrench[A] = new ErrorEntrench(???)
+}

--- a/src/main/scala/parsley/internal/deepembedding/ErrorEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/ErrorEmbedding.scala
@@ -10,8 +10,7 @@ private [parsley] final class Unexpected(private [Unexpected] val msg: String)
     extends Singleton[Nothing](s"unexpected($msg)", new instructions.Unexpected(msg)) with MZero
 
 private [parsley] final class ErrorLabel[A](_p: =>Parsley[A], private [ErrorLabel] val label: String)
-    extends Unary[A, A](_p)(c => s"$c.label($label)", ErrorLabel.empty(label)) {
-    final override val numInstrs = 2
+    extends ScopedUnary[A, A](_p, s"label($label)", ErrorLabel.empty(label), new instructions.InputCheck(_, true), new instructions.ApplyError(label)) {
     final override def optimise: Parsley[A] = p match {
         case ct@CharTok(c) if !ct.expected.contains("") => new CharTok(c, Some(label)).asInstanceOf[Parsley[A]]
         case st@StringTok(s) if !st.expected.contains("") => new StringTok(s, Some(label)).asInstanceOf[Parsley[A]]
@@ -19,27 +18,9 @@ private [parsley] final class ErrorLabel[A](_p: =>Parsley[A], private [ErrorLabe
         case ErrorLabel(p, label2) if label2 != "" => ErrorLabel(p, label)
         case _ => this
     }
-    final override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont, R], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
-        val handler = state.freshLabel()
-        instrs += new instructions.InputCheck(handler, true)
-        p.codeGen |> {
-            instrs += new instructions.Label(handler)
-            instrs += new instructions.ApplyError(label)
-        }
-    }
 }
 private [parsley] final class ErrorExplain[A](_p: =>Parsley[A], reason: String)
-    extends Unary[A, A](_p)(c => s"$c.explain($reason)", ErrorExplain.empty(reason)) {
-    final override val numInstrs = 2
-    final override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont, R], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
-        val handler = state.freshLabel()
-        instrs += new instructions.InputCheck(handler)
-        p.codeGen |> {
-            instrs += new instructions.Label(handler)
-            instrs += new instructions.ApplyReason(reason)
-        }
-    }
-}
+    extends ScopedUnary[A, A](_p, s"explain($reason)", ErrorExplain.empty(reason), new instructions.InputCheck(_), new instructions.ApplyReason(reason))
 
 private [parsley] final class ErrorAmend[A](_p: =>Parsley[A]) extends ScopedUnaryWithState[A, A](_p, "amend", false, ErrorAmend.empty, instructions.Amend)
 private [parsley] final class ErrorEntrench[A](_p: =>Parsley[A])

--- a/src/main/scala/parsley/internal/deepembedding/ErrorEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/ErrorEmbedding.scala
@@ -3,8 +3,8 @@ package parsley.internal.deepembedding
 import ContOps.{result, ContAdapter}
 import parsley.internal.machine.instructions
 
-private [parsley] final class Fail(private [Fail] val msg: String)
-    extends Singleton[Nothing](s"fail($msg)", new instructions.Fail(msg)) with MZero
+private [parsley] final class Fail(private [Fail] val msgs: String*)
+    extends Singleton[Nothing](s"fail(${msgs.mkString(", ")})", new instructions.Fail(msgs: _*)) with MZero
 
 private [parsley] final class Unexpected(private [Unexpected] val msg: String)
     extends Singleton[Nothing](s"unexpected($msg)", new instructions.Unexpected(msg)) with MZero
@@ -44,7 +44,6 @@ private [parsley] final class ErrorExplain[A](_p: =>Parsley[A], reason: String)
 private [parsley] final class ErrorAmend[A](_p: =>Parsley[A]) extends ScopedUnaryWithState[A, A](_p, "amend", false, ErrorAmend.empty, instructions.Amend)
 private [parsley] final class ErrorEntrench[A](_p: =>Parsley[A])
     extends ScopedUnary[A, A](_p, "entrench", ErrorEntrench.empty, new instructions.PushHandler(_), instructions.Entrench)
-
 
 private [deepembedding] object ErrorLabel {
     def empty[A](label: String): ErrorLabel[A] = new ErrorLabel(???, label)

--- a/src/main/scala/parsley/internal/machine/Context.scala
+++ b/src/main/scala/parsley/internal/machine/Context.scala
@@ -215,7 +215,7 @@ private [parsley] final class Context(private [machine] var instrs: Array[Instr]
         }
     }
 
-    private [machine] def failWithMessage(msg: String): Unit = this.fail(new ClassicFancyError(offset, line, col, msg))
+    private [machine] def failWithMessage(msgs: String*): Unit = this.fail(new ClassicFancyError(offset, line, col, msgs: _*))
     private [machine] def unexpectedFail(expected: Option[ErrorItem], unexpected: ErrorItem): Unit = {
         this.fail(new ClassicUnexpectedError(offset, line, col, expected, unexpected))
     }

--- a/src/main/scala/parsley/internal/machine/errors/DefuncError.scala
+++ b/src/main/scala/parsley/internal/machine/errors/DefuncError.scala
@@ -99,10 +99,10 @@ private [machine] case class ClassicUnexpectedError(offset: Int, line: Int, col:
         state.updateUnexpected(unexpected)
     }
 }
-private [machine] case class ClassicFancyError(offset: Int, line: Int, col: Int, msg: String) extends DefuncError with MakesFancy {
+private [machine] case class ClassicFancyError(offset: Int, line: Int, col: Int, msgs: String*) extends DefuncError with MakesFancy {
     override def makeFancy(state: FancyState): Unit = {
         state.pos_=(line, col)
-        state += msg
+        state ++= msgs
     }
 }
 private [machine] case class EmptyError(offset: Int, line: Int, col: Int) extends DefuncError with MakesTrivial  {
@@ -237,6 +237,7 @@ private [machine] object Amended {
 private [errors] case class Entrenched private (err: DefuncError) extends DefuncError with MakesTrivial with MakesFancy {
     override val isTrivialError: Boolean = err.isTrivialError
     override val isExpectedEmpty: Boolean = err.isExpectedEmpty
+    override val entrenched: Boolean = true
     val offset = err.offset
     override def makeTrivial(state: TrivialState): Unit = err.asInstanceOf[MakesTrivial].makeTrivial(state)
     override def makeFancy(state: FancyState): Unit = err.asInstanceOf[MakesFancy].makeFancy(state)

--- a/src/main/scala/parsley/internal/machine/errors/DefuncStates.scala
+++ b/src/main/scala/parsley/internal/machine/errors/DefuncStates.scala
@@ -68,7 +68,7 @@ private [errors] final class FancyState(offset: Int) {
         this.col = col
     }
 
-    def +=(msg: String): Unit = this.msgs += msg
+    def ++=(msg: Seq[String]): Unit = this.msgs ++= msg
     def mkError: FancyError = {
         new FancyError(offset, line, col, msgs.toSet)
     }

--- a/src/main/scala/parsley/internal/machine/instructions/ErrorInstrs.scala
+++ b/src/main/scala/parsley/internal/machine/instructions/ErrorInstrs.scala
@@ -113,10 +113,10 @@ private [internal] object Entrench extends Instr {
     // $COVERAGE-ON$
 }
 
-private [internal] final class Fail(msg: String) extends Instr {
-    override def apply(ctx: Context): Unit = ctx.failWithMessage(msg)
+private [internal] final class Fail(msgs: String*) extends Instr {
+    override def apply(ctx: Context): Unit = ctx.failWithMessage(msgs: _*)
     // $COVERAGE-OFF$
-    override def toString: String = s"Fail($msg)"
+    override def toString: String = s"Fail(${msgs.mkString(", ")})"
     // $COVERAGE-ON$
 }
 

--- a/src/main/scala/parsley/internal/machine/instructions/ErrorInstrs.scala
+++ b/src/main/scala/parsley/internal/machine/instructions/ErrorInstrs.scala
@@ -4,7 +4,7 @@ import parsley.internal.machine.{Context, Good}
 import parsley.internal.ResizableArray
 
 import parsley.internal.errors.{ErrorItem, Desc}
-import parsley.internal.machine.errors.{WithReason, MergedErrors, WithLabel}
+import parsley.internal.machine.errors.{WithReason, MergedErrors, WithLabel, Entrenched, Amended}
 
 private [internal] final class ApplyError(label: String) extends Instr {
     val isHide: Boolean = label.isEmpty
@@ -75,6 +75,41 @@ private [internal] class ApplyReason(reason: String) extends Instr {
 
     // $COVERAGE-OFF$
     override def toString: String = s"ApplyReason($reason)"
+    // $COVERAGE-ON$
+}
+
+private [internal] object Amend extends Instr {
+    override def apply(ctx: Context): Unit = {
+        if (ctx.status eq Good) {
+            ctx.handlers = ctx.handlers.tail
+            ctx.inc()
+        }
+        else {
+            ctx.errs.error = Amended(ctx.states.offset, ctx.states.line, ctx.states.col, ctx.errs.error)
+            ctx.fail()
+        }
+        ctx.states = ctx.states.tail
+    }
+
+    // $COVERAGE-OFF$
+    override def toString: String = "Amend"
+    // $COVERAGE-ON$
+}
+
+private [internal] object Entrench extends Instr {
+    override def apply(ctx: Context): Unit = {
+        if (ctx.status eq Good) {
+            ctx.handlers = ctx.handlers.tail
+            ctx.inc()
+        }
+        else {
+            ctx.errs.error = Entrenched(ctx.errs.error)
+            ctx.fail()
+        }
+    }
+
+    // $COVERAGE-OFF$
+    override def toString: String = "Entrench"
     // $COVERAGE-ON$
 }
 


### PR DESCRIPTION
Added the `amend` and `entrench` combinators, which work as a pair to correct (and prevent correction) of error messages in special circumstances.