### PR TITLE
Added range-based char class operations `oneOf` and `noneOf`

### DIFF
--- a/src/main/scala/parsley/character.scala
+++ b/src/main/scala/parsley/character.scala
@@ -8,6 +8,7 @@ import parsley.errors.combinator.ErrorMethods
 
 import scala.annotation.switch
 import scala.language.implicitConversions
+import scala.collection.immutable.NumericRange
 
 /** This module contains many parsers to do with reading one or more characters. Almost every parser will need something from this module.
   * @since 2.2.0
@@ -46,6 +47,14 @@ object character
     /**`oneOf(cs)` succeeds if the current character is in the supplied sequence of characters `cs`.
       * Returns the parsed character. See also `satisfy`.*/
     def oneOf(cs: Char*): Parsley[Char] = oneOf(cs.toSet)
+
+    /**`oneOf(cs)` succeeds if the current character is in the supplied sequence of characters `cs`.
+      * Returns the parsed character. See also `satisfy`.*/
+    def oneOf(cs: NumericRange[Char]): Parsley[Char] = oneOf(cs.toSet)
+
+    /**As the dual of `oneOf`, `noneOf(cs)` succeeds if the current character is not in the supplied
+      * sequence of characters `cs`. Returns the parsed character.*/
+    def noneOf(cs: NumericRange[Char]): Parsley[Char] = noneOf(cs.toSet)
 
     /**As the dual of `oneOf`, `noneOf(cs)` succeeds if the current character is not in the supplied
       * sequence of characters `cs`. Returns the parsed character.*/

--- a/src/test/scala/parsley/CharTests.scala
+++ b/src/test/scala/parsley/CharTests.scala
@@ -121,17 +121,27 @@ class CharTests extends ParsleyTest {
 
     "oneOf" should "match any of the characters provided" in {
         val p = character.oneOf('a', 'b', 'c')
+        val q = character.oneOf('a' to 'c')
         p.parse("a") should not be a [Failure[_]]
         p.parse("b") should not be a [Failure[_]]
         p.parse("c") should not be a [Failure[_]]
         p.parse("d") shouldBe a [Failure[_]]
+        q.parse("a") should not be a [Failure[_]]
+        q.parse("b") should not be a [Failure[_]]
+        q.parse("c") should not be a [Failure[_]]
+        q.parse("d") shouldBe a [Failure[_]]
     }
 
     "noneOf" should "match none of the characters provided" in {
         val p = character.noneOf('a', 'b', 'c')
+        val q = character.noneOf('a' to 'c')
         p.parse("a") shouldBe a [Failure[_]]
         p.parse("b") shouldBe a [Failure[_]]
         p.parse("c") shouldBe a [Failure[_]]
         p.parse("d") should not be a [Failure[_]]
+        q.parse("a") shouldBe a [Failure[_]]
+        q.parse("b") shouldBe a [Failure[_]]
+        q.parse("c") shouldBe a [Failure[_]]
+        q.parse("d") should not be a [Failure[_]]
     }
 }


### PR DESCRIPTION
It would be nice to be able to write `oneOf('a' to 'z')`... now you can!