### PR TITLE
Strict API

### DIFF
--- a/src/main/scala-2.12/parsley/WithFilter.scala
+++ b/src/main/scala-2.12/parsley/WithFilter.scala
@@ -7,7 +7,7 @@ object Parsley212 {
       *  It does not appear in any 2.13+ releases
       * @since 3.0
       */
-    implicit final class LazyParsley212[P, +A](p: =>P)(implicit con: P => Parsley[A]) {
+    implicit final class LazyParsley212[P, +A](p: P)(implicit con: P => Parsley[A]) {
         // $COVERAGE-OFF$
         /**
           * This is an alias for `p.filter(pred)`. It is needed to support for-comprehension syntax with `if`s in Scala 2.12.

--- a/src/main/scala-2.12/parsley/WithFilter.scala
+++ b/src/main/scala-2.12/parsley/WithFilter.scala
@@ -1,18 +1,16 @@
 package parsley
 
-import Parsley.LazyParsley
-
 object Parsley212 {
     /** This class enables any combinators and functionality that is only supported to provide back-compat with Scala 2.12.
       *  It does not appear in any 2.13+ releases
       * @since 3.0
       */
-    implicit final class LazyParsley212[P, +A](p: P)(implicit con: P => Parsley[A]) {
+    implicit final class Parsley212[P, +A](p: P)(implicit con: P => Parsley[A]) {
         // $COVERAGE-OFF$
         /**
           * This is an alias for `p.filter(pred)`. It is needed to support for-comprehension syntax with `if`s in Scala 2.12.
           */
-        def withFilter(pred: A => Boolean): Parsley[A] = new LazyParsley(p).filter(pred)
+        def withFilter(pred: A => Boolean): Parsley[A] = p.filter(pred)
         // $COVERAGE-ON$
     }
 }

--- a/src/main/scala/parsley/Parsley.scala
+++ b/src/main/scala/parsley/Parsley.scala
@@ -4,12 +4,13 @@ import parsley.internal.machine.Context
 import parsley.internal.deepembedding
 import parsley.expr.chain
 import parsley.combinator.{option, some}
+import parsley.Parsley._
+import parsley.errors.ErrorBuilder
 
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.reflect.ClassTag
 import scala.language.{higherKinds, implicitConversions}
-import parsley.errors.ErrorBuilder
 
 // User API
 /**
@@ -49,267 +50,259 @@ final class Parsley[+A] private [parsley] (private [parsley] val internal: deepe
       * @since 3.0.0
       */
     def parse[Err: ErrorBuilder](input: String): Result[Err, A] = new Context(internal.threadSafeInstrs, input).runParser()
+
+    /* COMBINATORS */
+    /**
+      * This is the functorial map operation for parsers. When the invokee produces a value, this value is fed through
+      * the function `f`.
+      *
+      * @note This is subject to aggressive optimisations assuming purity; the compiler is permitted to optimise such
+      * that the application of `f` actually only happens once at compile time. In order to preserve the behaviour of
+      * impure functions, consider using the `unsafe` method before map; `p.unsafe.map(f)`.
+      * @param f The mutator to apply to the result of previous parse
+      * @return A new parser which parses the same input as the invokee but mutated by function `f`
+      */
+    def map[B](f: A => B): Parsley[B] = pure(f) <*> this
+    /**
+      * This is the Applicative application parser. The type of `pf` is `Parsley[A => B]`. Then, given a
+      * `Parsley[A]`, we can produce a `Parsley[B]` by parsing `pf` to retrieve `f: A => B`, then parse `px`
+      * to receive `x: A` then return `f(x): B`.
+      *
+      * @note `pure(f) <*> p` is subject to the same aggressive optimisations as `map`. When using impure functions
+      * the optimiser may decide to cache the result of the function execution, be sure to use `unsafe` in order to
+      * prevent these optimisations.
+      * @param px A parser of type A, where the invokee is A => B
+      * @return A new parser which parses `pf`, then `px` then applies the value returned by `px` to the function
+      *         returned by `pf`
+      */
+    def <*>[B, C](px: =>Parsley[B])(implicit ev: Parsley[A] <:< Parsley[B=>C]): Parsley[C] = new Parsley(new deepembedding.<*>[B, C](ev(this).internal, px.internal))
+
+    /**
+      * This is the traditional Monadic binding operator for parsers. When the invokee produces a value, the function
+      * `f` is used to produce a new parser that continued the computation.
+      *
+      * @note There is significant overhead for using flatMap; if possible try to write parsers in an applicative
+      * style otherwise try and use the intrinsic parsers provided to replace the flatMap.
+      * @param f A function that produces the next parser
+      * @return The parser produces from the application of `f` on the result of the last parser
+      */
+    def flatMap[B](f: A => Parsley[B]): Parsley[B] = new Parsley(new deepembedding.>>=(this.internal, f.andThen(_.internal)))
+    /**This combinator is an alias for `flatMap(identity)`.*/
+    def flatten[B](implicit ev: A <:< Parsley[B]): Parsley[B] = this.flatMap[B](ev)
+    /**This combinator is an alias for `flatMap`*/
+    def >>=[B](f: A => Parsley[B]): Parsley[B] = this.flatMap(f)
+    /**This combinator is defined as `lift2((x, f) => f(x), p, f)`. It is pure syntactic sugar.*/
+    def <**>[B](pf: =>Parsley[A => B]): Parsley[B] = lift.lift2[A, A=>B, B]((x, f) => f(x), this, pf)
+
+    /**
+      * This is the traditional Alternative choice operator for parsers. Following the parsec semantics precisely,
+      * this combinator first tries to parse the invokee. If this is successful, no further action is taken. If the
+      * invokee failed *without* consuming input, then `q` is parsed instead. If the invokee did parse input then the
+      * whole parser fails. This is done to prevent space leaks and to give good error messages. If this behaviour
+      * is not desired, use the `<\>` combinator (or `attempt(this) <|> q`) to parse `q` regardless of how the
+      * invokee failed.
+      * @param q The parser to run if the invokee failed without consuming input
+      * @return The value produced by the invokee if it was successful, or if it failed without consuming input, the
+      *         possible result of parsing q.
+      */
+    def <|>[Aʹ >: A](q: =>Parsley[Aʹ]): Parsley[Aʹ] = new Parsley(new deepembedding.<|>(this.internal, q.internal))
+    /**This combinator is defined as `p <|> pure(x)`. It is pure syntactic sugar.*/
+    def </>[Aʹ >: A](x: Aʹ): Parsley[Aʹ] = this <|> pure(x)
+    /**This combinator is an alias for `<|>`.*/
+    def orElse[Aʹ >: A](q: =>Parsley[Aʹ]): Parsley[Aʹ] = this <|> q
+    /**This combinator is an alias for `</>`.*/
+    def getOrElse[Aʹ >: A](x: Aʹ): Parsley[Aʹ] = this </> x
+    /**
+      * This combinator, pronounced "sum", is similar to `<|>`, except it allows the
+      * types of either side of the combinator to vary by returning their result as
+      * part of an `Either`.
+      *
+      * @param q The parser to run if the invokee failed without consuming input
+      * @return the result of the parser which succeeded, if any
+      */
+    def <+>[B](q: Parsley[B]): Parsley[Either[A, B]] = this.map(Left(_)) <|> q.map(Right(_))
+    /**
+      * This is the parser that corresponds to a more optimal version of `p.map(_ => x => x) <*> q`. It performs
+      * the parse action of both parsers, in order, but discards the result of the invokee.
+      * @param q The parser whose result should be returned
+      * @return A new parser which first parses `p`, then `q` and returns the result of `q`
+      */
+    def *>[B](q: =>Parsley[B]): Parsley[B] = new Parsley(new deepembedding.*>(this.internal, q.internal))
+    /**
+      * This is the parser that corresponds to a more optimal version of `p.map(x => _ => x) <*> q`. It performs
+      * the parse action of both parsers, in order, but discards the result of the second parser.
+      * @param q The parser who should be executed but then discarded
+      * @return A new parser which first parses `p`, then `q` and returns the result of the `p`
+      */
+    def <*[B](q: =>Parsley[B]): Parsley[A] = new Parsley(new deepembedding.<*(this.internal, q.internal))
+    /**
+      * This is the parser that corresponds to `p *> pure(x)` or a more optimal version of `p.map(_ => x)`.
+      * It performs the parse action of the invokee but discards its result and then results the value `x` instead
+      * @param x The value to be returned after the execution of the invokee
+      * @return A new parser which first parses the invokee, then results `x`
+      */
+    def #>[B](x: B): Parsley[B] = this *> pure(x)
+    /**
+      * This is the parser that corresponds to a more optimal version of `(p <~> q).map(_._2)`. It performs
+      * the parse action of both parsers, in order, but discards the result of the invokee.
+      * @param q The parser whose result should be returned
+      * @return A new parser which first parses `p`, then `q` and returns the result of `q`
+      * @since 2.4.0
+      */
+    def ~>[B](q: Parsley[B]): Parsley[B] = this *> q
+    /**
+      * This is the parser that corresponds to a more optimal version of `(p <~> q).map(_._1)`. It performs
+      * the parse action of both parsers, in order, but discards the result of the second parser.
+      * @param q The parser who should be executed but then discarded
+      * @return A new parser which first parses `p`, then `q` and returns the result of the `p`
+      * @since 2.4.0
+      */
+    def <~[B](q: Parsley[B]): Parsley[A] = this <* q
+    /**This parser corresponds to `lift2(_+:_, p, ps)`.*/
+    def <+:>[Aʹ >: A](ps: =>Parsley[Seq[Aʹ]]): Parsley[Seq[Aʹ]] = lift.lift2[A, Seq[Aʹ], Seq[Aʹ]](_ +: _, this, ps)
+    /**This parser corresponds to `lift2(_::_, p, ps)`.*/
+    def <::>[Aʹ >: A](ps: =>Parsley[List[Aʹ]]): Parsley[List[Aʹ]] = lift.lift2[A, List[Aʹ], List[Aʹ]](_ :: _, this, ps)
+    /**This parser corresponds to `lift2((_, _), p, q)`. For now it is sugar, but in future may be more optimal*/
+    def <~>[Aʹ >: A, B](q: =>Parsley[B]): Parsley[(Aʹ, B)] = lift.lift2[Aʹ, B, (Aʹ, B)]((_, _), this, q)
+    /** This combinator is an alias for `<~>`
+      * @since 2.3.0
+      */
+    def zip[Aʹ >: A, B](q: =>Parsley[B]): Parsley[(Aʹ, B)] = this <~> q
+
+    /** Filter the value of a parser; if the value returned by the parser matches the predicate `pred` then the
+      * filter succeeded, otherwise the parser fails with an empty error
+      * @param pred The predicate that is tested against the parser result
+      * @return The result of the invokee if it passes the predicate
+      */
+    def filter(pred: A => Boolean): Parsley[A] = new Parsley(new deepembedding.Filter(this.internal, pred))
+    /** Filter the value of a parser; if the value returned by the parser does not match the predicate `pred` then the
+      * filter succeeded, otherwise the parser fails with an empty error
+      * @param pred The predicate that is tested against the parser result
+      * @return The result of the invokee if it fails the predicate
+      */
+    def filterNot(pred: A => Boolean): Parsley[A] = this.filter(!pred(_))
+    /** Attempts to first filter the parser to ensure that `pf` is defined over it. If it is, then the function `pf`
+      * is mapped over its result. Roughly the same as a `filter` then a `map`.
+      * @param pf The partial function
+      * @return The result of applying `pf` to this parsers value (if possible), or fails
+      * @since 2.0.0
+      */
+    def collect[B](pf: PartialFunction[A, B]): Parsley[B] = this.filter(pf.isDefinedAt).map(pf)
+    /**
+      * A fold for a parser: `p.foldRight(k)(f)` will try executing `p` many times until it fails, combining the
+      * results with right-associative application of `f` with a `k` at the right-most position
+      *
+      * @example {{{p.foldRight(Nil)(_::_) == many(p) //many is more efficient, however}}}
+      *
+      * @param k base case for iteration
+      * @param f combining function
+      * @return the result of folding the results of `p` with `f` and `k`
+      */
+    def foldRight[B](k: B)(f: (A, B) => B): Parsley[B] = chain.prefix(this.map(f.curried), pure(k))
+    /**
+      * A fold for a parser: `p.foldLeft(k)(f)` will try executing `p` many times until it fails, combining the
+      * results with left-associative application of `f` with a `k` on the left-most position
+      *
+      * @example {{{val natural: Parsley[Int] = digit.foldLeft(0)((x, d) => x * 10 + d.toInt)}}}
+      *
+      * @param k base case for iteration
+      * @param f combining function
+      * @return the result of folding the results of `p` with `f` and `k`
+      */
+    def foldLeft[B](k: B)(f: (B, A) => B): Parsley[B] = new Parsley(new deepembedding.Chainl(pure(k).internal, this.internal, pure(f).internal))
+    /**
+      * A fold for a parser: `p.foldRight1(k)(f)` will try executing `p` many times until it fails, combining the
+      * results with right-associative application of `f` with a `k` at the right-most position. It must parse `p`
+      * at least once.
+      *
+      * @example {{{p.foldRight1(Nil)(_::_) == some(p) //some is more efficient, however}}}
+      *
+      * @param k base case for iteration
+      * @param f combining function
+      * @return the result of folding the results of `p` with `f` and `k`
+      * @since 2.1.0
+      */
+    def foldRight1[B](k: B)(f: (A, B) => B): Parsley[B] = {
+        lift.lift2(f, this, this.foldRight(k)(f))
+    }
+    /**
+      * A fold for a parser: `p.foldLeft1(k)(f)` will try executing `p` many times until it fails, combining the
+      * results with left-associative application of `f` with a `k` on the left-most position. It must parse `p`
+      * at least once.
+      *
+      * @example {{{val natural: Parsley[Int] = digit.foldLeft1(0)((x, d) => x * 10 + d.toInt)}}}
+      *
+      * @param k base case for iteration
+      * @param f combining function
+      * @return the result of folding the results of `p` with `f` and `k`
+      * @since 2.1.0
+      */
+    def foldLeft1[B](k: B)(f: (B, A) => B): Parsley[B] = {
+        new Parsley(new deepembedding.Chainl(this.map(f(k, _)).internal, this.internal, pure(f).internal))
+    }
+    /**
+      * A reduction for a parser: `p.reduceRight(op)` will try executing `p` many times until it fails, combining the
+      * results with right-associative application of `op`. It must parse `p` at least once.
+      *
+      * @param op combining function
+      * @return the result of reducing the results of `p` with `op`
+      * @since 2.3.0
+      */
+    def reduceRight[B >: A](op: (A, B) => B): Parsley[B] = some(this).map(_.reduceRight(op))
+    /**
+      * A reduction for a parser: `p.reduceRight(op)` will try executing `p` many times until it fails, combining the
+      * results with right-associative application of `op`. If there is no `p`, it returns `None`, otherwise it returns
+      * `Some(x)` where `x` is the result of the reduction.
+      *
+      * @param op combining function
+      * @return the result of reducing the results of `p` with `op` wrapped in `Some` or `None` otherwise
+      * @since 2.3.0
+      */
+    def reduceRightOption[B >: A](op: (A, B) => B): Parsley[Option[B]] = option(this.reduceRight(op))
+    /**
+      * A reduction for a parser: `p.reduceLeft(op)` will try executing `p` many times until it fails, combining the
+      * results with left-associative application of `op`. It must parse `p` at least once.
+      *
+      * @param op combining function
+      * @return the result of reducing the results of `p` with `op`
+      * @since 2.3.0
+      */
+    def reduceLeft[B >: A](op: (B, A) => B): Parsley[B] = chain.left1(this, pure(op))
+    /**
+      * A reduction for a parser: `p.reduceLeft(op)` will try executing `p` many times until it fails, combining the
+      * results with left-associative application of `op`. If there is no `p`, it returns `None`, otherwise it returns
+      * `Some(x)` where `x` is the result of the reduction.
+      *
+      * @param op combining function
+      * @return the result of reducing the results of `p` with `op` wrapped in `Some` or `None` otherwise
+      * @since 2.3.0
+      */
+    def reduceLeftOption[B >: A](op: (B, A) => B): Parsley[Option[B]] = option(this.reduceLeft(op))
+    /**
+      * This casts the result of the parser into a new type `B`. If the value returned by the parser
+      * is castable to type `B`, then this cast is performed. Otherwise the parser fails.
+      * @tparam B The type to attempt to cast into
+      * @since 2.0.0
+      */
+    def cast[B: ClassTag]: Parsley[B] = this.collect {
+        case x: B => x
+    }
 }
+
 /** This object contains the core "function-style" combinators as well as the implicit classes which provide
   * the "method-style" combinators. All parsers will likely require something from within! */
 object Parsley
 {
-    /**
-      * This class exposes the commonly used combinators in Parsley. For a description of why the library is
-      * designed in this way, see: [[https://github.com/j-mie6/Parsley/wiki/Understanding-the-API the Parsley wiki]]
-      *
-      * @param p The parser which serves as the method receiver
-      * @param con A conversion (if required) to turn `p` into a parser
-      * @version 1.0.0
-      */
-    implicit final class LazyParsley[P, +A](p: =>P)(implicit con: P => Parsley[A])
-    {
-        /**
-          * This is the functorial map operation for parsers. When the invokee produces a value, this value is fed through
-          * the function `f`.
-          *
-          * @note This is subject to aggressive optimisations assuming purity; the compiler is permitted to optimise such
-          * that the application of `f` actually only happens once at compile time. In order to preserve the behaviour of
-          * impure functions, consider using the `unsafe` method before map; `p.unsafe.map(f)`.
-          * @param f The mutator to apply to the result of previous parse
-          * @return A new parser which parses the same input as the invokee but mutated by function `f`
-          */
-        def map[B](f: A => B): Parsley[B] = pure(f) <*> con(p)
-        /**
-          * This is the Applicative application parser. The type of `pf` is `Parsley[A => B]`. Then, given a
-          * `Parsley[A]`, we can produce a `Parsley[B]` by parsing `pf` to retrieve `f: A => B`, then parse `px`
-          * to receive `x: A` then return `f(x): B`.
-          *
-          * @note `pure(f) <*> p` is subject to the same aggressive optimisations as `map`. When using impure functions
-          * the optimiser may decide to cache the result of the function execution, be sure to use `unsafe` in order to
-          * prevent these optimisations.
-          * @param px A parser of type A, where the invokee is A => B
-          * @return A new parser which parses `pf`, then `px` then applies the value returned by `px` to the function
-          *         returned by `pf`
-          */
-        def <*>[B, C](px: =>Parsley[B])(implicit ev: P <:< Parsley[B=>C]): Parsley[C] = new Parsley(new deepembedding.<*>[B, C](ev(p).internal, px.internal))
-        /**
-          * This is the traditional Monadic binding operator for parsers. When the invokee produces a value, the function
-          * `f` is used to produce a new parser that continued the computation.
-          *
-          * @note There is significant overhead for using flatMap; if possible try to write parsers in an applicative
-          * style otherwise try and use the intrinsic parsers provided to replace the flatMap.
-          * @param f A function that produces the next parser
-          * @return The parser produces from the application of `f` on the result of the last parser
-          */
-        def flatMap[B](f: A => Parsley[B]): Parsley[B] = new Parsley(new deepembedding.>>=(con(p).internal, f.andThen(_.internal)))
-        /**This combinator is an alias for `flatMap(identity)`.*/
-        def flatten[B](implicit ev: A <:< Parsley[B]): Parsley[B] = this.flatMap[B](ev)
-
-        /**This combinator is an alias for `flatMap`*/
-        def >>=[B](f: A => Parsley[B]): Parsley[B] = this.flatMap(f)
-        /**This combinator is defined as `lift2((x, f) => f(x), p, f)`. It is pure syntactic sugar.*/
-        def <**>[B](pf: =>Parsley[A => B]): Parsley[B] = lift.lift2[A, A=>B, B]((x, f) => f(x), con(p), pf)
-        /**
-          * This is the traditional Alternative choice operator for parsers. Following the parsec semantics precisely,
-          * this combinator first tries to parse the invokee. If this is successful, no further action is taken. If the
-          * invokee failed *without* consuming input, then `q` is parsed instead. If the invokee did parse input then the
-          * whole parser fails. This is done to prevent space leaks and to give good error messages. If this behaviour
-          * is not desired, use the `<\>` combinator (or `attempt(this) <|> q`) to parse `q` regardless of how the
-          * invokee failed.
-          * @param q The parser to run if the invokee failed without consuming input
-          * @return The value produced by the invokee if it was successful, or if it failed without consuming input, the
-          *         possible result of parsing q.
-          */
-        def <|>[B >: A](q: =>Parsley[B]): Parsley[B] = new Parsley(new deepembedding.<|>(con(p).internal, q.internal))
-        /**This combinator is defined as `p <|> pure(x)`. It is pure syntactic sugar.*/
-        def </>[B >: A](x: B): Parsley[B] = this <|> pure(x)
-        /**This combinator is an alias for `<|>`.*/
-        def orElse[B >: A](q: =>Parsley[B]): Parsley[B] = this <|> q
-        /**This combinator is an alias for `</>`.*/
-        def getOrElse[B >: A](x: B): Parsley[B] = this </> x
-        /**
-          * This combinator, pronounced "sum", is similar to `<|>`, except it allows the
-          * types of either side of the combinator to vary by returning their result as
-          * part of an `Either`.
-          *
-          * @param q The parser to run if the invokee failed without consuming input
-          * @return the result of the parser which succeeded, if any
-          */
-        def <+>[B](q: Parsley[B]): Parsley[Either[A, B]] = this.map(Left(_)) <|> q.map(Right(_))
-        /**
-          * This is the parser that corresponds to a more optimal version of `p.map(_ => x => x) <*> q`. It performs
-          * the parse action of both parsers, in order, but discards the result of the invokee.
-          * @param q The parser whose result should be returned
-          * @return A new parser which first parses `p`, then `q` and returns the result of `q`
-          */
-        def *>[A_ >: A, B](q: =>Parsley[B]): Parsley[B] = new Parsley(new deepembedding.*>[A_, B](con(p).internal, q.internal))
-        /**
-          * This is the parser that corresponds to a more optimal version of `p.map(x => _ => x) <*> q`. It performs
-          * the parse action of both parsers, in order, but discards the result of the second parser.
-          * @param q The parser who should be executed but then discarded
-          * @return A new parser which first parses `p`, then `q` and returns the result of the `p`
-          */
-        def <*[B](q: =>Parsley[B]): Parsley[A] = new Parsley(new deepembedding.<*(con(p).internal, q.internal))
-        /**
-          * This is the parser that corresponds to `p *> pure(x)` or a more optimal version of `p.map(_ => x)`.
-          * It performs the parse action of the invokee but discards its result and then results the value `x` instead
-          * @param x The value to be returned after the execution of the invokee
-          * @return A new parser which first parses the invokee, then results `x`
-          */
-        def #>[B](x: B): Parsley[B] = this *> pure(x)
-        /**
-          * This is the parser that corresponds to a more optimal version of `(p <~> q).map(_._2)`. It performs
-          * the parse action of both parsers, in order, but discards the result of the invokee.
-          * @param q The parser whose result should be returned
-          * @return A new parser which first parses `p`, then `q` and returns the result of `q`
-          * @since 2.4.0
-          */
-        def ~>[B](q: Parsley[B]): Parsley[B] = this *> q
-        /**
-          * This is the parser that corresponds to a more optimal version of `(p <~> q).map(_._1)`. It performs
-          * the parse action of both parsers, in order, but discards the result of the second parser.
-          * @param q The parser who should be executed but then discarded
-          * @return A new parser which first parses `p`, then `q` and returns the result of the `p`
-          * @since 2.4.0
-          */
-        def <~[B](q: Parsley[B]): Parsley[A] = this <* q
-        /**This parser corresponds to `lift2(_+:_, p, ps)`.*/
-        def <+:>[B >: A](ps: =>Parsley[Seq[B]]): Parsley[Seq[B]] = lift.lift2[A, Seq[B], Seq[B]](_ +: _, con(p), ps)
-        /**This parser corresponds to `lift2(_::_, p, ps)`.*/
-        def <::>[B >: A](ps: =>Parsley[List[B]]): Parsley[List[B]] = lift.lift2[A, List[B], List[B]](_ :: _, con(p), ps)
-        /**This parser corresponds to `lift2((_, _), p, q)`. For now it is sugar, but in future may be more optimal*/
-        def <~>[A_ >: A, B](q: =>Parsley[B]): Parsley[(A_, B)] = lift.lift2[A_, B, (A_, B)]((_, _), con(p), q)
-        /** This combinator is an alias for `<~>`
-          * @since 2.3.0
-          */
-        def zip[A_ >: A, B](q: =>Parsley[B]): Parsley[(A_, B)] = this <~> q
-        /** Filter the value of a parser; if the value returned by the parser matches the predicate `pred` then the
-          * filter succeeded, otherwise the parser fails with an empty error
-          * @param pred The predicate that is tested against the parser result
-          * @return The result of the invokee if it passes the predicate
-          */
-        def filter(pred: A => Boolean): Parsley[A] = new Parsley(new deepembedding.Filter(con(p).internal, pred))
-        /** Filter the value of a parser; if the value returned by the parser does not match the predicate `pred` then the
-          * filter succeeded, otherwise the parser fails with an empty error
-          * @param pred The predicate that is tested against the parser result
-          * @return The result of the invokee if it fails the predicate
-          */
-        def filterNot(pred: A => Boolean): Parsley[A] = this.filter(!pred(_))
-        /** Attempts to first filter the parser to ensure that `pf` is defined over it. If it is, then the function `pf`
-          * is mapped over its result. Roughly the same as a `filter` then a `map`.
-          * @param pf The partial function
-          * @return The result of applying `pf` to this parsers value (if possible), or fails
-          * @since 2.0.0
-          */
-        def collect[B](pf: PartialFunction[A, B]): Parsley[B] = this.filter(pf.isDefinedAt).map(pf)
-        /**
-          * A fold for a parser: `p.foldRight(k)(f)` will try executing `p` many times until it fails, combining the
-          * results with right-associative application of `f` with a `k` at the right-most position
-          *
-          * @example {{{p.foldRight(Nil)(_::_) == many(p) //many is more efficient, however}}}
-          *
-          * @param k base case for iteration
-          * @param f combining function
-          * @return the result of folding the results of `p` with `f` and `k`
-          */
-        def foldRight[B](k: B)(f: (A, B) => B): Parsley[B] = chain.prefix(this.map(f.curried), pure(k))
-        /**
-          * A fold for a parser: `p.foldLeft(k)(f)` will try executing `p` many times until it fails, combining the
-          * results with left-associative application of `f` with a `k` on the left-most position
-          *
-          * @example {{{val natural: Parsley[Int] = digit.foldLeft(0)((x, d) => x * 10 + d.toInt)}}}
-          *
-          * @param k base case for iteration
-          * @param f combining function
-          * @return the result of folding the results of `p` with `f` and `k`
-          */
-        def foldLeft[B](k: B)(f: (B, A) => B): Parsley[B] = new Parsley(new deepembedding.Chainl(pure(k).internal, con(p).internal, pure(f).internal))
-        /**
-          * A fold for a parser: `p.foldRight1(k)(f)` will try executing `p` many times until it fails, combining the
-          * results with right-associative application of `f` with a `k` at the right-most position. It must parse `p`
-          * at least once.
-          *
-          * @example {{{p.foldRight1(Nil)(_::_) == some(p) //some is more efficient, however}}}
-          *
-          * @param k base case for iteration
-          * @param f combining function
-          * @return the result of folding the results of `p` with `f` and `k`
-          * @since 2.1.0
-          */
-        def foldRight1[B](k: B)(f: (A, B) => B): Parsley[B] = {
-            lazy val q: Parsley[A] = con(p)
-            lift.lift2(f, q, q.foldRight(k)(f))
-        }
-        /**
-          * A fold for a parser: `p.foldLeft1(k)(f)` will try executing `p` many times until it fails, combining the
-          * results with left-associative application of `f` with a `k` on the left-most position. It must parse `p`
-          * at least once.
-          *
-          * @example {{{val natural: Parsley[Int] = digit.foldLeft1(0)((x, d) => x * 10 + d.toInt)}}}
-          *
-          * @param k base case for iteration
-          * @param f combining function
-          * @return the result of folding the results of `p` with `f` and `k`
-          * @since 2.1.0
-          */
-        def foldLeft1[B](k: B)(f: (B, A) => B): Parsley[B] = {
-            lazy val q: Parsley[A] = con(p)
-            new Parsley(new deepembedding.Chainl(q.map(f(k, _)).internal, q.internal, pure(f).internal))
-        }
-        /**
-          * A reduction for a parser: `p.reduceRight(op)` will try executing `p` many times until it fails, combining the
-          * results with right-associative application of `op`. It must parse `p` at least once.
-          *
-          * @param op combining function
-          * @return the result of reducing the results of `p` with `op`
-          * @since 2.3.0
-          */
-        def reduceRight[B >: A](op: (A, B) => B): Parsley[B] = some(con(p)).map(_.reduceRight(op))
-        /**
-          * A reduction for a parser: `p.reduceRight(op)` will try executing `p` many times until it fails, combining the
-          * results with right-associative application of `op`. If there is no `p`, it returns `None`, otherwise it returns
-          * `Some(x)` where `x` is the result of the reduction.
-          *
-          * @param op combining function
-          * @return the result of reducing the results of `p` with `op` wrapped in `Some` or `None` otherwise
-          * @since 2.3.0
-          */
-        def reduceRightOption[B >: A](op: (A, B) => B): Parsley[Option[B]] = option(this.reduceRight(op))
-        /**
-          * A reduction for a parser: `p.reduceLeft(op)` will try executing `p` many times until it fails, combining the
-          * results with left-associative application of `op`. It must parse `p` at least once.
-          *
-          * @param op combining function
-          * @return the result of reducing the results of `p` with `op`
-          * @since 2.3.0
-          */
-        def reduceLeft[B >: A](op: (B, A) => B): Parsley[B] = chain.left1(con(p), pure(op))
-        /**
-          * A reduction for a parser: `p.reduceLeft(op)` will try executing `p` many times until it fails, combining the
-          * results with left-associative application of `op`. If there is no `p`, it returns `None`, otherwise it returns
-          * `Some(x)` where `x` is the result of the reduction.
-          *
-          * @param op combining function
-          * @return the result of reducing the results of `p` with `op` wrapped in `Some` or `None` otherwise
-          * @since 2.3.0
-          */
-        def reduceLeftOption[B >: A](op: (B, A) => B): Parsley[Option[B]] = option(this.reduceLeft(op))
-        /**
-          * This casts the result of the parser into a new type `B`. If the value returned by the parser
-          * is castable to type `B`, then this cast is performed. Otherwise the parser fails.
-          * @tparam B The type to attempt to cast into
-          * @since 2.0.0
-          */
-        def cast[B: ClassTag]: Parsley[B] = this.collect {
-            case x: B => x
-        }
-    }
     /**
       * This class exposes the `<#>` combinator on functions.
       *
       * @param f The function that is used for the map
       * @version 1.0.0
       */
-    implicit final class LazyMapParsley[-A, +B](f: A => B)
+    implicit final class LazyMapParsley[-A, +B](val f: A => B) extends AnyVal
     {
         /**This combinator is an alias for `map`*/
-        def <#>(p: =>Parsley[A]): Parsley[B] = p.map(f)
+        def <#>(p: Parsley[A]): Parsley[B] = p.map(f)
     }
     /**
       * This class exposes a ternary operator on pairs of parsers.
@@ -329,7 +322,7 @@ object Parsley
           * @param b The parser that yields the condition value
           * @return The result of either `p` or `q` depending on the return value of the invokee
           */
-        def ?:(b: =>Parsley[Boolean]): Parsley[A] = new Parsley(new deepembedding.If(b.internal, con(p).internal, con(q).internal))
+        def ?:(b: Parsley[Boolean]): Parsley[A] = new Parsley(new deepembedding.If(b.internal, con(p).internal, con(q).internal))
     }
 
     /** This is the traditional applicative pure function (or monadic return) for parsers. It consumes no input and
@@ -347,7 +340,7 @@ object Parsley
       * @param q If `b` returns `Right` then this parser is executed with the result
       * @return Either the result from `p` or `q` depending on `b`.
       */
-    def branch[A, B, C](b: =>Parsley[Either[A, B]], p: =>Parsley[A => C], q: =>Parsley[B => C]): Parsley[C] = {
+    def branch[A, B, C](b: Parsley[Either[A, B]], p: =>Parsley[A => C], q: =>Parsley[B => C]): Parsley[C] = {
         new Parsley(new deepembedding.Branch(b.internal, p.internal, q.internal))
     }
     /** This is one of the core operations of a selective functor. It will conditionally execute one of `q` depending on
@@ -357,21 +350,21 @@ object Parsley
       * @param q If `p` returns `Left` then this parser is executed with the result
       * @return Either the result from `p` if it returned `Left` or the result of `q` applied to the `Right` from `p`
       */
-    def select[A, B](p: =>Parsley[Either[A, B]], q: =>Parsley[A => B]): Parsley[B] = branch(p, q, pure(identity[B](_)))
+    def select[A, B](p: Parsley[Either[A, B]], q: =>Parsley[A => B]): Parsley[B] = branch(p, q, pure(identity[B](_)))
     /**This function is an alias for `_.flatten`. Provides namesake to Haskell.*/
-    def join[A](p: =>Parsley[Parsley[A]]): Parsley[A] = p.flatten
+    def join[A](p: Parsley[Parsley[A]]): Parsley[A] = p.flatten
     /** Given a parser `p`, attempts to parse `p`. If the parser fails, then `attempt` ensures that no input was
       * consumed. This allows for backtracking capabilities, disabling the implicit cut semantics offered by `<|>`.
       * @param p The parser to run
       * @return The result of `p`, or if `p` failed ensures the parser state was as it was on entry.
       */
-    def attempt[A](p: =>Parsley[A]): Parsley[A] = new Parsley(new deepembedding.Attempt(p.internal))
+    def attempt[A](p: Parsley[A]): Parsley[A] = new Parsley(new deepembedding.Attempt(p.internal))
     /** Parses `p` without consuming any input. If `p` fails and consumes input then so does `lookAhead(p)`. Combine with
       * `attempt` if this is undesirable.
       * @param p The parser to look ahead at
       * @return The result of the lookahead
       */
-    def lookAhead[A](p: =>Parsley[A]): Parsley[A] = new Parsley(new deepembedding.Look(p.internal))
+    def lookAhead[A](p: Parsley[A]): Parsley[A] = new Parsley(new deepembedding.Look(p.internal))
     /**`notFollowedBy(p)` only succeeds when parser `p` fails. This parser does not consume any input.
       * This parser can be used to implement the 'longest match' rule. For example, when recognising
       * keywords, we want to make sure that a keyword is not followed by a legal identifier character,

--- a/src/main/scala/parsley/character.scala
+++ b/src/main/scala/parsley/character.scala
@@ -1,6 +1,5 @@
 package parsley
 
-import parsley.Parsley
 import parsley.combinator.skipMany
 import parsley.implicits.character.charLift
 import parsley.internal.deepembedding

--- a/src/main/scala/parsley/character.scala
+++ b/src/main/scala/parsley/character.scala
@@ -1,6 +1,6 @@
 package parsley
 
-import parsley.Parsley.{LazyParsley}
+import parsley.Parsley
 import parsley.combinator.skipMany
 import parsley.implicits.character.charLift
 import parsley.internal.deepembedding

--- a/src/main/scala/parsley/combinator.scala
+++ b/src/main/scala/parsley/combinator.scala
@@ -19,53 +19,50 @@ object combinator {
 
     /** `repeat(n, p)` parses `n` occurrences of `p`. If `n` is smaller or equal to zero, the parser is
       *  `pure(Nil)`. Returns a list of `n` values returned by `p`.*/
-    def repeat[A](n: Int, p: =>Parsley[A]): Parsley[List[A]] = {
-        lazy val _p = p
-        sequence((for (_ <- 1 to n) yield _p): _*)
+    def repeat[A](n: Int, p: Parsley[A]): Parsley[List[A]] = {
+        sequence((for (_ <- 1 to n) yield p): _*)
     }
 
     /**`option(p)` tries to apply parser `p`. If `p` fails without consuming input, it returns
       * `None`, otherwise it returns `Some` of the value returned by `p`.*/
-    def option[A](p: =>Parsley[A]): Parsley[Option[A]] = p.map(Some(_)).getOrElse(None)
+    def option[A](p: Parsley[A]): Parsley[Option[A]] = p.map(Some(_)).getOrElse(None)
 
     /**`decide(p)` removes the option from inside parser `p`, and if it returned `None` will fail.*/
-    def decide[A](p: =>Parsley[Option[A]]): Parsley[A] = p.collect {
+    def decide[A](p: Parsley[Option[A]]): Parsley[A] = p.collect {
         case Some(x) => x
     }
 
     /**`decide(p, q)` removes the option from inside parser `p`, if it returned `None` then `q` is executed.*/
-    def decide[A](p: =>Parsley[Option[A]], q: =>Parsley[A]): Parsley[A] = select(p.map(_.toRight(())), q.map(x => (_: Unit) => x))
+    def decide[A](p: Parsley[Option[A]], q: =>Parsley[A]): Parsley[A] = select(p.map(_.toRight(())), q.map(x => (_: Unit) => x))
 
     /**optional(p) tries to apply parser `p`. It will parse `p` or nothing. It only fails if `p`
       * fails after consuming input. It discards the result of `p`.*/
-    def optional(p: =>Parsley[_]): Parsley[Unit] = optionally(p, ())
+    def optional(p: Parsley[_]): Parsley[Unit] = optionally(p, ())
 
     /**optionally(p, x) tries to apply parser `p`. It will always result in `x` regardless of
       * whether or not `p` succeeded or `p` failed without consuming input.*/
-    def optionally[A](p: =>Parsley[_], x: =>A): Parsley[A] = {
-        lazy val _x = x
+    def optionally[A](p: Parsley[_], x: A): Parsley[A] = {
         (p #> x).getOrElse(x)
     }
 
     /**`between(open, close, p)` parses `open`, followed by `p` and `close`. Returns the value returned by `p`.*/
-    def between[A](open: =>Parsley[_],
+    def between[A](open: Parsley[_],
                    close: =>Parsley[_],
                    p: =>Parsley[A]): Parsley[A] = open *> p <* close
 
     /** `many(p)` executes the parser `p` zero or more times. Returns a list of the returned values of `p`.
       * @since 2.2.0
       */
-    def many[A](p: =>Parsley[A]): Parsley[List[A]] = new Parsley(new deepembedding.Many(p.internal))
+    def many[A](p: Parsley[A]): Parsley[List[A]] = new Parsley(new deepembedding.Many(p.internal))
 
     /**`some(p)` applies the parser `p` *one* or more times. Returns a list of the returned values of `p`.*/
-    def some[A](p: =>Parsley[A]): Parsley[List[A]] = manyN(1, p)
+    def some[A](p: Parsley[A]): Parsley[List[A]] = manyN(1, p)
 
     /**`manyN(n, p)` applies the parser `p` *n* or more times. Returns a list of the returned values of `p`.*/
-    def manyN[A](n: Int, p: =>Parsley[A]): Parsley[List[A]] = {
-        lazy val _p = p
-        @tailrec def go(n: Int, acc: Parsley[List[A]] = many(_p)): Parsley[List[A]] = {
+    def manyN[A](n: Int, p: Parsley[A]): Parsley[List[A]] = {
+        @tailrec def go(n: Int, acc: Parsley[List[A]] = many(p)): Parsley[List[A]] = {
             if (n == 0) acc
-            else go(n-1, _p <::> acc)
+            else go(n-1, p <::> acc)
         }
         go(n)
     }
@@ -73,48 +70,45 @@ object combinator {
     /** `skipMany(p)` executes the parser `p` zero or more times and ignores the results. Returns `()`
       * @since 2.2.0
       */
-    def skipMany[A](p: =>Parsley[A]): Parsley[Unit] = new Parsley(new deepembedding.SkipMany(p.internal))
+    def skipMany[A](p: Parsley[A]): Parsley[Unit] = new Parsley(new deepembedding.SkipMany(p.internal))
 
     /**`skipSome(p)` applies the parser `p` *one* or more times, skipping its result.*/
-    def skipSome[A](p: => Parsley[A]): Parsley[Unit] = skipManyN(1, p)
+    def skipSome[A](p: Parsley[A]): Parsley[Unit] = skipManyN(1, p)
 
     /**`skipManyN(n, p)` applies the parser `p` *n* or more times, skipping its result.*/
-    def skipManyN[A](n: Int, p: =>Parsley[A]): Parsley[Unit] = {
-        lazy val _p = p
-        @tailrec def go(n: Int, acc: Parsley[Unit] = skipMany(_p)): Parsley[Unit] =
-        {
+    def skipManyN[A](n: Int, p: Parsley[A]): Parsley[Unit] = {
+        @tailrec def go(n: Int, acc: Parsley[Unit] = skipMany(p)): Parsley[Unit] = {
             if (n == 0) acc
-            else go(n-1, _p *> acc)
+            else go(n-1, p *> acc)
         }
         go(n)
     }
 
     /**`sepBy(p, sep)` parses *zero* or more occurrences of `p`, separated by `sep`. Returns a list
       * of values returned by `p`.*/
-    def sepBy[A, B](p: =>Parsley[A], sep: =>Parsley[B]): Parsley[List[A]] = sepBy1(p, sep).getOrElse(Nil)
+    def sepBy[A, B](p: Parsley[A], sep: =>Parsley[B]): Parsley[List[A]] = sepBy1(p, sep).getOrElse(Nil)
 
     /**`sepBy1(p, sep)` parses *one* or more occurrences of `p`, separated by `sep`. Returns a list
       *  of values returned by `p`.*/
-    def sepBy1[A, B](p: =>Parsley[A], sep: =>Parsley[B]): Parsley[List[A]] = {
-        lazy val _p = p
-        _p <::> many(sep *> _p)
+    def sepBy1[A, B](p: Parsley[A], sep: =>Parsley[B]): Parsley[List[A]] = {
+        p <::> many(sep *> p)
     }
 
     /**`sepEndBy(p, sep)` parses *zero* or more occurrences of `p`, separated and optionally ended
       * by `sep`. Returns a list of values returned by `p`.*/
-    def sepEndBy[A, B](p: =>Parsley[A], sep: =>Parsley[B]): Parsley[List[A]] = sepEndBy1(p, sep).getOrElse(Nil)
+    def sepEndBy[A, B](p: Parsley[A], sep: =>Parsley[B]): Parsley[List[A]] = sepEndBy1(p, sep).getOrElse(Nil)
 
     /**`sepEndBy1(p, sep)` parses *one* or more occurrences of `p`, separated and optionally ended
       * by `sep`. Returns a list of values returned by `p`.*/
-    def sepEndBy1[A, B](p: =>Parsley[A], sep: =>Parsley[B]): Parsley[List[A]] = new Parsley(new deepembedding.SepEndBy1(p.internal, sep.internal))
+    def sepEndBy1[A, B](p: Parsley[A], sep: =>Parsley[B]): Parsley[List[A]] = new Parsley(new deepembedding.SepEndBy1(p.internal, sep.internal))
 
     /**`endBy(p, sep)` parses *zero* or more occurrences of `p`, separated and ended by `sep`. Returns a list
       * of values returned by `p`.*/
-    def endBy[A, B](p: =>Parsley[A], sep: =>Parsley[B]): Parsley[List[A]] = many(p <* sep)
+    def endBy[A, B](p: Parsley[A], sep: =>Parsley[B]): Parsley[List[A]] = many(p <* sep)
 
     /**`endBy1(p, sep)` parses *one* or more occurrences of `p`, separated and ended by `sep`. Returns a list
       * of values returned by `p`.*/
-    def endBy1[A, B](p: =>Parsley[A], sep: =>Parsley[B]): Parsley[List[A]] = some(p <* sep)
+    def endBy1[A, B](p: Parsley[A], sep: =>Parsley[B]): Parsley[List[A]] = some(p <* sep)
 
     /**This parser only succeeds at the end of the input. This is a primitive parser.*/
     val eof: Parsley[Unit] = new Parsley(deepembedding.Eof)
@@ -124,16 +118,15 @@ object combinator {
 
     /**`manyUntil(p, end)` applies parser `p` zero or more times until the parser `end` succeeds.
       * Returns a list of values returned by `p`. This parser can be used to scan comments.*/
-    def manyUntil[A, B](p: =>Parsley[A], end: =>Parsley[B]): Parsley[List[A]] = {
+    def manyUntil[A, B](p: =>Parsley[A], end: Parsley[B]): Parsley[List[A]] = {
         new Parsley(new deepembedding.ManyUntil((end #> deepembedding.ManyUntil.Stop <|> p).internal))
     }
 
     /**`someUntil(p, end)` applies parser `p` one or more times until the parser `end` succeeds.
       * Returns a list of values returned by `p`.*/
-    def someUntil[A, B](p: =>Parsley[A], end: =>Parsley[B]): Parsley[List[A]] = {
+    def someUntil[A, B](p: =>Parsley[A], end: Parsley[B]): Parsley[List[A]] = {
         lazy val _p = p
-        lazy val _end = end
-        notFollowedBy(_end) *> (_p <::> manyUntil(_p, _end))
+        notFollowedBy(end) *> (_p <::> manyUntil(_p, end))
     }
 
     /** `when(p, q)` will first perform `p`, and if the result is `true` will then execute `q` or else return unit.
@@ -141,14 +134,14 @@ object combinator {
       * @param q If `p` returns `true` then this parser is executed
       * @return ()
       */
-    def when(p: =>Parsley[Boolean], q: =>Parsley[Unit]): Parsley[Unit] = p ?: (q, unit)
+    def when(p: Parsley[Boolean], q: =>Parsley[Unit]): Parsley[Unit] = p ?: (q, unit)
 
     /** `whileP(p)` will continue to run `p` until it returns `false`. This is often useful in conjunction with stateful
       * parsers.
       * @param p The parser to continuously execute
       * @return ()
       */
-    def whileP(p: =>Parsley[Boolean]): Parsley[Unit] = {
+    def whileP(p: Parsley[Boolean]): Parsley[Unit] = {
         lazy val whilePP: Parsley[Unit] = when(p, whilePP)
         whilePP
     }

--- a/src/main/scala/parsley/combinator.scala
+++ b/src/main/scala/parsley/combinator.scala
@@ -1,6 +1,6 @@
 package parsley
 
-import parsley.Parsley.{LazyParsley, unit, empty, select, sequence, notFollowedBy, attempt}
+import parsley.Parsley.{unit, empty, select, sequence, notFollowedBy, attempt}
 import parsley.internal.deepembedding
 import parsley.expr.chain
 import scala.annotation.{tailrec, implicitNotFound}

--- a/src/main/scala/parsley/errors/combinator.scala
+++ b/src/main/scala/parsley/errors/combinator.scala
@@ -30,7 +30,7 @@ object combinator {
       * @param p A parser whose error messages should be adjusted
       * @since 3.1.0
       */
-    def amend[A](p: =>Parsley[A]): Parsley[A] = new Parsley(new deepembedding.ErrorAmend(p.internal))
+    def amend[A](p: Parsley[A]): Parsley[A] = new Parsley(new deepembedding.ErrorAmend(p.internal))
 
     /**
       * Sometimes, the error adjustments performed by `[[amend]]` should only affect errors generated
@@ -41,7 +41,7 @@ object combinator {
       * @param p A parser whose error messages should not be adjusted by any surrounding `[[amend]]`
       * @since 3.1.0
       */
-    def entrench[A](p: =>Parsley[A]): Parsley[A] = new Parsley(new deepembedding.ErrorEntrench(p.internal))
+    def entrench[A](p: Parsley[A]): Parsley[A] = new Parsley(new deepembedding.ErrorEntrench(p.internal))
 
     /**
       * This class exposes helpful combinators that are specialised for generating more helpful errors messages.
@@ -52,7 +52,7 @@ object combinator {
       * @param con A conversion (if required) to turn `p` into a parser
       * @version 3.0.0
       */
-    implicit final class ErrorMethods[P, +A](p: =>P)(implicit con: P => Parsley[A]) {
+    implicit final class ErrorMethods[P, +A](p: P)(implicit con: P => Parsley[A]) {
         /** Filter the value of a parser; if the value returned by the parser is defined for the given partial function, then
           * the `filterOut` fails, using the result of the function as the ''reason'' (see [[explain]]), otherwise the parser
           * succeeds

--- a/src/main/scala/parsley/expr/chain.scala
+++ b/src/main/scala/parsley/expr/chain.scala
@@ -16,25 +16,24 @@ object chain {
       * returned by `p`. If there are no occurrences of `p`, the value `x` is returned.
       * @since 2.2.0
       */
-    def right[A, B, C >: B]
-        (p: =>Parsley[A], op: =>Parsley[(A, C) => B], x: C)
-        (implicit @implicitNotFound("Please provide a wrapper function from ${A} to ${C}") wrap: A => C): Parsley[C] = right1(p, op).getOrElse(x)
+    def right[A, B, C >: B](p: Parsley[A], op: =>Parsley[(A, C) => B], x: C)
+            (implicit @implicitNotFound("Please provide a wrapper function from ${A} to ${C}") wrap: A => C): Parsley[C] = right1(p, op).getOrElse(x)
 
     /**`left(p, op, x)` parses *zero* or more occurrences of `p`, separated by `op`. Returns a value
       * obtained by a left associative application of all functions returned by `op` to the values
       * returned by `p`. If there are no occurrences of `p`, the value `x` is returned.
       * @since 2.2.0
       */
-    def left[A, B, C >: B](p: =>Parsley[A], op: =>Parsley[(C, A) => B], x: C)
-                  (implicit @implicitNotFound("Please provide a wrapper function from ${A} to ${C}") wrap: A => C): Parsley[C] = left1(p, op).getOrElse(x)
+    def left[A, B, C >: B](p: Parsley[A], op: =>Parsley[(C, A) => B], x: C)
+            (implicit @implicitNotFound("Please provide a wrapper function from ${A} to ${C}") wrap: A => C): Parsley[C] = left1(p, op).getOrElse(x)
 
     /**`right1(p, op)` parses *one* or more occurrences of `p`, separated by `op`. Returns a value
       * obtained by a right associative application of all functions return by `op` to the values
       * returned by `p`.
       * @since 2.2.0
       */
-    def right1[A, B, C >: B](p: =>Parsley[A], op: =>Parsley[(A, C) => B])
-                    (implicit @implicitNotFound("Please provide a wrapper function from ${A} to ${B}") wrap: A => C): Parsley[C] = {
+    def right1[A, B, C >: B](p: Parsley[A], op: =>Parsley[(A, C) => B])
+            (implicit @implicitNotFound("Please provide a wrapper function from ${A} to ${B}") wrap: A => C): Parsley[C] = {
         new Parsley(new deepembedding.Chainr(p.internal, op.internal, wrap))
     }
 
@@ -44,8 +43,8 @@ object chain {
       * typically occurs in expression grammars.
       * @since 2.2.0
       */
-    def left1[A, B, C >: B](p: =>Parsley[A], op: =>Parsley[(C, A) => B])
-                   (implicit @implicitNotFound("Please provide a wrapper function from ${A} to ${B}") wrap: A => C): Parsley[C] = {
+    def left1[A, B, C >: B](p: Parsley[A], op: =>Parsley[(C, A) => B])
+            (implicit @implicitNotFound("Please provide a wrapper function from ${A} to ${B}") wrap: A => C): Parsley[C] = {
         lazy val _p = p
         // a sneaky sneaky trick :) If we know that A =:= B because refl was provided, then we can skip the wrapping
         new Parsley(new deepembedding.Chainl(parsley.XCompat.applyWrap(wrap)(_p).internal, _p.internal, op.internal))
@@ -54,18 +53,18 @@ object chain {
     /**`prefix(op, p)` parses many prefixed applications of `op` onto a single final result of `p`
       * @since 2.2.0
       */
-    def prefix[A](op: =>Parsley[A => A], p: =>Parsley[A]): Parsley[A] = new Parsley(new deepembedding.ChainPre(p.internal, op.internal))
+    def prefix[A](op: Parsley[A => A], p: =>Parsley[A]): Parsley[A] = new Parsley(new deepembedding.ChainPre(p.internal, op.internal))
 
     /**`postfix(p, op)` parses one occurrence of `p`, followed by many postfix applications of `op`
       * that associate to the left.
       * @since 2.2.0
       */
-    def postfix[A](p: =>Parsley[A], op: =>Parsley[A => A]): Parsley[A] = new Parsley(new deepembedding.ChainPost(p.internal, op.internal))
+    def postfix[A](p: Parsley[A], op: =>Parsley[A => A]): Parsley[A] = new Parsley(new deepembedding.ChainPost(p.internal, op.internal))
 
     /**`prefix1(op, p)` parses one or more prefixed applications of `op` onto a single final result of `p`
       * @since 3.0.0
       */
-    def prefix1[A, B <: A](op: =>Parsley[A => B], p: =>Parsley[A]): Parsley[B] = {
+    def prefix1[A, B <: A](op: Parsley[A => B], p: =>Parsley[A]): Parsley[B] = {
         lazy val op_ = op
         op_ <*> prefix(op_, p)
     }
@@ -74,7 +73,7 @@ object chain {
       * that associate to the left.
       * @since 3.0.0
       */
-    def postfix1[A, B <: A](p: =>Parsley[A], op: =>Parsley[A => B]): Parsley[B] = {
+    def postfix1[A, B <: A](p: =>Parsley[A], op: Parsley[A => B]): Parsley[B] = {
         lazy val op_ = op
         postfix(p <**> op_, op_)
     }

--- a/src/main/scala/parsley/expr/chain.scala
+++ b/src/main/scala/parsley/expr/chain.scala
@@ -1,6 +1,6 @@
 package parsley.expr
 
-import parsley.Parsley, Parsley.LazyParsley
+import parsley.Parsley
 import parsley.internal.deepembedding
 
 import scala.annotation.implicitNotFound

--- a/src/main/scala/parsley/implicits/lift.scala
+++ b/src/main/scala/parsley/implicits/lift.scala
@@ -18,60 +18,60 @@ object lift
     }
     /** Exposes a combinator similar to `.map`, but in reverse: `p.map(f) = f.lift(p)` */
     implicit final class Lift1[T1, R](private val f: T1 => R) extends AnyVal {
-        def lift(p1: =>Parsley[T1]): Parsley[R] = lift1(f, p1)
+        def lift(p1: Parsley[T1]): Parsley[R] = lift1(f, p1)
     }
     /** Exposes a combinator for postfix application of `lift2` */
     implicit final class Lift2[T1, T2, R](private val f: (T1, T2) => R) extends AnyVal {
-        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2]): Parsley[R] = lift2(f, p1, p2)
+        def lift(p1: Parsley[T1], p2: =>Parsley[T2]): Parsley[R] = lift2(f, p1, p2)
     }
     /** Exposes a combinator for postfix application of `lift3` */
     implicit final class Lift3[T1, T2, T3, R](private val f: (T1, T2, T3) => R) extends AnyVal {
-        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3]): Parsley[R] = lift3(f, p1, p2, p3)
+        def lift(p1: Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3]): Parsley[R] = lift3(f, p1, p2, p3)
     }
     /** Exposes a combinator for postfix application of `lift4` */
     implicit final class Lift4[T1, T2, T3, T4, R](private val f: (T1, T2, T3, T4) => R) extends AnyVal {
-        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4]): Parsley[R] = lift4(f, p1, p2, p3, p4)
+        def lift(p1: Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4]): Parsley[R] = lift4(f, p1, p2, p3, p4)
     }
     /** Exposes a combinator for postfix application of `lift5` */
     implicit final class Lift5[T1, T2, T3, T4, T5, R](private val f: (T1, T2, T3, T4, T5) => R) extends AnyVal {
-        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5]): Parsley[R] = lift5(f, p1, p2, p3, p4, p5)
+        def lift(p1: Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5]): Parsley[R] = lift5(f, p1, p2, p3, p4, p5)
     }
     /** Exposes a combinator for postfix application of `lift6` */
     implicit final class Lift6[T1, T2, T3, T4, T5, T6, R](private val f: (T1, T2, T3, T4, T5, T6) => R) extends AnyVal {
-        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6]): Parsley[R] =
+        def lift(p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6]): Parsley[R] =
             lift6(f, p1, p2, p3, p4, p5, p6)
     }
     /** Exposes a combinator for postfix application of `lift7` */
     implicit final class Lift7[T1, T2, T3, T4, T5, T6, T7, R](private val f: (T1, T2, T3, T4, T5, T6, T7) => R) extends AnyVal {
-        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
+        def lift(p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
                  p7: =>Parsley[T7]): Parsley[R] = lift7(f, p1, p2, p3, p4, p5, p6, p7)
     }
     /** Exposes a combinator for postfix application of `lift8` */
     implicit final class Lift8[T1, T2, T3, T4, T5, T6, T7, T8, R](private val f: (T1, T2, T3, T4, T5, T6, T7, T8) => R) extends AnyVal {
-        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
+        def lift(p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
                  p7: =>Parsley[T7], p8: =>Parsley[T8]): Parsley[R] = lift8(f, p1, p2, p3, p4, p5, p6, p7, p8)
     }
     /** Exposes a combinator for postfix application of `lift9` */
     implicit final class Lift9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R](private val f: (T1, T2, T3, T4, T5, T6, T7, T8, T9) => R) extends AnyVal {
-        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
+        def lift(p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
                  p7: =>Parsley[T7], p8: =>Parsley[T8], p9: =>Parsley[T9]): Parsley[R] = lift9(f, p1, p2, p3, p4, p5, p6, p7, p8, p9)
     }
     /** Exposes a combinator for postfix application of `lift10` */
     implicit final class Lift10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R](private val f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) => R) extends AnyVal {
-        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
+        def lift(p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
                  p7: =>Parsley[T7], p8: =>Parsley[T8], p9: =>Parsley[T9], p10: =>Parsley[T10]): Parsley[R] = lift10(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10)
     }
     /** Exposes a combinator for postfix application of `lift11` */
     implicit final class Lift11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R]
         (private val f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) => R) extends AnyVal {
-        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
+        def lift(p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
                  p7: =>Parsley[T7], p8: =>Parsley[T8], p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11]): Parsley[R] =
             lift11(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11)
     }
     /** Exposes a combinator for postfix application of `lift12` */
     implicit final class Lift12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R]
         (private val f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) => R) extends AnyVal {
-        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4],
+        def lift(p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4],
                  p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
                  p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12]): Parsley[R] =
             lift12(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12)
@@ -79,21 +79,21 @@ object lift
     /** Exposes a combinator for postfix application of `lift13` */
     implicit final class Lift13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R]
         (private val f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) => R) extends AnyVal {
-        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
+        def lift(p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
                  p7: =>Parsley[T7], p8: =>Parsley[T8], p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12],
                  p13: =>Parsley[T13]): Parsley[R] = lift13(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13)
     }
     /** Exposes a combinator for postfix application of `lift14` */
     implicit final class Lift14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R]
         (private val f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) => R) extends AnyVal {
-        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
+        def lift(p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
                  p7: =>Parsley[T7], p8: =>Parsley[T8], p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12],
                  p13: =>Parsley[T13], p14: =>Parsley[T14]): Parsley[R] = lift14(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14)
     }
     /** Exposes a combinator for postfix application of `lift15` */
     implicit final class Lift15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R]
         (private val f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) => R) extends AnyVal {
-        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
+        def lift(p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
                  p7: =>Parsley[T7], p8: =>Parsley[T8], p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12],
                  p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15]): Parsley[R] =
             lift15(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15)
@@ -101,7 +101,7 @@ object lift
     /** Exposes a combinator for postfix application of `lift16` */
     implicit final class Lift16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R]
         (private val f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) => R) extends AnyVal {
-        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
+        def lift(p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
                  p7: =>Parsley[T7], p8: =>Parsley[T8], p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12],
                  p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15], p16: =>Parsley[T16]): Parsley[R] =
             lift16(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16)
@@ -109,7 +109,7 @@ object lift
     /** Exposes a combinator for postfix application of `lift17` */
     implicit final class Lift17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R]
         (private val f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) => R) extends AnyVal {
-        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
+        def lift(p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
                  p7: =>Parsley[T7], p8: =>Parsley[T8], p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12],
                  p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15], p16: =>Parsley[T16], p17: =>Parsley[T17]): Parsley[R] =
             lift17(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17)
@@ -117,7 +117,7 @@ object lift
     /** Exposes a combinator for postfix application of `lift18` */
     implicit final class Lift18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R]
         (private val f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) => R) extends AnyVal {
-        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
+        def lift(p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
                  p7: =>Parsley[T7], p8: =>Parsley[T8], p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12],
                  p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15], p16: =>Parsley[T16], p17: =>Parsley[T17], p18: =>Parsley[T18]): Parsley[R] =
             lift18(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18)
@@ -125,7 +125,7 @@ object lift
     /** Exposes a combinator for postfix application of `lift19` */
     implicit final class Lift19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R]
         (private val f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) => R) extends AnyVal {
-        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
+        def lift(p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
                  p7: =>Parsley[T7], p8: =>Parsley[T8], p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12],
                  p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15], p16: =>Parsley[T16], p17: =>Parsley[T17], p18: =>Parsley[T18],
                  p19: =>Parsley[T19]): Parsley[R] = lift19(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19)
@@ -133,7 +133,7 @@ object lift
     /** Exposes a combinator for postfix application of `lift20` */
     implicit final class Lift20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R]
         (private val f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) => R) extends AnyVal {
-        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
+        def lift(p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
                  p7: =>Parsley[T7], p8: =>Parsley[T8], p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12],
                  p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15], p16: =>Parsley[T16], p17: =>Parsley[T17], p18: =>Parsley[T18],
                  p19: =>Parsley[T19], p20: =>Parsley[T20]): Parsley[R] =
@@ -142,7 +142,7 @@ object lift
     /** Exposes a combinator for postfix application of `lift21` */
     implicit final class Lift21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R]
         (private val f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21) => R) extends AnyVal {
-        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
+        def lift(p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
                  p7: =>Parsley[T7], p8: =>Parsley[T8], p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12],
                  p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15], p16: =>Parsley[T16], p17: =>Parsley[T17], p18: =>Parsley[T18],
                  p19: =>Parsley[T19], p20: =>Parsley[T20], p21: =>Parsley[T21]): Parsley[R] =
@@ -151,7 +151,7 @@ object lift
     /** Exposes a combinator for postfix application of `lift22` */
     implicit final class Lift22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R]
         (private val f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22) => R) extends AnyVal {
-        def lift(p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
+        def lift(p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6],
                  p7: =>Parsley[T7], p8: =>Parsley[T8], p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12],
                  p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15], p16: =>Parsley[T16], p17: =>Parsley[T17], p18: =>Parsley[T18],
                  p19: =>Parsley[T19], p20: =>Parsley[T20], p21: =>Parsley[T21], p22: =>Parsley[T22]): Parsley[R] =

--- a/src/main/scala/parsley/internal/deepembedding/AlternativeEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/AlternativeEmbedding.scala
@@ -9,7 +9,7 @@ import scala.collection.mutable
 import scala.language.higherKinds
 
 // TODO: Tablification is too aggressive. It appears that `optional` is being compiled to jumptable
-private [parsley] final class <|>[A, B](_p: =>Parsley[A], _q: =>Parsley[B]) extends Binary[A, B, B](_p, _q)((l, r) => s"($l <|> $r)", <|>.empty) {
+private [parsley] final class <|>[A, B](_p: =>Parsley[A], _q: =>Parsley[B]) extends Binary[A, B, B](_p, _q, (l, r) => s"($l <|> $r)", new <|>(???, ???)) {
     override val numInstrs = 3
 
     override def optimise: Parsley[B] = (left, right) match {
@@ -207,7 +207,6 @@ private [parsley] final class <|>[A, B](_p: =>Parsley[A], _q: =>Parsley[B]) exte
 private [parsley] object Empty extends Singleton[Nothing]("empty", instructions.Empty) with MZero
 
 private [deepembedding] object <|> {
-    def empty[A, B]: A <|> B = new <|>(???, ???)
-    def apply[A, B](left: Parsley[A], right: Parsley[B]): A <|> B = empty.ready(left, right)
+    def apply[A, B](left: Parsley[A], right: Parsley[B]): A <|> B = new <|>(???, ???).ready(left, right)
     def unapply[A, B](self: A <|> B): Some[(Parsley[A], Parsley[B])] = Some((self.left, self.right))
 }

--- a/src/main/scala/parsley/internal/deepembedding/AlternativeEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/AlternativeEmbedding.scala
@@ -9,7 +9,7 @@ import scala.collection.mutable
 import scala.language.higherKinds
 
 // TODO: Tablification is too aggressive. It appears that `optional` is being compiled to jumptable
-private [parsley] final class <|>[A, B](_p: =>Parsley[A], _q: =>Parsley[B]) extends Binary[A, B, B](_p, _q, (l, r) => s"($l <|> $r)", new <|>(???, ???)) {
+private [parsley] final class <|>[A, B](_p: Parsley[A], _q: =>Parsley[B]) extends Binary[A, B, B](_p, _q, (l, r) => s"($l <|> $r)", new <|>(_, ???)) {
     override val numInstrs = 3
 
     override def optimise: Parsley[B] = (left, right) match {
@@ -207,6 +207,6 @@ private [parsley] final class <|>[A, B](_p: =>Parsley[A], _q: =>Parsley[B]) exte
 private [parsley] object Empty extends Singleton[Nothing]("empty", instructions.Empty) with MZero
 
 private [deepembedding] object <|> {
-    def apply[A, B](left: Parsley[A], right: Parsley[B]): A <|> B = new <|>(???, ???).ready(left, right)
+    def apply[A, B](left: Parsley[A], right: Parsley[B]): A <|> B = new <|>(left, ???).ready(right)
     def unapply[A, B](self: A <|> B): Some[(Parsley[A], Parsley[B])] = Some((self.left, self.right))
 }

--- a/src/main/scala/parsley/internal/deepembedding/ErrorEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/ErrorEmbedding.scala
@@ -9,8 +9,8 @@ private [parsley] final class Fail(private [Fail] val msgs: String*)
 private [parsley] final class Unexpected(private [Unexpected] val msg: String)
     extends Singleton[Nothing](s"unexpected($msg)", new instructions.Unexpected(msg)) with MZero
 
-private [parsley] final class ErrorLabel[A](private [deepembedding] var p: Parsley[A], private [ErrorLabel] val label: String)
-    extends ScopedUnary[A, A](s"label($label)", new ErrorLabel(_, label), new instructions.InputCheck(_, true), new instructions.ApplyError(label)) {
+private [parsley] final class ErrorLabel[A](_p: Parsley[A], private [ErrorLabel] val label: String)
+    extends ScopedUnary[A, A](_p, s"label($label)", new ErrorLabel(_, label), new instructions.InputCheck(_, true), new instructions.ApplyError(label)) {
     final override def optimise: Parsley[A] = p match {
         case ct@CharTok(c) if !ct.expected.contains("") => new CharTok(c, Some(label)).asInstanceOf[Parsley[A]]
         case st@StringTok(s) if !st.expected.contains("") => new StringTok(s, Some(label)).asInstanceOf[Parsley[A]]
@@ -19,12 +19,12 @@ private [parsley] final class ErrorLabel[A](private [deepembedding] var p: Parsl
         case _ => this
     }
 }
-private [parsley] final class ErrorExplain[A](private [deepembedding] var p: Parsley[A], reason: String)
-    extends ScopedUnary[A, A](s"explain($reason)", new ErrorExplain(_, reason), new instructions.InputCheck(_), new instructions.ApplyReason(reason))
+private [parsley] final class ErrorExplain[A](_p: Parsley[A], reason: String)
+    extends ScopedUnary[A, A](_p, s"explain($reason)", new ErrorExplain(_, reason), new instructions.InputCheck(_), new instructions.ApplyReason(reason))
 
-private [parsley] final class ErrorAmend[A](private [deepembedding] var p: Parsley[A]) extends ScopedUnaryWithState[A, A]("amend", false, new ErrorAmend(_), instructions.Amend)
-private [parsley] final class ErrorEntrench[A](private [deepembedding] var p: Parsley[A])
-    extends ScopedUnary[A, A]("entrench", new ErrorEntrench(_), new instructions.PushHandler(_), instructions.Entrench)
+private [parsley] final class ErrorAmend[A](_p: Parsley[A]) extends ScopedUnaryWithState[A, A](_p, "amend", false, new ErrorAmend(_), instructions.Amend)
+private [parsley] final class ErrorEntrench[A](_p: Parsley[A])
+    extends ScopedUnary[A, A](_p, "entrench", new ErrorEntrench(_), new instructions.PushHandler(_), instructions.Entrench)
 
 private [deepembedding] object ErrorLabel {
     def apply[A](p: Parsley[A], label: String): ErrorLabel[A] = new ErrorLabel(p, label).ready()

--- a/src/main/scala/parsley/internal/deepembedding/ErrorEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/ErrorEmbedding.scala
@@ -9,8 +9,8 @@ private [parsley] final class Fail(private [Fail] val msgs: String*)
 private [parsley] final class Unexpected(private [Unexpected] val msg: String)
     extends Singleton[Nothing](s"unexpected($msg)", new instructions.Unexpected(msg)) with MZero
 
-private [parsley] final class ErrorLabel[A](_p: =>Parsley[A], private [ErrorLabel] val label: String)
-    extends ScopedUnary[A, A](_p, s"label($label)", ErrorLabel.empty(label), new instructions.InputCheck(_, true), new instructions.ApplyError(label)) {
+private [parsley] final class ErrorLabel[A](private [deepembedding] var p: Parsley[A], private [ErrorLabel] val label: String)
+    extends ScopedUnary[A, A](s"label($label)", new ErrorLabel(_, label), new instructions.InputCheck(_, true), new instructions.ApplyError(label)) {
     final override def optimise: Parsley[A] = p match {
         case ct@CharTok(c) if !ct.expected.contains("") => new CharTok(c, Some(label)).asInstanceOf[Parsley[A]]
         case st@StringTok(s) if !st.expected.contains("") => new StringTok(s, Some(label)).asInstanceOf[Parsley[A]]
@@ -19,25 +19,17 @@ private [parsley] final class ErrorLabel[A](_p: =>Parsley[A], private [ErrorLabe
         case _ => this
     }
 }
-private [parsley] final class ErrorExplain[A](_p: =>Parsley[A], reason: String)
-    extends ScopedUnary[A, A](_p, s"explain($reason)", ErrorExplain.empty(reason), new instructions.InputCheck(_), new instructions.ApplyReason(reason))
+private [parsley] final class ErrorExplain[A](private [deepembedding] var p: Parsley[A], reason: String)
+    extends ScopedUnary[A, A](s"explain($reason)", new ErrorExplain(_, reason), new instructions.InputCheck(_), new instructions.ApplyReason(reason))
 
-private [parsley] final class ErrorAmend[A](_p: =>Parsley[A]) extends ScopedUnaryWithState[A, A](_p, "amend", false, ErrorAmend.empty, instructions.Amend)
-private [parsley] final class ErrorEntrench[A](_p: =>Parsley[A])
-    extends ScopedUnary[A, A](_p, "entrench", ErrorEntrench.empty, new instructions.PushHandler(_), instructions.Entrench)
+private [parsley] final class ErrorAmend[A](private [deepembedding] var p: Parsley[A]) extends ScopedUnaryWithState[A, A]("amend", false, new ErrorAmend(_), instructions.Amend)
+private [parsley] final class ErrorEntrench[A](private [deepembedding] var p: Parsley[A])
+    extends ScopedUnary[A, A]("entrench", new ErrorEntrench(_), new instructions.PushHandler(_), instructions.Entrench)
 
 private [deepembedding] object ErrorLabel {
-    def empty[A](label: String): ErrorLabel[A] = new ErrorLabel(???, label)
-    def apply[A](p: Parsley[A], label: String): ErrorLabel[A] = empty(label).ready(p)
+    def apply[A](p: Parsley[A], label: String): ErrorLabel[A] = new ErrorLabel(p, label).ready()
     def unapply[A](self: ErrorLabel[A]): Some[(Parsley[A], String)] = Some((self.p, self.label))
 }
 private [deepembedding] object ErrorExplain {
-    def empty[A](reason: String): ErrorExplain[A] = new ErrorExplain(???, reason)
-    def apply[A](p: Parsley[A], reason: String): ErrorExplain[A] = empty(reason).ready(p)
-}
-private [deepembedding] object ErrorAmend {
-    def empty[A]: ErrorAmend[A] = new ErrorAmend(???)
-}
-private [deepembedding] object ErrorEntrench {
-    def empty[A]: ErrorEntrench[A] = new ErrorEntrench(???)
+    def apply[A](p: Parsley[A], reason: String): ErrorExplain[A] = new ErrorExplain(p, reason).ready()
 }

--- a/src/main/scala/parsley/internal/deepembedding/IntrinsicEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/IntrinsicEmbedding.scala
@@ -17,8 +17,8 @@ private [parsley] final class StringTok(private [StringTok] val s: String, val e
     }
 }
 // TODO: Perform applicative fusion optimisations
-private [parsley] final class Lift2[A, B, C](private [Lift2] val f: (A, B) => C, _p: =>Parsley[A], _q: =>Parsley[B])
-    extends Binary[A, B, C](_p, _q, (l, r) => s"lift2(f, $l, $r)", new Lift2(f, ???, ???))  {
+private [parsley] final class Lift2[A, B, C](private [Lift2] val f: (A, B) => C, _p: Parsley[A], _q: =>Parsley[B])
+    extends Binary[A, B, C](_p, _q, (l, r) => s"lift2(f, $l, $r)", new Lift2(f, _, ???))  {
     override val numInstrs = 1
     override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont, R],  instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
         left.codeGen >>
@@ -41,8 +41,8 @@ private [parsley] object Eof extends Singleton[Unit]("eof", instructions.Eof)
 
 private [parsley] final class Modify[S](val reg: Reg[S], f: S => S)
     extends Singleton[Unit](s"modify($reg, ?)", new instructions.Modify(reg.addr, f)) with UsesRegister
-private [parsley] final class Local[S, A](val reg: Reg[S], _p: =>Parsley[S], _q: =>Parsley[A])
-    extends Binary[S, A, A](_p, _q, (l, r) => s"local($reg, $l, $r)", new Local(reg, ???, ???)) with UsesRegister {
+private [parsley] final class Local[S, A](val reg: Reg[S], _p: Parsley[S], _q: =>Parsley[A])
+    extends Binary[S, A, A](_p, _q, (l, r) => s"local($reg, $l, $r)", new Local(reg, _, ???)) with UsesRegister {
     override val numInstrs = 2
     override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont, R], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
         left.codeGen >> {

--- a/src/main/scala/parsley/internal/deepembedding/IterativeEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/IterativeEmbedding.scala
@@ -7,8 +7,8 @@ import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.language.higherKinds
 
-private [deepembedding] sealed abstract class ManyLike[A, B](_p: =>Parsley[A], name: String, empty: =>ManyLike[A, B], unit: B, instr: Int => instructions.Instr)
-    extends Unary[A, B](_p)(c => s"$name($c)", empty) {
+private [deepembedding] sealed abstract class ManyLike[A, B](name: String, make: Parsley[A] => ManyLike[A, B], unit: B, instr: Int => instructions.Instr)
+    extends Unary[A, B](c => s"$name($c)", make) {
     final override val numInstrs = 2
     final override def optimise: Parsley[B] = p match {
         case _: Pure[_] => throw new Exception(s"$name given parser which consumes no input")
@@ -26,8 +26,8 @@ private [deepembedding] sealed abstract class ManyLike[A, B](_p: =>Parsley[A], n
         }
     }
 }
-private [parsley] final class Many[A](_p: =>Parsley[A]) extends ManyLike[A, List[A]](_p, "many", Many.empty, Nil, new instructions.Many(_))
-private [parsley] final class SkipMany[A](_p: =>Parsley[A]) extends ManyLike[A, Unit](_p, "skipMany", SkipMany.empty, (), new instructions.SkipMany(_))
+private [parsley] final class Many[A](private [deepembedding] var p: Parsley[A]) extends ManyLike[A, List[A]]("many", new Many(_), Nil, new instructions.Many(_))
+private [parsley] final class SkipMany[A](private [deepembedding] var p: Parsley[A]) extends ManyLike[A, Unit]("skipMany", new SkipMany(_), (), new instructions.SkipMany(_))
 private [deepembedding] sealed abstract class ChainLike[A](_p: =>Parsley[A], _op: =>Parsley[A => A], pretty: (String, String) => String, empty: =>ChainLike[A])
     extends Binary[A, A => A, A](_p, _op)(pretty, empty) {
     override def optimise: Parsley[A] = right match {
@@ -68,7 +68,7 @@ private [parsley] final class ChainPre[A](_p: =>Parsley[A], _op: =>Parsley[A => 
         }
     }
 }
-private [parsley] final class Chainl[A, B](_init: Parsley[B], _p: =>Parsley[A], _op: =>Parsley[(B, A) => B])
+private [parsley] final class Chainl[A, B](_init: =>Parsley[B], _p: =>Parsley[A], _op: =>Parsley[(B, A) => B])
     extends Ternary[B, A, (B, A) => B, B](_init, _p, _op)((f, s, t) => s"chainl1($s, $t)", Chainl.empty) {
     override val numInstrs = 2
     override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont, R], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
@@ -119,7 +119,7 @@ private [parsley] final class SepEndBy1[A, B](_p: =>Parsley[A], _sep: =>Parsley[
         }
     }
 }
-private [parsley] final class ManyUntil[A](_body: =>Parsley[Any]) extends Unary[Any, List[A]](_body)(c => s"manyUntil($c)", ManyUntil.empty) {
+private [parsley] final class ManyUntil[A](private [deepembedding] var p: Parsley[Any]) extends Unary[Any, List[A]](c => s"manyUntil($c)", new ManyUntil(_)) {
     override val numInstrs = 2
     override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont, R], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
         val start = state.freshLabel()
@@ -133,28 +133,21 @@ private [parsley] final class ManyUntil[A](_body: =>Parsley[Any]) extends Unary[
     }
 }
 
-private [deepembedding] object Many {
-    def empty[A]: Many[A] = new Many(null)
-}
-private [deepembedding] object SkipMany {
-    def empty[A]: SkipMany[A] = new SkipMany(null)
-}
 private [deepembedding] object ChainPost {
-    def empty[A]: ChainPost[A] = new ChainPost(null, null)
+    def empty[A]: ChainPost[A] = new ChainPost(???, ???)
 }
 private [deepembedding] object ChainPre {
-    def empty[A]: ChainPre[A] = new ChainPre(null, null)
+    def empty[A]: ChainPre[A] = new ChainPre(???, ???)
 }
 private [deepembedding] object Chainl {
-    def empty[A, B]: Chainl[A, B] = new Chainl(null, null, null)
+    def empty[A, B]: Chainl[A, B] = new Chainl(???, ???, ???)
 }
 private [deepembedding] object Chainr {
-    def empty[A, B](wrap: A => B): Chainr[A, B] = new Chainr(null, null, wrap)
+    def empty[A, B](wrap: A => B): Chainr[A, B] = new Chainr(???, ???, wrap)
 }
 private [deepembedding] object SepEndBy1 {
-    def empty[A, B]: SepEndBy1[A, B] = new SepEndBy1(null, null)
+    def empty[A, B]: SepEndBy1[A, B] = new SepEndBy1(???, ???)
 }
 private [parsley] object ManyUntil {
     object Stop
-    def empty[A]: ManyUntil[A] = new ManyUntil(null)
 }

--- a/src/main/scala/parsley/internal/deepembedding/PrimitiveEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/PrimitiveEmbedding.scala
@@ -12,10 +12,12 @@ import scala.language.higherKinds
 private [parsley] final class Satisfy(private [Satisfy] val f: Char => Boolean, val expected: Option[String])
     extends Singleton[Char]("satisfy(f)", new instructions.Satisfies(f, expected))
 
-private [parsley] final class Attempt[A](_p: =>Parsley[A]) extends ScopedUnaryWithState[A, A](_p, "attempt", false, Attempt.empty, instructions.Attempt)
-private [parsley] final class Look[A](_p: =>Parsley[A]) extends ScopedUnaryWithState[A, A](_p, "lookAhead", true, Look.empty, instructions.Look)
-private [parsley] final class NotFollowedBy[A](_p: =>Parsley[A])
-    extends ScopedUnaryWithState[A, Unit](_p, "notFollowedBy", true, NotFollowedBy.empty, instructions.NotFollowedBy) {
+private [parsley] final class Attempt[A](private [deepembedding] var p: Parsley[A])
+    extends ScopedUnaryWithState[A, A]("attempt", false, new Attempt(_), instructions.Attempt)
+private [parsley] final class Look[A](private [deepembedding] var p: Parsley[A])
+    extends ScopedUnaryWithState[A, A]("lookAhead", true, new Look(_), instructions.Look)
+private [parsley] final class NotFollowedBy[A](private [deepembedding] var p: Parsley[A])
+    extends ScopedUnaryWithState[A, Unit]("notFollowedBy", true, new NotFollowedBy(_), instructions.NotFollowedBy) {
     override def optimise: Parsley[Unit] = p match {
         case z: MZero => new Pure(())
         case _ => this
@@ -58,8 +60,8 @@ private [deepembedding] final class Let[A](var p: Parsley[A]) extends Parsley[A]
 private [parsley] object Line extends Singleton[Int]("line", instructions.Line)
 private [parsley] object Col extends Singleton[Int]("col", instructions.Col)
 private [parsley] final class Get[S](val reg: Reg[S]) extends Singleton[S](s"get($reg)", new instructions.Get(reg.addr)) with UsesRegister
-private [parsley] final class Put[S](val reg: Reg[S], _p: =>Parsley[S])
-    extends Unary[S, Unit](_p)(c => s"put($reg, $c)", Put.empty(reg)) with UsesRegister {
+private [parsley] final class Put[S](val reg: Reg[S], private [deepembedding] var p: Parsley[S])
+    extends Unary[S, Unit](c => s"put($reg, $c)", new Put(reg, _)) with UsesRegister {
     override val numInstrs = 1
     override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont, R], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
         p.codeGen |>
@@ -68,8 +70,8 @@ private [parsley] final class Put[S](val reg: Reg[S], _p: =>Parsley[S])
 }
 
 // $COVERAGE-OFF$
-private [parsley] final class Debug[A](_p: =>Parsley[A], name: String, ascii: Boolean, break: Breakpoint)
-    extends Unary[A, A](_p)(identity[String], Debug.empty(name, ascii, break)) {
+private [parsley] final class Debug[A](private [deepembedding] var p: Parsley[A], name: String, ascii: Boolean, break: Breakpoint)
+    extends Unary[A, A](identity[String], new Debug(_, name, ascii, break)) {
     override val numInstrs = 2
     override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont, R], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
         val handler = state.freshLabel()
@@ -86,20 +88,5 @@ private [deepembedding] object Satisfy {
     def unapply(self: Satisfy): Some[Char => Boolean] = Some(self.f)
 }
 private [deepembedding] object Attempt {
-    def empty[A]: Attempt[A] = new Attempt(???)
     def unapply[A](self: Attempt[A]): Some[Parsley[A]] = Some(self.p)
 }
-private [deepembedding] object Look {
-    def empty[A]: Look[A] = new Look(???)
-}
-private [deepembedding] object NotFollowedBy {
-    def empty[A]: NotFollowedBy[A] = new NotFollowedBy(???)
-}
-private [deepembedding] object Put {
-    def empty[S](r: Reg[S]): Put[S] = new Put(r, ???)
-}
-// $COVERAGE-OFF$
-private [deepembedding] object Debug {
-    def empty[A](name: String, ascii: Boolean, break: Breakpoint): Debug[A] = new Debug(???, name, ascii, break)
-}
-// $COVERAGE-ON$

--- a/src/main/scala/parsley/internal/deepembedding/SequenceEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/SequenceEmbedding.scala
@@ -75,8 +75,8 @@ private [parsley] final class <*>[A, B](_pf: =>Parsley[A => B], _px: =>Parsley[A
     }
 }
 
-private [parsley] final class >>=[A, B](_p: =>Parsley[A], private [>>=] val f: A => Parsley[B])
-    extends Unary[A, B](_p)(l => s"($l >>= ?)", >>=.empty(f)) {
+private [parsley] final class >>=[A, B](private [deepembedding] var p: Parsley[A], private [>>=] val f: A => Parsley[B])
+    extends Unary[A, B](l => s"($l >>= ?)", new >>=(_, f)) {
     override val numInstrs = 1
     override def optimise: Parsley[B] = p match {
         // monad law 1: pure x >>= f = f x
@@ -207,8 +207,7 @@ private [deepembedding] object <*> {
     def unapply[A, B](self: <*>[A, B]): Some[(Parsley[A=>B], Parsley[A])] = Some((self.left, self.right))
 }
 private [deepembedding] object >>= {
-    def empty[A, B](f: A => Parsley[B]): >>=[A, B] = new >>=(???, f)
-    def apply[A, B](p: Parsley[A], f: A => Parsley[B]): >>=[A, B] = empty(f).ready(p)
+    def apply[A, B](p: Parsley[A], f: A => Parsley[B]): >>=[A, B] = new >>=(p, f).ready()
     def unapply[A, B](self: >>=[A, B]): Some[(Parsley[A], A => Parsley[B])] = Some((self.p, self.f))
 }
 private [deepembedding] object Seq {

--- a/src/main/scala/parsley/internal/deepembedding/SequenceEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/SequenceEmbedding.scala
@@ -75,8 +75,8 @@ private [parsley] final class <*>[A, B](_pf: =>Parsley[A => B], _px: =>Parsley[A
     }
 }
 
-private [parsley] final class >>=[A, B](private [deepembedding] var p: Parsley[A], private [>>=] val f: A => Parsley[B])
-    extends Unary[A, B](l => s"($l >>= ?)", new >>=(_, f)) {
+private [parsley] final class >>=[A, B](_p: Parsley[A], private [>>=] val f: A => Parsley[B])
+    extends Unary[A, B](_p, l => s"($l >>= ?)", new >>=(_, f)) {
     override val numInstrs = 1
     override def optimise: Parsley[B] = p match {
         // monad law 1: pure x >>= f = f x

--- a/src/main/scala/parsley/internal/deepembedding/SequenceEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/SequenceEmbedding.scala
@@ -10,8 +10,8 @@ import scala.language.higherKinds
 // Core Embedding
 private [parsley] final class Pure[A](private [Pure] val x: A) extends Singleton[A](s"pure($x)", new instructions.Push(x))
 
-private [parsley] final class <*>[A, B](_pf: =>Parsley[A => B], _px: =>Parsley[A])
-    extends Binary[A => B, A, B](_pf, _px, (l, r) => s"($l <*> $r)", new <*>(???, ???)) {
+private [parsley] final class <*>[A, B](_pf: Parsley[A => B], _px: =>Parsley[A])
+    extends Binary[A => B, A, B](_pf, _px, (l, r) => s"($l <*> $r)", new <*>(_, ???)) {
     override val numInstrs = 1
     // TODO: Refactor
     override def optimise: Parsley[B] = (left, right) match {
@@ -43,7 +43,7 @@ private [parsley] final class <*>[A, B](_pf: =>Parsley[A => B], _px: =>Parsley[A
         /* RE-ASSOCIATION LAWS */
         // re-association law 1: (q *> left) <*> right = q *> (left <*> right)
         case (q *> uf, ux) => *>(q, <*>(uf, ux).optimise)
-        case (uf, seq: Seq[_, _]) => seq match {
+        case (uf, seq: Seq[_, _, _, A]) => seq match {
             // re-association law 2: left <*> (right <* q) = (left <*> right) <* q
             case ux <* v => <*(<*>(uf, ux).optimise, v).optimise
             // re-association law 3: p *> pure x = pure x <* p
@@ -103,36 +103,35 @@ private [parsley] final class >>=[A, B](_p: Parsley[A], private [>>=] val f: A =
     }
 }
 
-private [deepembedding] sealed abstract class Seq[A, B](_discard: =>Parsley[A], _result: =>Parsley[B], pretty: String, empty: =>Seq[A, B])
-    extends Binary[A, B, B](_discard, _result, (l, r) => s"($l $pretty $r)", empty) {
-    final def result: Parsley[B] = right
-    final def discard: Parsley[A] = left
-    final def result_=(p: Parsley[B]): Unit = right = p
-    final def discard_=(p: Parsley[A]): Unit = left = p
+private [deepembedding] sealed abstract class Seq[A, B, Dis, Res](_left: Parsley[A], _right: =>Parsley[B], pretty: String, make: Parsley[A]=>Seq[A, B, Dis, Res])
+    extends Binary[A, B, Res](_left, _right, (l, r) => s"($l $pretty $r)", make) {
+    def result: Parsley[Res]
+    def discard: Parsley[Dis]
+    def result_=(p: Parsley[Res]): Unit
+    def discard_=(p: Parsley[Dis]): Unit
     final override val numInstrs = 1
-    def copy[B_ >: B](prev: Parsley[A], next: Parsley[B_]): Seq[A, B_]
-    private def buildResult[R](make: (StringTok, Pure[B]) => Parsley[B])(s: String, r: R, ex1: Option[String], ex2: Option[String]) = {
-        make(new StringTok(s, if (ex1.nonEmpty) ex1 else ex2), new Pure(r.asInstanceOf[B]))
+    private def buildResult[R](make: (StringTok, Pure[Res]) => Parsley[Res])(s: String, r: R, ex1: Option[String], ex2: Option[String]) = {
+        make(new StringTok(s, if (ex1.nonEmpty) ex1 else ex2), new Pure(r.asInstanceOf[Res]))
     }
-    private def optimiseStringResult(combine: (String, String) => String, make: (StringTok, Pure[B]) => Parsley[B])
-                                    (s: String, ex: Option[String]): Parsley[B] = result match {
+    private def optimiseStringResult(combine: (String, String) => String, make: (StringTok, Pure[Res]) => Parsley[Res])
+                                    (s: String, ex: Option[String]): Parsley[Res] = result match {
         case ct@CharTok(c) => buildResult(make)(combine(s, c.toString), c, ex, ct.expected)
         case st@StringTok(t) => buildResult(make)(combine(s, t), t, ex, st.expected)
     }
     final protected def optimiseSeq(combine: (String, String) => String,
-                                    make: (StringTok, Pure[B]) => Parsley[B]): PartialFunction[Parsley[A], Parsley[B]] = {
+                                    make: (StringTok, Pure[Res]) => Parsley[Res]): PartialFunction[Parsley[Dis], Parsley[Res]] = {
         // pure _ *> p = p = p <* pure _
         case _: Pure[_] => result
         // p *> pure _ *> q = p *> q, p <* (q *> pure _) = p <* q
         case u *> (_: Pure[_]) =>
-            discard = u.asInstanceOf[Parsley[A]]
+            discard = u.asInstanceOf[Parsley[Dis]]
             optimise
         case ct@CharTok(c) if result.isInstanceOf[CharTok] || result.isInstanceOf[StringTok] => optimiseStringResult(combine, make)(c.toString, ct.expected)
         case st@StringTok(s) if result.isInstanceOf[CharTok] || result.isInstanceOf[StringTok] => optimiseStringResult(combine, make)(s, st.expected)
     }
     final protected def codeGenSeq[Cont[_, +_], R](default: =>Cont[R, Unit])(implicit ops: ContOps[Cont, R], instrs: InstrBuffer,
                                                                                       state: CodeGenState): Cont[R, Unit] = (result, discard) match {
-        case (Pure(x), ct@CharTok(c)) => ContOps.result(instrs += instructions.CharTokFastPerform[Char, B](c, _ => x, ct.expected))
+        case (Pure(x), ct@CharTok(c)) => ContOps.result(instrs += instructions.CharTokFastPerform[Char, Res](c, _ => x, ct.expected))
         case (Pure(x), st@StringTok(s)) => ContOps.result(instrs += instructions.StringTokFastPerform(s, _ => x, st.expected))
         case (Pure(x), st@Satisfy(f)) => ContOps.result(instrs += new instructions.SatisfyExchange(f, x, st.expected))
         case (Pure(x), v) =>
@@ -141,7 +140,11 @@ private [deepembedding] sealed abstract class Seq[A, B](_discard: =>Parsley[A], 
         case _ => default
     }
 }
-private [parsley] final class *>[A, B](_p: =>Parsley[A], _q: =>Parsley[B]) extends Seq[A, B](_p, _q, "*>", new *>(???, ???)) {
+private [parsley] final class *>[A, B](_p: Parsley[A], _q: =>Parsley[B]) extends Seq[A, B, A, B](_p, _q, "*>", new *>(_, ???)) {
+    override def result: Parsley[B] = right
+    override def discard: Parsley[A] = left
+    override def result_=(p: Parsley[B]): Unit = right = p
+    override def discard_=(p: Parsley[A]): Unit = left = p
     def optimiseSeq: Option[Parsley[B]] = optimiseSeq(_ + _, (str, res) => {
         discard = str.asInstanceOf[Parsley[A]]
         result = res
@@ -168,9 +171,12 @@ private [parsley] final class *>[A, B](_p: =>Parsley[A], _q: =>Parsley[B]) exten
             result.codeGen
         }
     }
-    override def copy[B_ >: B](prev: Parsley[A], next: Parsley[B_]): A *> B_ = *>(prev, next)
 }
-private [parsley] final class <*[A, B](_p: =>Parsley[A], _q: =>Parsley[B]) extends Seq[B, A](_q, _p, "<*", new <*(???, ???)) {
+private [parsley] final class <*[A, B](_p: Parsley[A], _q: =>Parsley[B]) extends Seq[A, B, B, A](_p, _q, "<*", new <*(_, ???)) {
+    override def result: Parsley[A] = left
+    override def discard: Parsley[B] = right
+    override def result_=(p: Parsley[A]): Unit = left = p
+    override def discard_=(p: Parsley[B]): Unit = right = p
     def optimiseSeq: Option[Parsley[A]] = optimiseSeq((t, s) => s + t, *>.apply).lift(discard)
     @tailrec override def optimise: Parsley[A] =  optimiseSeq match {
         case Some(p) => p
@@ -196,14 +202,13 @@ private [parsley] final class <*[A, B](_p: =>Parsley[A], _q: =>Parsley[B]) exten
         discard.codeGen |>
         (instrs += instructions.Pop)
     }
-    override def copy[A_ >: A](prev: Parsley[B], next: Parsley[A_]): <*[A_, B] = <*(next, prev)
 }
 
 private [deepembedding] object Pure {
     def unapply[A](self: Pure[A]): Some[A] = Some(self.x)
 }
 private [deepembedding] object <*> {
-    def apply[A, B](left: Parsley[A=>B], right: Parsley[A]): <*>[A, B] = new <*>(???, ???).ready(left, right)
+    def apply[A, B](left: Parsley[A=>B], right: Parsley[A]): <*>[A, B] = new <*>[A, B](left, ???).ready(right)
     def unapply[A, B](self: <*>[A, B]): Some[(Parsley[A=>B], Parsley[A])] = Some((self.left, self.right))
 }
 private [deepembedding] object >>= {
@@ -211,13 +216,13 @@ private [deepembedding] object >>= {
     def unapply[A, B](self: >>=[A, B]): Some[(Parsley[A], A => Parsley[B])] = Some((self.p, self.f))
 }
 private [deepembedding] object Seq {
-    def unapply[A, B](self: Seq[A, B]): Some[(Parsley[A], Parsley[B])] = Some((self.discard, self.result))
+    def unapply[A, B, Dis, Res](self: Seq[A, B, Dis, Res]): Some[(Parsley[Dis], Parsley[Res])] = Some((self.discard, self.result))
 }
 private [deepembedding] object *> {
-    def apply[A, B](left: Parsley[A], right: Parsley[B]): A *> B = new *>(???, ???).ready(left, right)
-    def unapply[A, B](self: A *> B): Some[(Parsley[A], Parsley[B])] = Some((self.left, self.right))
+    def apply[A, B](left: Parsley[A], right: Parsley[B]): A *> B = new *>(left, ???).ready(right)
+    def unapply[A, B](self: A *> B): Some[(Parsley[A], Parsley[B])] = Some((self.discard, self.result))
 }
 private [deepembedding] object <* {
-    def apply[A, B](left: Parsley[A], right: Parsley[B]): A <* B = new <*(???, ???).ready(right, left)
+    def apply[A, B](left: Parsley[A], right: Parsley[B]): A <* B = new <*(left, ???).ready(right)
     def unapply[A, B](self: A <* B): Some[(Parsley[A], Parsley[B])] = Some((self.result, self.discard))
 }

--- a/src/main/scala/parsley/lift.scala
+++ b/src/main/scala/parsley/lift.scala
@@ -12,114 +12,114 @@ import parsley.internal.deepembedding
 object lift {
     def lift1[T1, R]
         (f: T1 => R,
-         p1: =>Parsley[T1]): Parsley[R] =
+         p1: Parsley[T1]): Parsley[R] =
         p1.map(f)
     def lift2[T1, T2, R]
         (f: (T1, T2) => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2]): Parsley[R] =
+         p1: Parsley[T1], p2: =>Parsley[T2]): Parsley[R] =
         new Parsley(new deepembedding.Lift2(f, p1.internal, p2.internal))
     def lift3[T1, T2, T3, R]
         (f: (T1, T2, T3) => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3]): Parsley[R] =
+         p1: Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3]): Parsley[R] =
         new Parsley(new deepembedding.Lift3(f, p1.internal, p2.internal, p3.internal))
     // $COVERAGE-OFF$
     def lift4[T1, T2, T3, T4, R]
         (f: (T1, T2, T3, T4) => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4]): Parsley[R] =
+         p1: Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4]): Parsley[R] =
         lift4(f.curried, p1, p2, p3, p4)
     def lift5[T1, T2, T3, T4, T5, R]
         (f: (T1, T2, T3, T4, T5) => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5]): Parsley[R] =
+         p1: Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5]): Parsley[R] =
         lift5(f.curried, p1, p2, p3, p4, p5)
     def lift6[T1, T2, T3, T4, T5, T6, R]
         (f: (T1, T2, T3, T4, T5, T6) => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6]): Parsley[R] =
+         p1: Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6]): Parsley[R] =
         lift6(f.curried, p1, p2, p3, p4, p5, p6)
     def lift7[T1, T2, T3, T4, T5, T6, T7, R]
         (f: (T1, T2, T3, T4, T5, T6, T7) => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7]): Parsley[R] =
+         p1: Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7]): Parsley[R] =
         lift7(f.curried, p1, p2, p3, p4, p5, p6, p7)
     def lift8[T1, T2, T3, T4, T5, T6, T7, T8, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8) => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7],
          p8: =>Parsley[T8]): Parsley[R] =
         lift8(f.curried, p1, p2, p3, p4, p5, p6, p7, p8)
     def lift9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9) => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
          p9: =>Parsley[T9]): Parsley[R] =
         lift9(f.curried, p1, p2, p3, p4, p5, p6, p7, p8, p9)
     def lift10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
          p9: =>Parsley[T9], p10: =>Parsley[T10]): Parsley[R] =
         lift10(f.curried, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10)
     def lift11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
          p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11]): Parsley[R] =
         lift11(f.curried, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11)
     def lift12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
          p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12]): Parsley[R] =
         lift12(f.curried, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12)
     def lift13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
          p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13]): Parsley[R] =
         lift13(f.curried, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13)
     def lift14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
          p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14]): Parsley[R] =
         lift14(f.curried, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14)
     def lift15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
          p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14],
          p15: =>Parsley[T15]): Parsley[R] =
         lift15(f.curried, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15)
     def lift16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
          p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15],
          p16: =>Parsley[T16]):
         Parsley[R] = lift16(f.curried, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16)
     def lift17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
          p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15],
          p16: =>Parsley[T16], p17: =>Parsley[T17]): Parsley[R] =
         lift17(f.curried, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17)
     def lift18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
          p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15],
          p16: =>Parsley[T16], p17: =>Parsley[T17], p18: =>Parsley[T18]): Parsley[R] =
         lift18(f.curried, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18)
     def lift19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
          p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15],
          p16: =>Parsley[T16], p17: =>Parsley[T17], p18: =>Parsley[T18], p19: =>Parsley[T19]): Parsley[R] =
         lift19(f.curried, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19)
     def lift20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
          p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15],
          p16: =>Parsley[T16], p17: =>Parsley[T17], p18: =>Parsley[T18], p19: =>Parsley[T19], p20: =>Parsley[T20]): Parsley[R] =
         lift20(f.curried, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20)
     def lift21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21) => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
          p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15],
          p16: =>Parsley[T16], p17: =>Parsley[T17], p18: =>Parsley[T18], p19: =>Parsley[T19], p20: =>Parsley[T20], p21: =>Parsley[T21]): Parsley[R] =
         lift21(f.curried, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21)
     // $COVERAGE-ON$
     def lift22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R]
         (f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22) => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
          p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15],
          p16: =>Parsley[T16], p17: =>Parsley[T17], p18: =>Parsley[T18], p19: =>Parsley[T19], p20: =>Parsley[T20], p21: =>Parsley[T21],
          p22: =>Parsley[T22]): Parsley[R] =
@@ -128,100 +128,100 @@ object lift {
     // INTERNAL HELPERS
     @inline private def lift4[T1, T2, T3, T4, R]
         (f: T1 => T2 => T3 => T4 => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4]): Parsley[R] =
+         p1: Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4]): Parsley[R] =
         lift3((x1: T1, x2: T2, x3: T3) => f(x1)(x2)(x3), p1, p2, p3) <*> p4
     @inline private def lift5[T1, T2, T3, T4, T5, R]
         (f: T1 => T2 => T3 => T4 => T5 => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5]): Parsley[R] =
+         p1: Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5]): Parsley[R] =
         lift4(f, p1, p2, p3, p4) <*> p5
     @inline private def lift6[T1, T2, T3, T4, T5, T6, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6]): Parsley[R] =
+         p1: Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6]): Parsley[R] =
         lift5(f, p1, p2, p3, p4, p5) <*> p6
     @inline private def lift7[T1, T2, T3, T4, T5, T6, T7, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7]): Parsley[R] =
+         p1: Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7]): Parsley[R] =
         lift6(f, p1, p2, p3, p4, p5, p6) <*> p7
     @inline private def lift8[T1, T2, T3, T4, T5, T6, T7, T8, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7],
          p8: =>Parsley[T8]): Parsley[R] =
         lift7(f, p1, p2, p3, p4, p5, p6, p7) <*> p8
     @inline private def lift9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => T9 => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
          p9: =>Parsley[T9]): Parsley[R] =
         lift8(f, p1, p2, p3, p4, p5, p6, p7, p8) <*> p9
     @inline private def lift10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => T9 => T10 => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
          p9: =>Parsley[T9], p10: =>Parsley[T10]): Parsley[R] =
         lift9(f, p1, p2, p3, p4, p5, p6, p7, p8, p9) <*> p10
     @inline private def lift11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => T9 => T10 => T11 => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
          p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11]): Parsley[R] =
         lift10(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10) <*> p11
     @inline private def lift12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => T9 => T10 => T11 => T12 => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
          p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12]): Parsley[R] =
         lift11(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11) <*> p12
     @inline private def lift13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => T9 => T10 => T11 => T12 => T13 => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
          p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13]): Parsley[R] =
         lift12(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12) <*> p13
     @inline private def lift14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => T9 => T10 => T11 => T12 => T13 => T14 => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
          p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14]): Parsley[R] =
         lift13(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13) <*> p14
     @inline private def lift15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => T9 => T10 => T11 => T12 => T13 => T14 => T15 => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
          p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14],
          p15: =>Parsley[T15]): Parsley[R] =
         lift14(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14) <*> p15
     @inline private def lift16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => T9 => T10 => T11 => T12 => T13 => T14 => T15 => T16 => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
          p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15],
          p16: =>Parsley[T16]):
         Parsley[R] = lift15(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15) <*> p16
     @inline private def lift17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => T9 => T10 => T11 => T12 => T13 => T14 => T15 => T16 => T17 => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
          p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15],
          p16: =>Parsley[T16], p17: =>Parsley[T17]): Parsley[R] =
         lift16(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16) <*> p17
     @inline private def lift18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => T9 => T10 => T11 => T12 => T13 => T14 => T15 => T16 => T17 => T18 => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
          p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15],
          p16: =>Parsley[T16], p17: =>Parsley[T17], p18: =>Parsley[T18]): Parsley[R] =
         lift17(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17) <*> p18
     @inline private def lift19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => T9 => T10 => T11 => T12 => T13 => T14 => T15 => T16 => T17 => T18 => T19 => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
          p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15],
          p16: =>Parsley[T16], p17: =>Parsley[T17], p18: =>Parsley[T18], p19: =>Parsley[T19]): Parsley[R] =
         lift18(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18) <*> p19
     @inline private def lift20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => T9 => T10 => T11 => T12 => T13 => T14 => T15 => T16 => T17 => T18 => T19 => T20 => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
          p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15],
          p16: =>Parsley[T16], p17: =>Parsley[T17], p18: =>Parsley[T18], p19: =>Parsley[T19], p20: =>Parsley[T20]): Parsley[R] =
         lift19(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19) <*> p20
     @inline private def lift21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => T9 => T10 => T11 => T12 => T13 => T14 => T15 => T16 => T17 => T18 => T19 => T20 => T21 => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
          p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15],
          p16: =>Parsley[T16], p17: =>Parsley[T17], p18: =>Parsley[T18], p19: =>Parsley[T19], p20: =>Parsley[T20], p21: =>Parsley[T21]): Parsley[R] =
         lift20(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20) <*> p21
     @inline private def lift22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R]
         (f: T1 => T2 => T3 => T4 => T5 => T6 => T7 => T8 => T9 => T10 => T11 => T12 => T13 => T14 => T15 => T16 => T17 => T18 => T19 => T20 => T21 => T22 => R,
-         p1: =>Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
+         p1:   Parsley[T1], p2: =>Parsley[T2], p3: =>Parsley[T3], p4: =>Parsley[T4], p5: =>Parsley[T5], p6: =>Parsley[T6], p7: =>Parsley[T7], p8: =>Parsley[T8],
          p9: =>Parsley[T9], p10: =>Parsley[T10], p11: =>Parsley[T11], p12: =>Parsley[T12], p13: =>Parsley[T13], p14: =>Parsley[T14], p15: =>Parsley[T15],
          p16: =>Parsley[T16], p17: =>Parsley[T17], p18: =>Parsley[T18], p19: =>Parsley[T19], p20: =>Parsley[T20], p21: =>Parsley[T21],
          p22: =>Parsley[T22]): Parsley[R] =

--- a/src/main/scala/parsley/registers.scala
+++ b/src/main/scala/parsley/registers.scala
@@ -59,14 +59,14 @@ object registers {
           * @param p The parser to derive the value from
           * @since 3.2.0
           */
-        def put(p: =>Parsley[A]): Parsley[Unit] = new Parsley(new deepembedding.Put(this, p.internal))
+        def put(p: Parsley[A]): Parsley[Unit] = new Parsley(new deepembedding.Put(this, p.internal))
         /**
           * Places the result of running `p` into this register.
           * @param p The parser to derive the value from
           * @param f A function which adapts the result of `p` so that it can fit in `r`
           * @since 3.0.0
           */
-        def puts[B](p: =>Parsley[B], f: B => A): Parsley[Unit] = this.put(p.map(f))
+        def puts[B](p: Parsley[B], f: B => A): Parsley[Unit] = this.put(p.map(f))
         /**
           * Modifies the value contained in this register using function `f`.
           * @param f The function used to modify the register
@@ -79,7 +79,7 @@ object registers {
           * @param f The function used to modify the register
           * @since 3.2.0
           */
-        def modify(pf: =>Parsley[A => A]): Parsley[Unit] = this.put(this.gets(pf))
+        def modify(pf: Parsley[A => A]): Parsley[Unit] = this.put(this.gets(pf))
         /**
           * For the duration of parser `p` the state stored in this register is instead set to `x`. The change is undone
           * after `p` has finished.
@@ -88,7 +88,7 @@ object registers {
           * @return The parser that performs `p` with the modified state
           * @since 3.2.0
           */
-        def local[B](x: A)(p: =>Parsley[B]): Parsley[B] = this.local(pure(x))(p)
+        def local[B](x: A)(p: Parsley[B]): Parsley[B] = this.local(pure(x))(p)
         /**
           * For the duration of parser `q` the state stored in this register is instead set to the return value of `p`. The
           * change is undone after `q` has finished.
@@ -97,7 +97,7 @@ object registers {
           * @return The parser that performs `q` with the modified state
           * @since 3.2.0
           */
-        def local[B](p: =>Parsley[A])(q: =>Parsley[B]): Parsley[B] = new Parsley(new deepembedding.Local(this, p.internal, q.internal))
+        def local[B](p: Parsley[A])(q: =>Parsley[B]): Parsley[B] = new Parsley(new deepembedding.Local(this, p.internal, q.internal))
         /**
           * For the duration of parser `p` the state stored in this register is instead modified with `f`. The change is undone
           * after `p` has finished.
@@ -106,7 +106,7 @@ object registers {
           * @return The parser that performs `p` with the modified state
           * @since 3.2.0
           */
-        def local[B](f: A => A)(p: =>Parsley[B]): Parsley[B] = this.local(this.gets(f))(p)
+        def local[B](f: A => A)(p: Parsley[B]): Parsley[B] = this.local(this.gets(f))(p)
 
         /** `rollback(reg, p)` will perform `p`, but if it fails without consuming input, any changes to this register will
           * be reverted.
@@ -141,7 +141,7 @@ object registers {
         def make[A]: Reg[A] = new Reg
     }
 
-    implicit final class RegisterMethods[P, A](p: =>P)(implicit con: P => Parsley[A]) {
+    implicit final class RegisterMethods[P, A](p: P)(implicit con: P => Parsley[A]) {
         /*def fillReg[B](body: Reg[A] => Parsley[B]): Parsley[B] = {
             val reg = Reg.make[A]
             reg.put(con(p)) *> body(reg)
@@ -177,7 +177,7 @@ object registers {
       * @param body The body of the loop performed each iteration
       * @return ()
       */
-    /*def forP[A](init: =>Parsley[A], cond: =>Parsley[A => Boolean], step: =>Parsley[A => A], body: =>Parsley[_]): Parsley[Unit] =
+    /*def forP[A](init: Parsley[A], cond: =>Parsley[A => Boolean], step: =>Parsley[A => A], body: =>Parsley[_]): Parsley[Unit] =
     {
         val reg = Reg.make[A]
         val _cond = reg.gets(cond)

--- a/src/main/scala/parsley/token/Lexer.scala
+++ b/src/main/scala/parsley/token/Lexer.scala
@@ -1,13 +1,13 @@
 package parsley.token
 
-import parsley.character.{digit, hexDigit, octDigit, satisfy}
+import parsley.character.{digit, hexDigit, octDigit, satisfy, char, string}
 import parsley.combinator.{sepBy, sepBy1, between, many, skipMany, some, skipSome}
 import parsley.lift.lift2
 import parsley.internal.deepembedding.Sign.{DoubleType, IntType, SignType}
-import parsley.Parsley, Parsley.{void, unit, attempt, pure, empty, notFollowedBy, LazyParsley}
+import parsley.Parsley, Parsley.{void, unit, attempt, pure, empty, notFollowedBy}
 import parsley.errors.combinator.{fail, ErrorMethods}
 import parsley.token.TokenSet
-import parsley.implicits.character.{charLift, stringLift}
+import parsley.implicits.character.{charLift}
 import parsley.internal.deepembedding
 
 import scala.language.implicitConversions
@@ -58,7 +58,7 @@ class Lexer(lang: LanguageDef)
     private def caseString(name: String): Parsley[String] =
     {
         def caseChar(c: Char): Parsley[Char] = if (c.isLetter) c.toLower <|> c.toUpper else c
-        if (lang.caseSensitive) name
+        if (lang.caseSensitive) string(name)
         else name.foldRight(pure(name))((c, p) => caseChar(c) *> p).label(name)
     }
     private def isReservedName(name: String): Boolean = theReservedNames.contains(if (lang.caseSensitive) name else name.toLowerCase)
@@ -97,7 +97,7 @@ class Lexer(lang: LanguageDef)
         case BitSetImpl(letter) => new Parsley(new deepembedding.Specific("operator", name, letter, true))
         case Predicate(letter) => new Parsley(new deepembedding.Specific("operator", name, letter, true))
         case NotRequired => new Parsley(new deepembedding.Specific("operator", name, _ => false, true))
-        case _ => attempt(name *> notFollowedBy(opLetter).label("end of " + name))
+        case _ => attempt(string(name) *> notFollowedBy(opLetter).label("end of " + name))
     }
 
     /**The lexeme parser `maxOp(name)` parses the symbol `name`, but also checks that the `name`
@@ -229,9 +229,9 @@ class Lexer(lang: LanguageDef)
 
     // White space & symbols
     /**Lexeme parser `symbol(s)` parses `string(s)` and skips trailing white space.*/
-    def symbol(name: String): Parsley[String] = lexeme[String](name)
+    def symbol(name: String): Parsley[String] = lexeme(string(name))
     /**Lexeme parser `symbol(c)` parses `char(c)` and skips trailing white space.*/
-    def symbol(name: Char): Parsley[Char] = lexeme[Char](name)
+    def symbol(name: Char): Parsley[Char] = lexeme(char(name))
 
     /**Like `symbol`, but treats it as a single token using `attempt`. Only useful for
      * strings, since characters are already single token.*/

--- a/src/main/scala/parsley/token/Lexer.scala
+++ b/src/main/scala/parsley/token/Lexer.scala
@@ -6,7 +6,6 @@ import parsley.lift.lift2
 import parsley.internal.deepembedding.Sign.{DoubleType, IntType, SignType}
 import parsley.Parsley, Parsley.{void, unit, attempt, pure, empty, notFollowedBy}
 import parsley.errors.combinator.{fail, ErrorMethods}
-import parsley.token.TokenSet
 import parsley.implicits.character.{charLift}
 import parsley.internal.deepembedding
 

--- a/src/test/scala/parsley/CoreTests.scala
+++ b/src/test/scala/parsley/CoreTests.scala
@@ -321,7 +321,7 @@ class CoreTests extends ParsleyTest {
     }
 
     "stack overflows" should "not be thrown by recursive parsers" in {
-        lazy val p: Parsley[Int] = p.map((x: Int) => x+1)
+        lazy val p: Parsley[Int] = 'b' *> p
         def many_[A](p: Parsley[A]): Parsley[List[A]] = {
             lazy val manyp: Parsley[List[A]] = (p <::> manyp) </> Nil
             manyp


### PR DESCRIPTION
Parsley has always been lazy in all combinators, including receivers. This allows for recursive parsers to be defined. However, the receivers of all combinators, as well as leading edges for all function combinators can be made strict: if they are recursive in the left-most position, this is left-recursion, which is illegal. This PR makes left-recursion into undefined behaviour, and Parsley no longer guards against it so readily. This does affect the order in which parsers must be with respect to forward-referencing, however. It should provide a performance boost for cold parsers, simplifies the user API, and allows for better implicit conversions.