### PR TITLE
Parsley 4 expression simplification

### DIFF
--- a/src/main/scala-2.12/parsley/XCompat.scala
+++ b/src/main/scala-2.12/parsley/XCompat.scala
@@ -4,18 +4,17 @@ import scala.collection.mutable
 import scala.language.higherKinds
 
 private [parsley] object XCompat {
-    def refl[A]: A =:= A = implicitly[A =:= A]
     def applyWrap[A, B](f: A => B)(p: Parsley[A]): Parsley[B] = f match {
         case refl: (A <:< B) => refl.substituteCo[Parsley](p)
         case refl: (A =:= B) => refl.substituteCo[Parsley](p)
         case wrap => p.map(wrap)
     }
 
-    implicit class SubtitutionEq[A, B](ev: A =:= B) {
+    private implicit class SubtitutionEq[A, B](ev: A =:= B) {
         def substituteCo[F[_]](fa: F[A]): F[B] = fa.asInstanceOf[F[B]]
     }
 
-    implicit class SubtitutionSub[A, B](ev: A <:< B) {
+    private implicit class SubtitutionSub[A, B](ev: A <:< B) {
         def substituteCo[F[_]](fa: F[A]): F[B] = fa.asInstanceOf[F[B]]
     }
 

--- a/src/main/scala-2.13+/parsley/XCompat.scala
+++ b/src/main/scala-2.13+/parsley/XCompat.scala
@@ -3,7 +3,6 @@ package parsley
 import scala.collection.mutable
 
 private[parsley] object XCompat {
-    def refl[A]: A =:= A = <:<.refl
     def applyWrap[A, B](f: A => B)(p: Parsley[A]): Parsley[B] = f match {
         case refl: (A <:< B) => refl.substituteCo[Parsley](p)
         case wrap => p.map(wrap)

--- a/src/main/scala-2.x/parsley/expr/Ops.scala
+++ b/src/main/scala-2.x/parsley/expr/Ops.scala
@@ -1,0 +1,39 @@
+package parsley.expr
+
+import parsley.Parsley
+
+/**
+ * Describes the operators at a specific level in the precedence tree, such that these ops
+ * consume `B`s, possibly `A`s and produce `B`s: this depends on the [[Fixity]] of the operators.
+ * @tparam A The base type consumed by the operators
+ * @tparam B The type produced/consumed by the operators
+ * @note For less complex types `Ops[A, A]` is sufficient
+ * @since 2.2.0
+ */
+sealed trait Ops[-A, B] {
+    private [expr] val wrap: A => B
+}
+private [expr] case class Lefts[A, B](ops: Parsley[InfixL.Op[A, B]]*)(implicit override val wrap: A => B) extends Ops[A, B]
+private [expr] case class Rights[A, B](ops: Parsley[InfixR.Op[A, B]]*)(implicit override val wrap: A => B) extends Ops[A, B]
+private [expr] case class Prefixes[A, B](ops: Parsley[Prefix.Op[A, B]]*)(implicit override val wrap: A => B) extends Ops[A, B]
+private [expr] case class Postfixes[A, B](ops: Parsley[Postfix.Op[A, B]]*)(implicit override val wrap: A => B) extends Ops[A, B]
+private [expr] case class NonAssocs[A, B](ops: Parsley[InfixN.Op[A, B]]*)(implicit override val wrap: A => B) extends Ops[A, B]
+
+/**
+ * Helper object to build values of `Ops[A, A]`, for monolithic precedence parsing
+ * @since 2.2.0
+ */
+object Ops {
+    /**
+    * '''NOTE''': Currently a bug in scaladoc incorrect displays this functions type, it should be:
+    * `fixity.Op[A, A]`, NOT `Op[A, A]`. Builds an `Ops` object which represents many operators
+    * which act at the same precedence level, with a given fixity. Using path-dependent typing,
+    * the given fixity describes the shape of the operators expected. For more information see
+    * [[https://github.com/j-mie6/Parsley/wiki/Building-Expression-Parsers the Parsley wiki]].
+    * @tparam A The type associated with the operators (which it consumes and produces)
+    * @param fixity The fixity of the operators described. See [[Fixity]]
+    * @param ops The operators themselves, in varargs
+    * @since 2.2.0
+    */
+    def apply[A](fixity: Fixity)(ops: Parsley[fixity.Op[A, A]]*): Ops[A, A] = GOps[A, A](fixity)(ops: _*)
+}

--- a/src/main/scala-3.x/parsley/expr/Ops.scala
+++ b/src/main/scala-3.x/parsley/expr/Ops.scala
@@ -1,0 +1,39 @@
+package parsley.expr
+
+import parsley.Parsley
+
+/**
+ * Describes the operators at a specific level in the precedence tree, such that these ops
+ * consume `B`s, possibly `A`s and produce `B`s: this depends on the [[Fixity]] of the operators.
+ * @tparam A The base type consumed by the operators
+ * @tparam B The type produced/consumed by the operators
+ * @note For less complex types `Ops[A, A]` is sufficient
+ * @since 2.2.0
+ */
+sealed trait Ops[A, B] {
+    private [expr] val wrap: A => B
+}
+private [expr] case class Lefts[A, B](ops: Parsley[InfixL.Op[A, B]]*)(implicit override val wrap: A => B) extends Ops[A, B]
+private [expr] case class Rights[A, B](ops: Parsley[InfixR.Op[A, B]]*)(implicit override val wrap: A => B) extends Ops[A, B]
+private [expr] case class Prefixes[A, B](ops: Parsley[Prefix.Op[A, B]]*)(implicit override val wrap: A => B) extends Ops[A, B]
+private [expr] case class Postfixes[A, B](ops: Parsley[Postfix.Op[A, B]]*)(implicit override val wrap: A => B) extends Ops[A, B]
+private [expr] case class NonAssocs[A, B](ops: Parsley[InfixN.Op[A, B]]*)(implicit override val wrap: A => B) extends Ops[A, B]
+
+/**
+ * Helper object to build values of `Ops[A, A]`, for monolithic precedence parsing
+ * @since 2.2.0
+ */
+object Ops {
+    /**
+    * '''NOTE''': Currently a bug in scaladoc incorrect displays this functions type, it should be:
+    * `fixity.Op[A, A]`, NOT `Op[A, A]`. Builds an `Ops` object which represents many operators
+    * which act at the same precedence level, with a given fixity. Using path-dependent typing,
+    * the given fixity describes the shape of the operators expected. For more information see
+    * [[https://github.com/j-mie6/Parsley/wiki/Building-Expression-Parsers the Parsley wiki]].
+    * @tparam A The type associated with the operators (which it consumes and produces)
+    * @param fixity The fixity of the operators described. See [[Fixity]]
+    * @param ops The operators themselves, in varargs
+    * @since 2.2.0
+    */
+    def apply[A](fixity: Fixity)(ops: Parsley[fixity.Op[A, A]]*): Ops[A, A] = GOps[A, A](fixity)(ops: _*)
+}

--- a/src/main/scala/parsley/expr/Fixity.scala
+++ b/src/main/scala/parsley/expr/Fixity.scala
@@ -52,10 +52,9 @@ case object Postfix extends Fixity {
 
 /**
   * Describes non-associative operators
-  * @since 3.0.0
+  * @since 4.0.0
   */
-// TODO: this should be renamed to InfixN
-case object NonAssoc extends Fixity {
+case object InfixN extends Fixity {
     override type GOp[-A, +B] = (A, A) => B
     override type SOp[-A, B >: A] = (A, A) => B
 }

--- a/src/main/scala/parsley/expr/Fixity.scala
+++ b/src/main/scala/parsley/expr/Fixity.scala
@@ -4,50 +4,43 @@ import scala.language.higherKinds
 
 /**
   * Denotes the fixity and associativity of an operator. Importantly, it also specifies the type of the
-  * of the operations themselves. For non-monolithic structures this is described by `fixity.GOp`, subtyped
-  * structures `fixity.SOp`, and for monolithic structures `fixity.Op`.
-  * @since 2.2.0
+  * of the operations themselves.
+  * @since 4.0.0
   */
 sealed trait Fixity {
-    type Op[A] = GOp[A, A]
-    type SOp[A, B >: A] <: GOp[A, B]
-    type GOp[-A, B]
+    type Op[A, B]
 }
 
 /**
   * Describes left-associative binary operators
-  * @since 2.2.0
+  * @since 4.0.0
   */
 case object InfixL extends Fixity {
-    override type GOp[-A, B] = (B, A) => B
-    override type SOp[-A, B >: A] = (B, A) => B
+    override type Op[-A, B] = (B, A) => B
 }
 
 /**
   * Describes right-associative binary operators
-  * @since 2.2.0
+  * @since 4.0.0
   */
 case object InfixR extends Fixity {
-    override type GOp[-A, B] = (A, B) => B
-    override type SOp[-A, B >: A] = (A, B) => B
+    override type Op[-A, B] = (A, B) => B
 }
 
 /**
   * Describes unary prefix operators
-  * @since 2.2.0
+  * @since 4.0.0
   */
 case object Prefix extends Fixity {
-    override type GOp[-A, B] = B => B
-    override type SOp[A, B >: A] = B => B
+    override type Op[A, B] = B => B
 }
 
 /**
   * Describes unary postfix operators
-  * @since 2.2.0
+  * @since 4.0.0
   */
 case object Postfix extends Fixity {
-    override type GOp[-A, B] = B => B
-    override type SOp[A, B >: A] = B => B
+    override type Op[A, B] = B => B
 }
 
 /**
@@ -55,6 +48,5 @@ case object Postfix extends Fixity {
   * @since 4.0.0
   */
 case object InfixN extends Fixity {
-    override type GOp[-A, +B] = (A, A) => B
-    override type SOp[-A, B >: A] = (A, A) => B
+    override type Op[-A, +B] = (A, A) => B
 }

--- a/src/main/scala/parsley/expr/Levels.scala
+++ b/src/main/scala/parsley/expr/Levels.scala
@@ -9,7 +9,8 @@ import parsley.Parsley
   * @tparam A The type of structure produced by the list of levels
   * @since 4.0.0
   */
-sealed trait Levels[+A] {
+/* FIXME: This should be covariant! */
+sealed trait Levels[A] {
     /**
       * Builds a larger precedence table from strongest to weakest
       * @tparam B The new result type for the larger table

--- a/src/main/scala/parsley/expr/Levels.scala
+++ b/src/main/scala/parsley/expr/Levels.scala
@@ -1,53 +1,44 @@
 package parsley.expr
 
-import parsley.XCompat._
 import parsley.Parsley
 
 /**
   * For more complex expression parser types `Levels` can be used to
   * describe the precedence table whilst preserving the intermediate
   * structure between each level.
-  * @tparam A The base type accepted by this list of levels
-  * @tparam B The type of structure produced by the list of levels
-  * @since 3.0.0
+  * @tparam A The type of structure produced by the list of levels
+  * @since 4.0.0
   */
-sealed trait Levels[-A, +B] {
+sealed trait Levels[+A] {
     /**
       * Builds a larger precedence table from strongest to weakest
-      * @tparam C The new result type for the larger table
+      * @tparam B The new result type for the larger table
       * @param ops The operators that transform the previous, stronger, layer into the new result
       */
-    final def :+[C](ops: Ops[B, C]): Levels[A, C] = Level(this, ops)
+    final def :+[B](ops: Ops[A, B]): Levels[B] = Level(this, ops)
     /**
       * Builds a larger parser precedence table from weakest to strongest
-      * @tparam C The new result type for the larger table
+      * @tparam B The new result type for the larger table
       * @param ops The operators that transform the next, stronger, layer into the new result
       */
-    final def +:[C](ops: Ops[B, C]): Levels[A, C] = Level(this, ops)
+    final def +:[B](ops: Ops[A, B]): Levels[B] = Level(this, ops)
 }
 /**
   * This represents a single new level of the hierarchy, with stronger
   * precedence than its tail.
-  * @tparam A The base type accepted by the layer below
-  * @tparam B The intermediate type produced by the layer below to be fed into this level
-  * @tparam C The type of structure produced by this layer
+  * @tparam A The intermediate type produced by the layer below to be fed into this level
+  * @tparam B The type of structure produced by this layer
   * @param ops The operators accepted at this level
   * @param lvls The next, stronger, levels in the precedence table
   * @return A larger precedence table transforming atoms of type `A` into
-  *          a structure of type `C`.
-  * @since 3.0.0
+  *          a structure of type `B`.
+  * @since 4.0.0
   */
-case class Level[-A, B, C](lvls: Levels[A, B], ops: Ops[B, C]) extends Levels[A, C]
-private [expr] case class Atoms_[A, B](ev: A =:= B, atoms: Parsley[A]*) extends Levels[A, B]
-
+case class Level[A, B](lvls: Levels[A], ops: Ops[A, B]) extends Levels[B]
 /**
-  * This represents the final level of the hierarchy, with the strongest binding.
+  * Given some atoms, produces the base of the precedence hierarchy
+  * @tparam A The base type of the hierarchy
+  * @param atoms The atoms at the bottom of the precedence table
+  * @since 4.0.0
   */
-object Atoms {
-    /**
-      * Given some atoms, produces the base of the precedence hierarchy
-      * @tparam A The base type of the hierarchy
-      * @param atoms The atoms at the bottom of the precedence table
-      */
-    def apply[A](atoms: Parsley[A]*): Levels[A, A] = new Atoms_(refl[A], atoms: _*)
-}
+case class Atoms[A](atoms: Parsley[A]*) extends Levels[A]

--- a/src/main/scala/parsley/expr/Levels.scala
+++ b/src/main/scala/parsley/expr/Levels.scala
@@ -3,26 +3,25 @@ package parsley.expr
 import parsley.Parsley
 
 /**
-  * For more complex expression parser types `Levels` can be used to
+  * For more complex expression parser types `Prec` can be used to
   * describe the precedence table whilst preserving the intermediate
   * structure between each level.
   * @tparam A The type of structure produced by the list of levels
   * @since 4.0.0
   */
-/* FIXME: This should be covariant! */
-sealed trait Levels[A] {
+sealed trait Prec[+A] {
     /**
       * Builds a larger precedence table from strongest to weakest
       * @tparam B The new result type for the larger table
       * @param ops The operators that transform the previous, stronger, layer into the new result
       */
-    final def :+[B](ops: Ops[A, B]): Levels[B] = Level(this, ops)
+    final def :+[Aʹ >: A, B](ops: Ops[Aʹ, B]): Prec[B] = Level(this, ops)
     /**
       * Builds a larger parser precedence table from weakest to strongest
       * @tparam B The new result type for the larger table
       * @param ops The operators that transform the next, stronger, layer into the new result
       */
-    final def +:[B](ops: Ops[A, B]): Levels[B] = Level(this, ops)
+    final def +:[Aʹ >: A, B](ops: Ops[Aʹ, B]): Prec[B] = Level(this, ops)
 }
 /**
   * This represents a single new level of the hierarchy, with stronger
@@ -35,11 +34,11 @@ sealed trait Levels[A] {
   *          a structure of type `B`.
   * @since 4.0.0
   */
-case class Level[A, B](lvls: Levels[A], ops: Ops[A, B]) extends Levels[B]
+case class Level[A, B](lvls: Prec[A], ops: Ops[A, B]) extends Prec[B]
 /**
   * Given some atoms, produces the base of the precedence hierarchy
   * @tparam A The base type of the hierarchy
   * @param atoms The atoms at the bottom of the precedence table
   * @since 4.0.0
   */
-case class Atoms[A](atoms: Parsley[A]*) extends Levels[A]
+case class Atoms[+A](atoms: Parsley[A]*) extends Prec[A]

--- a/src/main/scala/parsley/expr/Ops.scala
+++ b/src/main/scala/parsley/expr/Ops.scala
@@ -40,11 +40,11 @@ object GOps {
     * @since 2.2.0
     */
     def apply[A, B](fixity: Fixity)(ops: Parsley[fixity.GOp[A, B]]*)(implicit wrap: A => B): Ops[A, B] = fixity match {
-        case InfixL   => Lefts[A, B](ops.asInstanceOf[Seq[Parsley[InfixL.GOp[A, B]]]]: _*)
-        case InfixR   => Rights[A, B](ops.asInstanceOf[Seq[Parsley[InfixR.GOp[A, B]]]]: _*)
-        case Prefix   => Prefixes[A, B](ops.asInstanceOf[Seq[Parsley[Prefix.GOp[A, B]]]]: _*)
-        case Postfix  => Postfixes[A, B](ops.asInstanceOf[Seq[Parsley[Postfix.GOp[A, B]]]]: _*)
-        case NonAssoc => NonAssocs[A, B](ops.asInstanceOf[Seq[Parsley[NonAssoc.GOp[A, B]]]]: _*)
+        case InfixL  => Lefts[A, B](ops.asInstanceOf[Seq[Parsley[InfixL.GOp[A, B]]]]: _*)
+        case InfixR  => Rights[A, B](ops.asInstanceOf[Seq[Parsley[InfixR.GOp[A, B]]]]: _*)
+        case Prefix  => Prefixes[A, B](ops.asInstanceOf[Seq[Parsley[Prefix.GOp[A, B]]]]: _*)
+        case Postfix => Postfixes[A, B](ops.asInstanceOf[Seq[Parsley[Postfix.GOp[A, B]]]]: _*)
+        case InfixN  => NonAssocs[A, B](ops.asInstanceOf[Seq[Parsley[InfixN.GOp[A, B]]]]: _*)
     }
 }
 

--- a/src/main/scala/parsley/expr/Ops.scala
+++ b/src/main/scala/parsley/expr/Ops.scala
@@ -3,30 +3,13 @@ package parsley.expr
 import parsley.Parsley
 
 /**
- * Describes the operators at a specific level in the precedence tree, such that these ops
- * consume `B`s, possibly `A`s and produce `B`s: this depends on the [[Fixity]] of the operators.
- * @tparam A The base type consumed by the operators
- * @tparam B The type produced/consumed by the operators
- * @note For less complex types `Ops[A, A]` is sufficient
- * @since 2.2.0
- */
-trait Ops[-A, B] {
-    private [expr] val wrap: A => B
-}
-private [expr] case class Lefts[-A, B](ops: Parsley[(B, A) => B]*)(implicit override val wrap: A => B) extends Ops[A, B]
-private [expr] case class Rights[-A, B](ops: Parsley[(A, B) => B]*)(implicit override val wrap: A => B) extends Ops[A, B]
-private [expr] case class Prefixes[-A, B](ops: Parsley[B => B]*)(implicit override val wrap: A => B) extends Ops[A, B]
-private [expr] case class Postfixes[-A, B](ops: Parsley[B => B]*)(implicit override val wrap: A => B) extends Ops[A, B]
-private [expr] case class NonAssocs[-A, B](ops: Parsley[(A, A) => B]*)(implicit override val wrap: A => B) extends Ops[A, B]
-
-/**
  * Helper object to build values of `Ops[A, B]`, for generalised precedence parsing
  * @since 2.2.0
  */
 object GOps {
     /**
     * '''NOTE''': Currently a bug in scaladoc incorrect displays this functions type, it should be:
-    * `fixity.GOp[A, B]`, NOT `GOp[A, B]`. Builds an `Ops` object which represents many operators
+    * `fixity.Op[A, B]`, NOT `Op[A, B]`. Builds an `Ops` object which represents many operators
     * which act at the same precedence level, with a given fixity. Using path-dependent typing,
     * the given fixity describes the shape of the operators expected. For more information see
     * [[https://github.com/j-mie6/Parsley/wiki/Building-Expression-Parsers the Parsley wiki]].
@@ -39,12 +22,12 @@ object GOps {
     *             the root of a prefix/postfix chain)
     * @since 2.2.0
     */
-    def apply[A, B](fixity: Fixity)(ops: Parsley[fixity.GOp[A, B]]*)(implicit wrap: A => B): Ops[A, B] = fixity match {
-        case InfixL  => Lefts[A, B](ops.asInstanceOf[Seq[Parsley[InfixL.GOp[A, B]]]]: _*)
-        case InfixR  => Rights[A, B](ops.asInstanceOf[Seq[Parsley[InfixR.GOp[A, B]]]]: _*)
-        case Prefix  => Prefixes[A, B](ops.asInstanceOf[Seq[Parsley[Prefix.GOp[A, B]]]]: _*)
-        case Postfix => Postfixes[A, B](ops.asInstanceOf[Seq[Parsley[Postfix.GOp[A, B]]]]: _*)
-        case InfixN  => NonAssocs[A, B](ops.asInstanceOf[Seq[Parsley[InfixN.GOp[A, B]]]]: _*)
+    def apply[A, B](fixity: Fixity)(ops: Parsley[fixity.Op[A, B]]*)(implicit wrap: A => B): Ops[A, B] = fixity match {
+        case InfixL  => Lefts[A, B](ops.asInstanceOf[Seq[Parsley[InfixL.Op[A, B]]]]: _*)
+        case InfixR  => Rights[A, B](ops.asInstanceOf[Seq[Parsley[InfixR.Op[A, B]]]]: _*)
+        case Prefix  => Prefixes[A, B](ops.asInstanceOf[Seq[Parsley[Prefix.Op[A, B]]]]: _*)
+        case Postfix => Postfixes[A, B](ops.asInstanceOf[Seq[Parsley[Postfix.Op[A, B]]]]: _*)
+        case InfixN  => NonAssocs[A, B](ops.asInstanceOf[Seq[Parsley[InfixN.Op[A, B]]]]: _*)
     }
 }
 
@@ -55,7 +38,7 @@ object GOps {
 object SOps {
     /**
     * '''NOTE''': Currently a bug in scaladoc incorrect displays this functions type, it should be:
-    * `fixity.SOp[A, B]`, NOT `SOp[A, B]`. Builds an `Ops` object which represents many operators
+    * `fixity.Op[A, B]`, NOT `Op[A, B]`. Builds an `Ops` object which represents many operators
     * which act at the same precedence level, with a given fixity. Using path-dependent typing,
     * the given fixity describes the shape of the operators expected. For more information see
     * [[https://github.com/j-mie6/Parsley/wiki/Building-Expression-Parsers the Parsley wiki]].
@@ -67,24 +50,5 @@ object SOps {
     * @note The order of types in this method is reversed compared with [[GOps.apply]], this is due to
     *       a Scala typing issue.
     */
-    def apply[B, A <: B](fixity: Fixity)(ops: Parsley[fixity.SOp[A, B]]*): Ops[A, B] = GOps(fixity)(ops: _*)
-}
-
-/**
- * Helper object to build values of `Ops[A, A]`, for monolithic precedence parsing
- * @since 2.2.0
- */
-object Ops {
-    /**
-    * '''NOTE''': Currently a bug in scaladoc incorrect displays this functions type, it should be:
-    * `fixity.Op[A]`, NOT `Op[A]`. Builds an `Ops` object which represents many operators
-    * which act at the same precedence level, with a given fixity. Using path-dependent typing,
-    * the given fixity describes the shape of the operators expected. For more information see
-    * [[https://github.com/j-mie6/Parsley/wiki/Building-Expression-Parsers the Parsley wiki]].
-    * @tparam A The type associated with the operators (which it consumes and produces)
-    * @param fixity The fixity of the operators described. See [[Fixity]]
-    * @param ops The operators themselves, in varargs
-    * @since 2.2.0
-    */
-    def apply[A](fixity: Fixity)(ops: Parsley[fixity.Op[A]]*): Ops[A, A] = GOps[A, A](fixity)(ops: _*)
+    def apply[B, A <: B](fixity: Fixity)(ops: Parsley[fixity.Op[A, B]]*): Ops[A, B] = GOps(fixity)(ops: _*)
 }

--- a/src/main/scala/parsley/expr/chain.scala
+++ b/src/main/scala/parsley/expr/chain.scala
@@ -16,24 +16,24 @@ object chain {
       * returned by `p`. If there are no occurrences of `p`, the value `x` is returned.
       * @since 2.2.0
       */
-    def right[A, B](p: =>Parsley[A], op: =>Parsley[(A, B) => B], x: B)
-                   (implicit @implicitNotFound("Please provide a wrapper function from ${A} to ${B}") wrap: A => B): Parsley[B] = right1(p, op).getOrElse(x)
+    def right[A, B, C >: B](p: =>Parsley[A], op: =>Parsley[(A, C) => B], x: C)
+                           (implicit @implicitNotFound("Please provide a wrapper function from ${A} to ${C}") wrap: A => C): Parsley[C] = right1(p, op).getOrElse(x)
 
     /**`left(p, op, x)` parses *zero* or more occurrences of `p`, separated by `op`. Returns a value
       * obtained by a left associative application of all functions returned by `op` to the values
       * returned by `p`. If there are no occurrences of `p`, the value `x` is returned.
       * @since 2.2.0
       */
-    def left[A, B](p: =>Parsley[A], op: =>Parsley[(B, A) => B], x: B)
-                  (implicit @implicitNotFound("Please provide a wrapper function from ${A} to ${B}") wrap: A => B): Parsley[B] = left1(p, op).getOrElse(x)
+    def left[A, B, C >: B](p: =>Parsley[A], op: =>Parsley[(C, A) => B], x: C)
+                  (implicit @implicitNotFound("Please provide a wrapper function from ${A} to ${C}") wrap: A => C): Parsley[C] = left1(p, op).getOrElse(x)
 
     /**`right1(p, op)` parses *one* or more occurrences of `p`, separated by `op`. Returns a value
       * obtained by a right associative application of all functions return by `op` to the values
       * returned by `p`.
       * @since 2.2.0
       */
-    def right1[A, B](p: =>Parsley[A], op: =>Parsley[(A, B) => B])
-                    (implicit @implicitNotFound("Please provide a wrapper function from ${A} to ${B}") wrap: A => B): Parsley[B] = {
+    def right1[A, B, C >: B](p: =>Parsley[A], op: =>Parsley[(A, C) => B])
+                    (implicit @implicitNotFound("Please provide a wrapper function from ${A} to ${B}") wrap: A => C): Parsley[C] = {
         new Parsley(new deepembedding.Chainr(p.internal, op.internal, wrap))
     }
 
@@ -43,8 +43,8 @@ object chain {
       * typically occurs in expression grammars.
       * @since 2.2.0
       */
-    def left1[A, B](p: =>Parsley[A], op: =>Parsley[(B, A) => B])
-                   (implicit @implicitNotFound("Please provide a wrapper function from ${A} to ${B}") wrap: A => B): Parsley[B] = {
+    def left1[A, B, C >: B](p: =>Parsley[A], op: =>Parsley[(C, A) => B])
+                   (implicit @implicitNotFound("Please provide a wrapper function from ${A} to ${B}") wrap: A => C): Parsley[C] = {
         lazy val _p = p
         // a sneaky sneaky trick :) If we know that A =:= B because refl was provided, then we can skip the wrapping
         new Parsley(new deepembedding.Chainl(parsley.XCompat.applyWrap(wrap)(_p).internal, _p.internal, op.internal))

--- a/src/main/scala/parsley/expr/precedence.scala
+++ b/src/main/scala/parsley/expr/precedence.scala
@@ -3,7 +3,6 @@ package parsley.expr
 import parsley.Parsley, Parsley.notFollowedBy
 import parsley.combinator.choice
 import parsley.implicits.zipped.Zipped2
-import parsley.XCompat._
 import parsley.errors.combinator.ErrorMethods
 
 /** This object is used to construct precedence parsers from either a [[Levels]] or many `Ops[A, A]`.
@@ -25,8 +24,8 @@ object precedence {
 
     }
 
-    private def crushLevels[A, B](lvls: Levels[A, B]): Parsley[B] = lvls match {
-        case Atoms_(ev, atoms@_*) => ev.substituteCo[Parsley](choice(atoms: _*))
+    private def crushLevels[A](lvls: Levels[A]): Parsley[A] = lvls match {
+        case Atoms(atoms@_*) => choice(atoms: _*)
         case Level(lvls, ops) => convertOperators(crushLevels(lvls), ops)(ops.wrap)
     }
 
@@ -39,7 +38,7 @@ object precedence {
       * @return A parser for the described expression language
       * @since 3.0.0
       */
-    def apply[A](atoms: Parsley[A]*)(table: Ops[A, A]*): Parsley[A] = apply(table.foldLeft(Atoms(atoms: _*))(Level.apply[A, A, A]))
+    def apply[A](atoms: Parsley[A]*)(table: Ops[A, A]*): Parsley[A] = apply(table.foldLeft[Levels[A]](Atoms(atoms: _*))(Level.apply))
 
     /** This is used to build an expression parser for a monolithic type: levels are specified from weakest
       * to strongest.
@@ -55,12 +54,11 @@ object precedence {
 
     /** This is used to build an expression parser for a multi-layered expression tree type. Levels can be
       * either tightest to loosest binding (using `:+`) or loosest to tightest (using `+:`)
-      * @tparam A The type of the atomic unit of the expression
-      * @tparam B The type of the resulting parse tree (outermost operations)
+      * @tparam A The type of the resulting parse tree (outermost operations)
       * @param table A table of operators. Table is ordered depending on the operator used to build it.
       *              See [[Levels]] and it's subtypes for a description of how the types work.
       * @return A parser for the described expression language
-      * @since 3.0.0
+      * @since 4.0.0
       */
-    def apply[A, B](table: Levels[A, B]): Parsley[B] = crushLevels(table)
+    def apply[A](table: Levels[A]): Parsley[A] = crushLevels(table)
 }

--- a/src/main/scala/parsley/expr/precedence.scala
+++ b/src/main/scala/parsley/expr/precedence.scala
@@ -25,7 +25,7 @@ object precedence {
     }
 
     private def crushLevels[A](lvls: Levels[A]): Parsley[A] = lvls match {
-        case Atoms(atoms@_*) => choice(atoms: _*)
+        case Atoms(atoms @ _*) => choice(atoms: _*)
         case Level(lvls, ops) => convertOperators(crushLevels(lvls), ops)(ops.wrap)
     }
 

--- a/src/main/scala/parsley/expr/precedence.scala
+++ b/src/main/scala/parsley/expr/precedence.scala
@@ -5,7 +5,7 @@ import parsley.combinator.choice
 import parsley.implicits.zipped.Zipped2
 import parsley.errors.combinator.ErrorMethods
 
-/** This object is used to construct precedence parsers from either a [[Levels]] or many `Ops[A, A]`.
+/** This object is used to construct precedence parsers from either a [[Prec]] or many `Ops[A, A]`.
   * @since 2.2.0
   */
 object precedence {
@@ -57,7 +57,7 @@ object precedence {
       * either tightest to loosest binding (using `:+`) or loosest to tightest (using `+:`)
       * @tparam A The type of the resulting parse tree (outermost operations)
       * @param table A table of operators. Table is ordered depending on the operator used to build it.
-      *              See [[Levels]] and it's subtypes for a description of how the types work.
+      *              See [[Prec]] and it's subtypes for a description of how the types work.
       * @return A parser for the described expression language
       * @since 4.0.0
       */

--- a/src/test/scala/parsley/ExpressionParserTests.scala
+++ b/src/test/scala/parsley/ExpressionParserTests.scala
@@ -3,7 +3,7 @@ package parsley
 import parsley.character.digit
 import parsley.implicits.character.{charLift, stringLift}
 import parsley.expr.chain
-import parsley.expr.{precedence, Ops, GOps, SOps, InfixL, InfixR, Prefix, Postfix, NonAssoc, Atoms}
+import parsley.expr.{precedence, Ops, GOps, SOps, InfixL, InfixR, Prefix, Postfix, InfixN, Atoms}
 import parsley.Parsley._
 import parsley._
 
@@ -189,7 +189,7 @@ class ExpressionParserTests extends ParsleyTest {
         case class Parens(x: Comp) extends Atom
         case class Num(x: Int) extends Atom
         lazy val expr: Parsley[Comp] = precedence(
-            SOps(NonAssoc)('<' #> Less) +:
+            SOps(InfixN)('<' #> Less) +:
             SOps(InfixL)('+' #> Add) +:
             SOps(InfixR)('*' #> Mul) +:
             SOps[Factor, Atom](Prefix)('-' #> Neg) +:
@@ -210,7 +210,7 @@ class ExpressionParserTests extends ParsleyTest {
         case class Parens(x: Comp) extends Atom
         case class Num(x: Int) extends Atom
         lazy val expr: Parsley[Comp] = precedence(
-            GOps[Expr, Comp](NonAssoc)('<' #> Less)(CompOf) +:
+            GOps[Expr, Comp](InfixN)('<' #> Less)(CompOf) +:
             GOps[Term, Expr](InfixL)('+' #> Add)(ExprOf) +:
             GOps[Atom, Term](InfixR)('*' #> Mul)(TermOf) +:
             Atoms(digit.map(_.asDigit).map(Num), '(' *> expr.map(Parens) <* ')'))

--- a/src/test/scala/parsley/ExpressionParserTests.scala
+++ b/src/test/scala/parsley/ExpressionParserTests.scala
@@ -24,7 +24,7 @@ class ExpressionParserTests extends ParsleyTest {
     }
     it must "not leave the stack in an inconsistent state on failure" in {
         val p = chain.postfix[Int]('1' #> 1, (col.#>[Int => Int](_ + 1)) <* '+')
-        val q = chain.left1[Int, Int](p, '*' #> (_ * _))
+        val q = chain.left1(p, '*' #> ((x: Int, y: Int) => x * y))
         noException should be thrownBy q.parse("1+*1+")
     }
 
@@ -87,7 +87,7 @@ class ExpressionParserTests extends ParsleyTest {
         sealed trait Expr
         case class Add(x: Int, y: Expr) extends Expr
         case class Num(x: Int) extends Expr
-        val p = chain.right1[Int, Expr]("1" #> 1, "+" #> Add.apply)(Num)
+        val p = chain.right1("1" #> 1, "+" #> ((x: Int, y: Expr) => Add(x, y)))(Num)
         p.parse("1+1+1") should be (Success(Add(1, Add(1, Num(1)))))
         p.parse("1") should be (Success(Num(1)))
     }
@@ -112,15 +112,15 @@ class ExpressionParserTests extends ParsleyTest {
         chain.left1("11" #> 1, "++" #> ((x: Int, y: Int) => x + y)).parse("11++11++11++1++11") shouldBe a [Failure[_]]
     }
     it must "not leave the stack in an inconsistent state on failure" in {
-        val p = chain.left1[Int, Int]('1' #> 1, (col.#>[(Int, Int) => Int](_ + _)) <* '+')
-        val q = chain.left1[Int, Int](p, '*' #> (_ * _))
+        val p = chain.left1('1' #> 1, (col.#>[(Int, Int) => Int](_ + _)) <* '+')
+        val q = chain.left1(p, '*'.#>[(Int, Int) => Int](_ * _))
         noException should be thrownBy q.parse("1+1*1+1")
     }
     it must "correctly accept the use of a wrapping function" in {
         sealed trait Expr
         case class Add(x: Expr, y: Int) extends Expr
         case class Num(x: Int) extends Expr
-        chain.left1[Int, Expr]("1" #> 1, "+" #> Add.apply)(Num).parse("1+1+1") should be (Success(Add(Add(Num(1), 1), 1)))
+        chain.left1("1" #> 1, "+".#>[(Expr, Int) => Expr](Add.apply))(Num).parse("1+1+1") should be (Success(Add(Add(Num(1), 1), 1)))
     }
     "chain.left" must "allow for no initial value" in {
         chain.left("11" #> 1, '+' #> ((x: Int, y: Int) => x + y), 0).parse("11") should be (Success(1))
@@ -185,6 +185,9 @@ class ExpressionParserTests extends ParsleyTest {
         case class Mul(x: Factor, y: Term) extends Term
         sealed trait Factor extends Term
         case class Neg(x: Factor) extends Factor
+        object Neg {
+            val mk: Factor => Factor = Neg(_)
+        }
         sealed trait Atom extends Factor
         case class Parens(x: Comp) extends Atom
         case class Num(x: Int) extends Atom
@@ -192,7 +195,7 @@ class ExpressionParserTests extends ParsleyTest {
             SOps(InfixN)('<' #> Less) +:
             SOps(InfixL)('+' #> Add) +:
             SOps(InfixR)('*' #> Mul) +:
-            SOps[Factor, Atom](Prefix)('-' #> Neg) +:
+            SOps(Prefix)('-' #> Neg.mk) +:
             Atoms(digit.map(_.asDigit).map(Num), '(' *> expr.map(Parens) <* ')'))
         expr.parse("(7+8)*2+3+6*2") should be (Success(Add(Add(Mul(Parens(Add(Num(7), Num(8))), Num(2)), Num(3)), Mul(Num(6), Num(2)))))
     }
@@ -210,6 +213,7 @@ class ExpressionParserTests extends ParsleyTest {
         case class Parens(x: Comp) extends Atom
         case class Num(x: Int) extends Atom
         lazy val expr: Parsley[Comp] = precedence(
+            // The type ascriptions are unneeded for Scala 3
             GOps[Expr, Comp](InfixN)('<' #> Less)(CompOf) +:
             GOps[Term, Expr](InfixL)('+' #> Add)(ExprOf) +:
             GOps[Atom, Term](InfixR)('*' #> Mul)(TermOf) +:


### PR DESCRIPTION
Simplifies the API based on knowledge gained from the Design Patterns of Parser Combinators work. Adds an extra parameter to the chains, which helps inference on Scala 3 and In some cases on Scala 2, but is more painful if things do go wrong. Removed redundant parameters in the precedence framework and improved inference massively for Scala 3. 