### PR TITLE
Improved rendering of whitespace leading unexpected tokens

### DIFF
--- a/src/main/scala/parsley/errors/helpers.scala
+++ b/src/main/scala/parsley/errors/helpers.scala
@@ -7,12 +7,15 @@ import scala.util.matching.Regex
 // $COVERAGE-OFF$
 private [parsley] object helpers {
     def renderRawString(s: String): String = s match {
-        case "\n"            => "newline"
-        case "\t"            => "tab"
-        case " "             => "space"
+        case cs if cs.head.isWhitespace => cs.head match {
+            case c if c.isSpaceChar  => "space"
+            case '\n'                => "newline"
+            case '\t'                => "tab"
+            case _                   => "whitespace character"
+        }
         case Unprintable(up) => f"unprintable character (\\u${up.head.toInt}%04X)"
         // Do we want this only in unexpecteds?
-        case cs              => "\"" + cs.takeWhile(c => c != '\n' && c != ' ') + "\""
+        case cs              => "\"" + cs.takeWhile(!_.isWhitespace) + "\""
     }
 
     def combineAsList(elems: List[String]): Option[String] = elems.sorted.reverse match {


### PR DESCRIPTION
When an unexpected token is larger than size 1, but has a leading space, it gets rendered as `""` by the `DefaultErrorBuilder`, which is not appropriate. Now it will still get rendered as `space`, and the whitespace handling has been made wider.