### PR TITLE
Meaningful `oneOf` and `noneOf` error labels

### DIFF
--- a/src/main/scala/parsley/errors/DefaultErrorBuilder.scala
+++ b/src/main/scala/parsley/errors/DefaultErrorBuilder.scala
@@ -1,7 +1,5 @@
 package parsley.errors
 
-import scala.util.matching.Regex
-
 // Turn coverage off, because the tests have their own error builder
 // We might want to test this on its own though
 // $COVERAGE-OFF$
@@ -58,13 +56,8 @@ class DefaultErrorBuilder extends ErrorBuilder[String] with revisions.Revision2 
 
     type ExpectedItems = Option[String]
     type Messages = Seq[Message]
-    override def combineExpectedItems(alts: Set[Item]): ExpectedItems = alts.toList.sorted.reverse.filter(_.nonEmpty) match {
-        case Nil => None
-        case List(alt) => Some(alt)
-        case List(alt1, alt2) => Some(s"$alt2 or $alt1")
-        // If the result would contains "," then it's probably nicer to preserve any potential grouping using ";"
-        case any@(alt::alts) if any.exists(_.contains(",")) => Some(s"${alts.reverse.mkString("; ")}; or $alt")
-        case alt::alts => Some(s"${alts.reverse.mkString(", ")}, or $alt")
+    override def combineExpectedItems(alts: Set[Item]): ExpectedItems = {
+        helpers.combineAsList(alts.toList.filter(_.nonEmpty))
     }
     override def combineMessages(alts: Seq[Message]): Messages = alts.filter(_.nonEmpty)
 
@@ -92,18 +85,10 @@ class DefaultErrorBuilder extends ErrorBuilder[String] with revisions.Revision2 
     type Raw = String
     type Named = String
     type EndOfInput = String
-    override def raw(item: String): Raw = item match {
-        case "\n"            => "newline"
-        case "\t"            => "tab"
-        case " "             => "space"
-        case Unprintable(up) => f"unprintable character (\\u${up.head.toInt}%04X)"
-        // Do we want this only in unexpecteds?
-        case cs              => "\"" + cs.takeWhile(c => c != '\n' && c != ' ') + "\""
-    }
+    override def raw(item: String): Raw = helpers.renderRawString(item)
     override def named(item: String): Named = item
     override val endOfInput: EndOfInput = "end of input"
 
-    private val Unprintable: Regex = "(\\p{C})".r
     private val Unknown = "unknown parse error"
 }
 // $COVERAGE-ON$

--- a/src/main/scala/parsley/errors/helpers.scala
+++ b/src/main/scala/parsley/errors/helpers.scala
@@ -1,0 +1,25 @@
+package parsley.errors
+
+import scala.util.matching.Regex
+
+private [parsley] object helpers {
+    def renderRawString(s: String): String = s match {
+        case "\n"            => "newline"
+        case "\t"            => "tab"
+        case " "             => "space"
+        case Unprintable(up) => f"unprintable character (\\u${up.head.toInt}%04X)"
+        // Do we want this only in unexpecteds?
+        case cs              => "\"" + cs.takeWhile(c => c != '\n' && c != ' ') + "\""
+    }
+
+    def combineAsList(elems: List[String]): Option[String] = elems.sorted.reverse match {
+        case Nil => None
+        case List(alt) => Some(alt)
+        case List(alt1, alt2) => Some(s"$alt2 or $alt1")
+        // If the result would contains "," then it's probably nicer to preserve any potential grouping using ";"
+        case any@(alt::alts) if any.exists(_.contains(",")) => Some(s"${alts.reverse.mkString("; ")}; or $alt")
+        case alt::alts => Some(s"${alts.reverse.mkString(", ")}, or $alt")
+    }
+
+    private val Unprintable: Regex = "(\\p{C})".r
+}

--- a/src/main/scala/parsley/internal/deepembedding/ErrorEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/ErrorEmbedding.scala
@@ -15,6 +15,7 @@ private [parsley] final class ErrorLabel[A](_p: =>Parsley[A], private [ErrorLabe
         case ct@CharTok(c) if !ct.expected.contains("") => new CharTok(c, Some(label)).asInstanceOf[Parsley[A]]
         case st@StringTok(s) if !st.expected.contains("") => new StringTok(s, Some(label)).asInstanceOf[Parsley[A]]
         case sat@Satisfy(f) if !sat.expected.contains("") => new Satisfy(f, Some(label)).asInstanceOf[Parsley[A]]
+        // TOOD: The hide property is required to be checked, but there is no test for it
         case ErrorLabel(p, label2) if label2 != "" => ErrorLabel(p, label)
         case _ => this
     }

--- a/src/main/scala/parsley/internal/machine/instructions/TokenInstrs.scala
+++ b/src/main/scala/parsley/internal/machine/instructions/TokenInstrs.scala
@@ -78,7 +78,8 @@ private [instructions] abstract class WhiteSpaceLike(start: String, end: String,
     }
 
     private final val impl = {
-        if (!lineAllowed) multisOnly(_)
+        if (!lineAllowed && !multiAllowed) spaces(_)
+        else if (!lineAllowed) multisOnly(_)
         else if (!multiAllowed) singlesOnly(_)
         else singlesAndMultis(_)
     }

--- a/src/test/scala/parsley/ErrorTests.scala
+++ b/src/test/scala/parsley/ErrorTests.scala
@@ -3,7 +3,7 @@ package parsley
 import parsley.combinator.{eof, optional}
 import parsley.Parsley._
 import parsley.implicits.character.{charLift, stringLift}
-import parsley.character.{anyChar, digit}
+import parsley.character, character.{anyChar, digit}
 import parsley.unsafe.ErrorLabel
 import parsley.errors.combinator.{fail => pfail, unexpected, amend, entrench, ErrorMethods}
 
@@ -308,5 +308,33 @@ class ErrorTests extends ParsleyTest {
         inside(p.parse("abc")) { case Failure(TestError((1, 3), _)) => }
         inside(p.parse("abcd")) { case Failure(TestError((1, 5), _)) => }
         inside(p.parse("abcde")) { case Failure(TestError((1, 2), _)) => }
+    }
+
+    "oneOf" should "incorporate range notation into the error" in {
+        inside(character.oneOf('0' to '9').parse("a")) { 
+            case Failure(TestError(_, VanillaError(_, expecteds, _))) => 
+                expecteds should contain only Named("one of \"0\" to \"9\"")
+        }
+    }
+
+    it should "incorporate sets of characters into the error" in {
+        inside(character.oneOf(('0' to '9').toSet).parse("a")) { 
+            case Failure(TestError(_, VanillaError(_, expecteds, _))) => 
+                expecteds should contain only Named("one of \"0\", \"1\", \"2\", \"3\", \"4\", \"5\", \"6\", \"7\", \"8\", or \"9\"")
+        }
+    }
+
+    "noneOf" should "incorporate range notation into the error" in {
+        inside(character.noneOf('0' to '9').parse("8")) { 
+            case Failure(TestError(_, VanillaError(_, expecteds, _))) => 
+                expecteds should contain only Named("anything outside of \"0\" to \"9\"")
+        }
+    }
+    
+    it should "incorporate sets of characters into the error" in {
+        inside(character.noneOf(('0' to '9').toSet).parse("8")) { 
+            case Failure(TestError(_, VanillaError(_, expecteds, _))) => 
+                expecteds should contain only Named("anything except \"0\", \"1\", \"2\", \"3\", \"4\", \"5\", \"6\", \"7\", \"8\", or \"9\"")
+        }
     }
 }


### PR DESCRIPTION
Added error labels to `oneOf` and `noneOf` that at least vaguely reflect what's inside. This might get very large, so more appropriate labels _should_ be provided.