### PR TITLE
Reshuffled Chains

### DIFF
--- a/src/main/scala/parsley/Parsley.scala
+++ b/src/main/scala/parsley/Parsley.scala
@@ -2,7 +2,7 @@ package parsley
 
 import parsley.internal.machine.Context
 import parsley.internal.deepembedding
-import parsley.expr.chain
+import parsley.expr.{chain, infix}
 import parsley.combinator.{option, some}
 import parsley.Parsley.pure
 import parsley.errors.ErrorBuilder
@@ -271,7 +271,7 @@ final class Parsley[+A] private [parsley] (private [parsley] val internal: deepe
       * @return the result of reducing the results of `p` with `op`
       * @since 2.3.0
       */
-    def reduceLeft[B >: A](op: (B, A) => B): Parsley[B] = chain.left1(this, pure(op))
+    def reduceLeft[B >: A](op: (B, A) => B): Parsley[B] = infix.left1(this, pure(op))
     /**
       * A reduction for a parser: `p.reduceLeftOption(op)` will try executing `p` many times until it fails, combining the
       * results with left-associative application of `op`. If there is no `p`, it returns `None`, otherwise it returns

--- a/src/main/scala/parsley/combinator.scala
+++ b/src/main/scala/parsley/combinator.scala
@@ -118,15 +118,14 @@ object combinator {
 
     /**`manyUntil(p, end)` applies parser `p` zero or more times until the parser `end` succeeds.
       * Returns a list of values returned by `p`. This parser can be used to scan comments.*/
-    def manyUntil[A, B](p: =>Parsley[A], end: Parsley[B]): Parsley[List[A]] = {
+    def manyUntil[A, B](p: Parsley[A], end: Parsley[B]): Parsley[List[A]] = {
         new Parsley(new deepembedding.ManyUntil((end #> deepembedding.ManyUntil.Stop <|> p).internal))
     }
 
     /**`someUntil(p, end)` applies parser `p` one or more times until the parser `end` succeeds.
       * Returns a list of values returned by `p`.*/
-    def someUntil[A, B](p: =>Parsley[A], end: Parsley[B]): Parsley[List[A]] = {
-        lazy val _p = p
-        notFollowedBy(end) *> (_p <::> manyUntil(_p, end))
+    def someUntil[A, B](p: Parsley[A], end: Parsley[B]): Parsley[List[A]] = {
+        notFollowedBy(end) *> (p <::> manyUntil(p, end))
     }
 
     /** `when(p, q)` will first perform `p`, and if the result is `true` will then execute `q` or else return unit.

--- a/src/main/scala/parsley/expr/infix.scala
+++ b/src/main/scala/parsley/expr/infix.scala
@@ -8,29 +8,38 @@ import scala.annotation.implicitNotFound
 /** This module contains the very useful chaining family of combinators,
   * which are mostly used to parse operators and expressions of varying fixities.
   * It is a more low-level API compared with [[precedence]].
-  * @since 2.2.0
+  *
+  * Compared with the combinators in [[chain]], these allow for more freedom in
+  * the type of the values and the operators.
+  *
+  * @since 4.0.0
   */
-object chain {
+object infix {
     /** `right(p, op, x)` parses *zero* or more occurrences of `p`, separated by `op`. Returns a value
       * obtained by a right associative application of all functions return by `op` to the values
       * returned by `p`. If there are no occurrences of `p`, the value `x` is returned.
       * @since 4.0.0
       */
-    def right[A](p: Parsley[A], op: =>Parsley[(A, A) => A], x: A): Parsley[A] = infix.right(p, op, x)
+    def right[A, B, C >: B](p: Parsley[A], op: =>Parsley[(A, C) => B], x: C)
+            (implicit @implicitNotFound("Please provide a wrapper function from ${A} to ${C}") wrap: A => C): Parsley[C] = right1(p, op).getOrElse(x)
 
     /** `left(p, op, x)` parses *zero* or more occurrences of `p`, separated by `op`. Returns a value
       * obtained by a left associative application of all functions returned by `op` to the values
       * returned by `p`. If there are no occurrences of `p`, the value `x` is returned.
       * @since 4.0.0
       */
-    def left[A](p: Parsley[A], op: =>Parsley[(A, A) => A], x: A): Parsley[A] = infix.left(p, op, x)
+    def left[A, B, C >: B](p: Parsley[A], op: =>Parsley[(C, A) => B], x: C)
+            (implicit @implicitNotFound("Please provide a wrapper function from ${A} to ${C}") wrap: A => C): Parsley[C] = left1(p, op).getOrElse(x)
 
     /** `right1(p, op)` parses *one* or more occurrences of `p`, separated by `op`. Returns a value
       * obtained by a right associative application of all functions return by `op` to the values
       * returned by `p`.
       * @since 4.0.0
       */
-    def right1[A](p: Parsley[A], op: =>Parsley[(A, A) => A]): Parsley[A] = infix.right1(p, op)
+    def right1[A, B, C >: B](p: Parsley[A], op: =>Parsley[(A, C) => B])
+            (implicit @implicitNotFound("Please provide a wrapper function from ${A} to ${B}") wrap: A => C): Parsley[C] = {
+        new Parsley(new deepembedding.Chainr(p.internal, op.internal, wrap))
+    }
 
     /** `left1(p, op)` parses *one* or more occurrences of `p`, separated by `op`. Returns a value
       * obtained by a left associative application of all functions return by `op` to the values
@@ -38,33 +47,10 @@ object chain {
       * typically occurs in expression grammars.
       * @since 4.0.0
       */
-    def left1[A](p: Parsley[A], op: =>Parsley[(A, A) => A]): Parsley[A] = infix.left1(p, op)
-
-    /** `prefix(op, p)` parses many prefixed applications of `op` onto a single final result of `p`
-      * @since 2.2.0
-      */
-    def prefix[A](op: Parsley[A => A], p: Parsley[A]): Parsley[A] = new Parsley(new deepembedding.ChainPre(p.internal, op.internal))
-
-    /** `postfix(p, op)` parses one occurrence of `p`, followed by many postfix applications of `op`
-      * that associate to the left.
-      * @since 2.2.0
-      */
-    def postfix[A](p: Parsley[A], op: =>Parsley[A => A]): Parsley[A] = new Parsley(new deepembedding.ChainPost(p.internal, op.internal))
-
-    /** `prefix1(op, p)` parses one or more prefixed applications of `op` onto a single final result of `p`
-      * @since 3.0.0
-      */
-    def prefix1[A, B <: A](op: Parsley[A => B], p: =>Parsley[A]): Parsley[B] = {
-        lazy val op_ = op
-        op_ <*> prefix(op_, p)
-    }
-
-    /** `postfix1(p, op)` parses one occurrence of `p`, followed by one or more postfix applications of `op`
-      * that associate to the left.
-      * @since 3.0.0
-      */
-    def postfix1[A, B <: A](p: Parsley[A], op: =>Parsley[A => B]): Parsley[B] = {
-        lazy val op_ = op
-        postfix(p <**> op_, op_)
+    def left1[A, B, C >: B](p: Parsley[A], op: =>Parsley[(C, A) => B])
+            (implicit @implicitNotFound("Please provide a wrapper function from ${A} to ${B}") wrap: A => C): Parsley[C] = {
+        lazy val _p = p
+        // a sneaky sneaky trick :) If we know that A =:= B because refl was provided, then we can skip the wrapping
+        new Parsley(new deepembedding.Chainl(parsley.XCompat.applyWrap(wrap)(_p).internal, _p.internal, op.internal))
     }
 }

--- a/src/main/scala/parsley/expr/mixed.scala
+++ b/src/main/scala/parsley/expr/mixed.scala
@@ -1,0 +1,45 @@
+package parsley.expr
+
+import parsley.Parsley, Parsley._
+import parsley.internal.deepembedding
+import parsley.lift.lift4
+import parsley.implicits.zipped.Zipped2
+
+import scala.annotation.implicitNotFound
+
+/** This module contains specialist combinators for mixing unary and binary operators
+  * on the same level. This is only sensible when mixing infix-left and postfix
+  * or infix-right and prefix.
+  *
+  * @since 4.0.0
+  */
+object mixed {
+    private def flip[A, B, C](f: (A, B) => C, y: B)(x: A) = f(x, y)
+
+    /**
+      * @since 4.0.0
+      */
+    def right1[A, B](p: Parsley[A], uop: Parsley[B => B], bop: =>Parsley[(A, B) => B])
+                    (implicit @implicitNotFound("Please provide a wrapper function from ${A} to ${B}") wrap: A => B) = {
+        lazy val rest: Parsley[B] = (
+                uop <*> rest
+            <|> (p <**> ((bop, rest).zipped(flip(_, _) _) <|> pure(wrap)))
+        )
+        rest
+    }
+
+    /**
+      * @since 4.0.0
+      */
+    def left1[A, B](p: =>Parsley[A], uop: =>Parsley[B => B], bop: =>Parsley[(B, A) => B])
+                   (implicit @implicitNotFound("Please provide a wrapper function from ${A} to ${B}") wrap: A => B) = {
+        lazy val _p = p
+        lazy val _uop = uop
+        lazy val uops = _uop.foldLeft(identity[B] _)(_ compose _)
+        lazy val rest: Parsley[B => B] = (
+                lift4((b: (B, A) => B, y: A, u: B => B, r: B => B) => (x: B) => r(u(b(x, y))), bop, _p, uops, rest)
+            <|> pure(identity[B] _)
+        )
+        chain.postfix(_p.map(wrap), _uop) <**> rest
+    }
+}

--- a/src/main/scala/parsley/expr/precedence.scala
+++ b/src/main/scala/parsley/expr/precedence.scala
@@ -12,8 +12,8 @@ object precedence {
     private def convertOperators[A, B](atom: Parsley[A], opList: Ops[A, B]): Parsley[B] = {
         implicit val wrap: A => B = opList.wrap
         opList match {
-            case Lefts(ops @ _*) => chain.left1(atom, choice(ops: _*))
-            case Rights(ops @ _*) => chain.right1(atom, choice(ops: _*))
+            case Lefts(ops @ _*) => infix.left1(atom, choice(ops: _*))
+            case Rights(ops @ _*) => infix.right1(atom, choice(ops: _*))
             case Prefixes(ops @ _*) => chain.prefix(choice(ops: _*), parsley.XCompat.applyWrap(wrap)(atom))
             // FIXME: Postfix operators which are similar to binary ops may fail, how can we work around this?
             case Postfixes(ops @ _*) => chain.postfix(parsley.XCompat.applyWrap(wrap)(atom), choice(ops: _*))

--- a/src/main/scala/parsley/implicits/zipped.scala
+++ b/src/main/scala/parsley/implicits/zipped.scala
@@ -9,6 +9,8 @@ import scala.language.implicitConversions
 /**
   * Provides an alterative to the `f.lift(x, y)` syntax that is instead `(x, y).zipped(f)`. This is prefered when type inferences fails. Also enables a
   * parameterless `zipped` method, to pair an arbitrary number of parsers such that `(p, q).zipped = p.zip(q)`
+  *
+  * Warning: these methods are *not* lazy like the `lift` syntax or `liftN` functions!
   * @since 3.0.0
   */
 object zipped
@@ -23,155 +25,133 @@ object zipped
         def zipped[R](f: (T1, T2, T3) => R): Parsley[R] = lift3(f, t._1, t._2, t._3)
         def zipped: Parsley[(T1, T2, T3)] = this.zipped((_, _, _))
     }
-    /** Compared with Zipped2, this class is lazy in the receiver and exposes `lazyZipped` instead, to avoid a clash with the `zipped` from Scala tuples. */
-    implicit final class LazyZipped2[T1, T2](t: =>(Parsley[T1], Parsley[T2])) {
-        lazy val (p1, p2) = t
-        def lazyZipped[R](f: (T1, T2) => R): Parsley[R] = lift2(f, p1, p2)
-        def lazyZipped: Parsley[(T1, T2)] = this.lazyZipped((_, _))
-    }
-    /** Compared with Zipped3, this class is lazy in the receiver and exposes `lazyZipped` instead, to avoid a clash with the `zipped` from Scala tuples. */
-    implicit final class LazyZipped3[T1, T2, T3](t: =>(Parsley[T1], Parsley[T2], Parsley[T3])) {
-        lazy val (p1, p2, p3) = t
-        def lazyZipped[R](f: (T1, T2, T3) => R): Parsley[R] = lift3(f, p1, p2, p3)
-        def lazyZipped: Parsley[(T1, T2, T3)] = this.lazyZipped((_, _, _))
-    }
-    implicit final class Zipped4[T1, T2, T3, T4](t: =>(Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4])) {
-        lazy val (p1, p2, p3, p4) = t
-        def zipped[R](f: (T1, T2, T3, T4) => R): Parsley[R] = lift4(f, p1, p2, p3, p4)
+    implicit final class Zipped4[T1, T2, T3, T4](private val t: (Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4])) extends AnyVal {
+        def zipped[R](f: (T1, T2, T3, T4) => R): Parsley[R] = lift4(f, t._1, t._2, t._3, t._4)
         def zipped: Parsley[(T1, T2, T3, T4)] = this.zipped((_, _, _, _))
     }
-    implicit final class Zipped5[T1, T2, T3, T4, T5](t: =>(Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5])) {
-        lazy val (p1, p2, p3, p4, p5) = t
-        def zipped[R](f: (T1, T2, T3, T4, T5) => R): Parsley[R] = lift5(f, p1, p2, p3, p4, p5)
+    implicit final class Zipped5[T1, T2, T3, T4, T5](private val t: (Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5])) extends AnyVal {
+        def zipped[R](f: (T1, T2, T3, T4, T5) => R): Parsley[R] = lift5(f, t._1, t._2, t._3, t._4, t._5)
         def zipped: Parsley[(T1, T2, T3, T4, T5)] = this.zipped((_, _, _, _, _))
     }
-    implicit final class Zipped6[T1, T2, T3, T4, T5, T6](t: =>(Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6])) {
-        lazy val (p1, p2, p3, p4, p5, p6) = t
-        def zipped[R](f: (T1, T2, T3, T4, T5, T6) => R): Parsley[R] = lift6(f, p1, p2, p3, p4, p5, p6)
+    implicit final class Zipped6[T1, T2, T3, T4, T5, T6]
+        (private val t: (Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6])) extends AnyVal {
+        def zipped[R](f: (T1, T2, T3, T4, T5, T6) => R): Parsley[R] = lift6(f, t._1, t._2, t._3, t._4, t._5, t._6)
         def zipped: Parsley[(T1, T2, T3, T4, T5, T6)] = this.zipped((_, _, _, _, _, _))
     }
-    implicit final class Zipped7[T1, T2, T3, T4, T5, T6, T7](t: =>(Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7])) {
-        lazy val (p1, p2, p3, p4, p5, p6, p7) = t
-        def zipped[R](f: (T1, T2, T3, T4, T5, T6, T7) => R): Parsley[R] = lift7(f, p1, p2, p3, p4, p5, p6, p7)
+    implicit final class Zipped7[T1, T2, T3, T4, T5, T6, T7]
+        (private val t: (Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7])) extends AnyVal {
+        def zipped[R](f: (T1, T2, T3, T4, T5, T6, T7) => R): Parsley[R] = lift7(f, t._1, t._2, t._3, t._4, t._5, t._6, t._7)
         def zipped: Parsley[(T1, T2, T3, T4, T5, T6, T7)] = this.zipped((_, _, _, _, _, _, _))
     }
     implicit final class Zipped8[T1, T2, T3, T4, T5, T6, T7, T8]
-        (t: =>(Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8])) {
-        lazy val (p1, p2, p3, p4, p5, p6, p7, p8) = t
-        def zipped[R](f: (T1, T2, T3, T4, T5, T6, T7, T8) => R): Parsley[R] = lift8(f, p1, p2, p3, p4, p5, p6, p7, p8)
+        (private val t: (Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8])) extends AnyVal {
+        def zipped[R](f: (T1, T2, T3, T4, T5, T6, T7, T8) => R): Parsley[R] = lift8(f, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8)
         def zipped: Parsley[(T1, T2, T3, T4, T5, T6, T7, T8)] = this.zipped((_, _, _, _, _, _, _, _))
     }
     implicit final class Zipped9[T1, T2, T3, T4, T5, T6, T7, T8, T9]
-        (t: =>(Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8], Parsley[T9])) {
-        lazy val (p1, p2, p3, p4, p5, p6, p7, p8, p9) = t
-        def zipped[R](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9) => R): Parsley[R] = lift9(f, p1, p2, p3, p4, p5, p6, p7, p8, p9)
+        (private val t: (Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8], Parsley[T9])) extends AnyVal {
+        def zipped[R](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9) => R): Parsley[R] = lift9(f, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9)
         def zipped: Parsley[(T1, T2, T3, T4, T5, T6, T7, T8, T9)] = this.zipped((_, _, _, _, _, _, _, _, _))
     }
     implicit final class Zipped10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]
-        (t: =>(Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8], Parsley[T9], Parsley[T10])) {
-        lazy val (p1, p2, p3, p4, p5, p6, p7, p8, p9, p10) = t
-        def zipped[R](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) => R): Parsley[R] = lift10(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10)
+        (private val t: (Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8], Parsley[T9],
+                         Parsley[T10])) extends AnyVal {
+        def zipped[R](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) => R): Parsley[R] = lift10(f, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10)
         def zipped: Parsley[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)] = this.zipped((_, _, _, _, _, _, _, _, _, _))
     }
     implicit final class Zipped11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]
-        (t: =>(Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8], Parsley[T9], Parsley[T10],
-               Parsley[T11])) {
-        lazy val (p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11) = t
-        def zipped[R](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) => R): Parsley[R] = lift11(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11)
+        (private val t: (Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8], Parsley[T9], Parsley[T10],
+                         Parsley[T11])) extends AnyVal {
+        def zipped[R](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11) => R): Parsley[R] =
+            lift11(f, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11)
         def zipped: Parsley[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)] = this.zipped((_, _, _, _, _, _, _, _, _, _, _))
     }
     implicit final class Zipped12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]
-        (t: =>(Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8], Parsley[T9], Parsley[T10], Parsley[T11],
-               Parsley[T12])) {
-        lazy val (p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12) = t
-        def zipped[R](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) => R): Parsley[R] = lift12(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12)
+        (private val t: (Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8], Parsley[T9], Parsley[T10],
+                         Parsley[T11], Parsley[T12])) extends AnyVal {
+        def zipped[R](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12) => R): Parsley[R] =
+            lift12(f, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12)
         def zipped: Parsley[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)] = this.zipped((_, _, _, _, _, _, _, _, _, _, _, _))
     }
     implicit final class Zipped13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]
-        (t: =>(Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8], Parsley[T9], Parsley[T10], Parsley[T11],
-               Parsley[T12], Parsley[T13])) {
-        lazy val (p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13) = t
+        (private val t: (Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8], Parsley[T9], Parsley[T10],
+                         Parsley[T11], Parsley[T12], Parsley[T13])) extends AnyVal {
         def zipped[R](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13) => R): Parsley[R] =
-            lift13(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13)
+            lift13(f, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13)
         def zipped: Parsley[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)] = this.zipped((_, _, _, _, _, _, _, _, _, _, _, _, _))
     }
     implicit final class Zipped14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]
-        (t: =>(Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8], Parsley[T9], Parsley[T10], Parsley[T11],
-               Parsley[T12], Parsley[T13], Parsley[T14])) {
-        lazy val (p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14) = t
+        (private val t: (Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8], Parsley[T9], Parsley[T10],
+                         Parsley[T11], Parsley[T12], Parsley[T13], Parsley[T14])) extends AnyVal {
         def zipped[R](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14) => R): Parsley[R] =
-            lift14(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14)
+            lift14(f, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14)
         def zipped: Parsley[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)] = this.zipped((_, _, _, _, _, _, _, _, _, _, _, _, _, _))
     }
     implicit final class Zipped15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]
-        (t: =>(Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8], Parsley[T9], Parsley[T10], Parsley[T11],
-               Parsley[T12], Parsley[T13], Parsley[T14], Parsley[T15])) {
-        lazy val (p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15) = t
+        (private val t: (Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8], Parsley[T9], Parsley[T10],
+                         Parsley[T11], Parsley[T12], Parsley[T13], Parsley[T14], Parsley[T15])) extends AnyVal {
         def zipped[R](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15) => R): Parsley[R] =
-            lift15(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15)
+            lift15(f, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15)
         def zipped: Parsley[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)] = this.zipped((_, _, _, _, _, _, _, _, _, _, _, _, _, _, _))
     }
     implicit final class Zipped16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]
-        (t: =>(Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8], Parsley[T9], Parsley[T10], Parsley[T11],
-               Parsley[T12], Parsley[T13], Parsley[T14], Parsley[T15], Parsley[T16])) {
-        lazy val (p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16) = t
+        (private val t: (Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8], Parsley[T9], Parsley[T10],
+                         Parsley[T11], Parsley[T12], Parsley[T13], Parsley[T14], Parsley[T15], Parsley[T16])) extends AnyVal {
         def zipped[R](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16) => R): Parsley[R] =
-            lift16(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16)
+            lift16(f, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16)
         def zipped: Parsley[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)] =
             this.zipped((_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _))
     }
     implicit final class Zipped17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]
-        (t: =>(Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8], Parsley[T9], Parsley[T10], Parsley[T11],
-               Parsley[T12], Parsley[T13], Parsley[T14], Parsley[T15], Parsley[T16], Parsley[T17])) {
-        lazy val (p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17) = t
+        (private val t: (Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8], Parsley[T9], Parsley[T10],
+                         Parsley[T11], Parsley[T12], Parsley[T13], Parsley[T14], Parsley[T15], Parsley[T16], Parsley[T17])) extends AnyVal {
         def zipped[R](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17) => R): Parsley[R] =
-            lift17(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17)
+            lift17(f, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17)
         def zipped: Parsley[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)] =
             this.zipped((_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _))
     }
     implicit final class Zipped18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]
-        (t: =>(Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8], Parsley[T9], Parsley[T10], Parsley[T11],
-               Parsley[T12], Parsley[T13], Parsley[T14], Parsley[T15], Parsley[T16], Parsley[T17], Parsley[T18])) {
-        lazy val (p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18) = t
+        (private val t: (Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8], Parsley[T9], Parsley[T10],
+                         Parsley[T11], Parsley[T12], Parsley[T13], Parsley[T14], Parsley[T15], Parsley[T16], Parsley[T17], Parsley[T18])) extends AnyVal {
         def zipped[R](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18) => R): Parsley[R] =
-            lift18(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18)
+            lift18(f, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18)
         def zipped: Parsley[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)] =
             this.zipped((_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _))
     }
     implicit final class Zipped19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]
-        (t: =>(Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8], Parsley[T9], Parsley[T10], Parsley[T11],
-               Parsley[T12], Parsley[T13], Parsley[T14], Parsley[T15], Parsley[T16], Parsley[T17], Parsley[T18], Parsley[T19])) {
-        lazy val (p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19) = t
+        (private val t: (Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8], Parsley[T9], Parsley[T10],
+                         Parsley[T11], Parsley[T12], Parsley[T13], Parsley[T14], Parsley[T15], Parsley[T16], Parsley[T17], Parsley[T18],
+                         Parsley[T19])) extends AnyVal {
         def zipped[R](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) => R): Parsley[R] =
-            lift19(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19)
+            lift19(f, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19)
         def zipped: Parsley[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)] =
             this.zipped((_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _))
     }
     implicit final class Zipped20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]
-        (t: =>(Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8], Parsley[T9], Parsley[T10], Parsley[T11],
-               Parsley[T12], Parsley[T13], Parsley[T14], Parsley[T15], Parsley[T16], Parsley[T17], Parsley[T18], Parsley[T19], Parsley[T20])) {
-        lazy val (p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20) = t
+        (private val t: (Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8], Parsley[T9], Parsley[T10],
+                         Parsley[T11], Parsley[T12], Parsley[T13], Parsley[T14], Parsley[T15], Parsley[T16], Parsley[T17], Parsley[T18], Parsley[T19],
+                         Parsley[T20])) extends AnyVal {
         def zipped[R](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20) => R): Parsley[R] =
-            lift20(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20)
+            lift20(f, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19, t._20)
         def zipped: Parsley[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)] =
             this.zipped((_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _))
     }
     implicit final class Zipped21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]
-        (t: =>(Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8], Parsley[T9], Parsley[T10], Parsley[T11],
-               Parsley[T12], Parsley[T13], Parsley[T14], Parsley[T15], Parsley[T16], Parsley[T17], Parsley[T18], Parsley[T19], Parsley[T20], Parsley[T21])) {
-        lazy val (p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21) = t
+        (private val t: (Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8], Parsley[T9], Parsley[T10],
+                         Parsley[T11], Parsley[T12], Parsley[T13], Parsley[T14], Parsley[T15], Parsley[T16], Parsley[T17], Parsley[T18], Parsley[T19],
+                         Parsley[T20], Parsley[T21])) extends AnyVal {
         def zipped[R](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21) => R): Parsley[R] =
-            lift21(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21)
+            lift21(f, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11, t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19, t._20, t._21)
         def zipped: Parsley[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)] =
             this.zipped((_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _))
     }
     implicit final class Zipped22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]
-        (t: =>(Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8], Parsley[T9], Parsley[T10], Parsley[T11],
-               Parsley[T12], Parsley[T13], Parsley[T14], Parsley[T15], Parsley[T16], Parsley[T17], Parsley[T18], Parsley[T19], Parsley[T20], Parsley[T21],
-               Parsley[T22])) {
-        lazy val (p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22) = t
+        (private val t: (Parsley[T1], Parsley[T2], Parsley[T3], Parsley[T4], Parsley[T5], Parsley[T6], Parsley[T7], Parsley[T8], Parsley[T9], Parsley[T10],
+                         Parsley[T11], Parsley[T12], Parsley[T13], Parsley[T14], Parsley[T15], Parsley[T16], Parsley[T17], Parsley[T18], Parsley[T19],
+                         Parsley[T20], Parsley[T21], Parsley[T22])) extends AnyVal {
         def zipped[R](f: (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22) => R): Parsley[R] =
-            lift22(f, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15, p16, p17, p18, p19, p20, p21, p22)
+            lift22(f, t._1, t._2, t._3, t._4, t._5, t._6, t._7, t._8, t._9, t._10, t._11,
+                      t._12, t._13, t._14, t._15, t._16, t._17, t._18, t._19, t._20, t._21, t._22)
         def zipped: Parsley[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)] =
             this.zipped((_, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _, _))
     }

--- a/src/main/scala/parsley/internal/deepembedding/IterativeEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/IterativeEmbedding.scala
@@ -29,17 +29,17 @@ private [deepembedding] sealed abstract class ManyLike[A, B](_p: Parsley[A], nam
 }
 private [parsley] final class Many[A](_p: Parsley[A]) extends ManyLike[A, List[A]](_p, "many", new Many(_), Nil, new instructions.Many(_))
 private [parsley] final class SkipMany[A](_p: Parsley[A]) extends ManyLike[A, Unit](_p, "skipMany", new SkipMany(_), (), new instructions.SkipMany(_))
-private [deepembedding] sealed abstract class ChainLike[A](_p: =>Parsley[A], _op: =>Parsley[A => A],
+private [deepembedding] sealed abstract class ChainLike[A](p: Parsley[A], _op: =>Parsley[A => A],
                                                            pretty: (String, String) => String, make: Parsley[A] => ChainLike[A])
-    extends Binary[A, A => A, A](_p, _op, pretty, make) {
+    extends Binary[A, A => A, A](p, _op, pretty, make) {
     override def optimise: Parsley[A] = right match {
         case _: Pure[_] => throw new Exception("chain given parser which consumes no input")
         case _: MZero => left
         case _ => this
     }
 }
-private [parsley] final class ChainPost[A](_p: =>Parsley[A], _op: =>Parsley[A => A])
-    extends ChainLike[A](_p, _op, (l, r) => s"chainPost($l, $r)", new ChainPost(_, ???)) {
+private [parsley] final class ChainPost[A](p: Parsley[A], _op: =>Parsley[A => A])
+    extends ChainLike[A](p, _op, (l, r) => s"chainPost($l, $r)", new ChainPost(_, ???)) {
     override val numInstrs = 2
     override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont, R], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
         val body = state.freshLabel()
@@ -54,8 +54,9 @@ private [parsley] final class ChainPost[A](_p: =>Parsley[A], _op: =>Parsley[A =>
         }
     }
 }
-private [parsley] final class ChainPre[A](_p: =>Parsley[A], _op: =>Parsley[A => A])
-    extends ChainLike[A](_p, _op, (l, r) => s"chainPre($r, $l)", new ChainPre(_, ???)) {
+// This can't be fully strict, because it depends on binary!
+private [parsley] final class ChainPre[A](p: Parsley[A], _op: =>Parsley[A => A])
+    extends ChainLike[A](p, _op, (l, r) => s"chainPre($r, $l)", new ChainPre(_, ???)) {
     override val numInstrs = 3
     override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont, R], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
         val body = state.freshLabel()
@@ -70,8 +71,8 @@ private [parsley] final class ChainPre[A](_p: =>Parsley[A], _op: =>Parsley[A => 
         }
     }
 }
-private [parsley] final class Chainl[A, B](_init: Parsley[B], _p: =>Parsley[A], _op: =>Parsley[(B, A) => B])
-    extends Ternary[B, A, (B, A) => B, B](_init, _p, _op, (f, s, t) => s"chainl1($s, $t)", new Chainl(_, ???, ???)) {
+private [parsley] final class Chainl[A, B](init: Parsley[B], _p: =>Parsley[A], _op: =>Parsley[(B, A) => B])
+    extends Ternary[B, A, (B, A) => B, B](init, _p, _op, (f, s, t) => s"chainl1($s, $t)", new Chainl(_, ???, ???)) {
     override val numInstrs = 2
     override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont, R], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
         val body = state.freshLabel()
@@ -87,8 +88,8 @@ private [parsley] final class Chainl[A, B](_init: Parsley[B], _p: =>Parsley[A], 
         }
     }
 }
-private [parsley] final class Chainr[A, B](_p: Parsley[A], _op: =>Parsley[(A, B) => B], private [Chainr] val wrap: A => B)
-    extends Binary[A, (A, B) => B, B](_p, _op, (l, r) => s"chainr1($l, $r)", new Chainr(_, ???, wrap)) {
+private [parsley] final class Chainr[A, B](p: Parsley[A], _op: =>Parsley[(A, B) => B], private [Chainr] val wrap: A => B)
+    extends Binary[A, (A, B) => B, B](p, _op, (l, r) => s"chainr1($l, $r)", new Chainr(_, ???, wrap)) {
     override val numInstrs = 3
     override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont, R], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit]= {
         val body = state.freshLabel()
@@ -104,8 +105,8 @@ private [parsley] final class Chainr[A, B](_p: Parsley[A], _op: =>Parsley[(A, B)
         }
     }
 }
-private [parsley] final class SepEndBy1[A, B](_p: Parsley[A], _sep: =>Parsley[B])
-    extends Binary[A, B, List[A]](_p, _sep, (l, r) => s"sepEndBy1($r, $l)", new SepEndBy1(_, ???)) {
+private [parsley] final class SepEndBy1[A, B](p: Parsley[A], _sep: =>Parsley[B])
+    extends Binary[A, B, List[A]](p, _sep, (l, r) => s"sepEndBy1($r, $l)", new SepEndBy1(_, ???)) {
     override val numInstrs = 3
     override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont, R], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
         val body = state.freshLabel()
@@ -121,7 +122,7 @@ private [parsley] final class SepEndBy1[A, B](_p: Parsley[A], _sep: =>Parsley[B]
         }
     }
 }
-private [parsley] final class ManyUntil[A](_body: Parsley[Any]) extends Unary[Any, List[A]](_body, c => s"manyUntil($c)", new ManyUntil(_)) {
+private [parsley] final class ManyUntil[A](body: Parsley[Any]) extends Unary[Any, List[A]](body, c => s"manyUntil($c)", new ManyUntil(_)) {
     override val numInstrs = 2
     override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont, R], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
         val start = state.freshLabel()

--- a/src/test/scala/parsley/ExpressionParserTests.scala
+++ b/src/test/scala/parsley/ExpressionParserTests.scala
@@ -2,7 +2,7 @@ package parsley
 
 import parsley.character.digit
 import parsley.implicits.character.{charLift, stringLift}
-import parsley.expr.chain
+import parsley.expr.{chain, infix}
 import parsley.expr.{precedence, Ops, GOps, SOps, InfixL, InfixR, Prefix, Postfix, InfixN, Atoms}
 import parsley.Parsley._
 import parsley._
@@ -87,7 +87,7 @@ class ExpressionParserTests extends ParsleyTest {
         sealed trait Expr
         case class Add(x: Int, y: Expr) extends Expr
         case class Num(x: Int) extends Expr
-        val p = chain.right1("1" #> 1, "+" #> ((x: Int, y: Expr) => Add(x, y)))(Num)
+        val p = infix.right1("1" #> 1, "+" #> ((x: Int, y: Expr) => Add(x, y)))(Num)
         p.parse("1+1+1") should be (Success(Add(1, Add(1, Num(1)))))
         p.parse("1") should be (Success(Num(1)))
     }
@@ -120,7 +120,7 @@ class ExpressionParserTests extends ParsleyTest {
         sealed trait Expr
         case class Add(x: Expr, y: Int) extends Expr
         case class Num(x: Int) extends Expr
-        chain.left1("1" #> 1, "+".#>[(Expr, Int) => Expr](Add.apply))(Num).parse("1+1+1") should be (Success(Add(Add(Num(1), 1), 1)))
+        infix.left1("1" #> 1, "+".#>[(Expr, Int) => Expr](Add.apply))(Num).parse("1+1+1") should be (Success(Add(Add(Num(1), 1), 1)))
     }
     "chain.left" must "allow for no initial value" in {
         chain.left("11" #> 1, '+' #> ((x: Int, y: Int) => x + y), 0).parse("11") should be (Success(1))


### PR DESCRIPTION
This breaks out the existing chain API into both `chain` and `infix` which corresponds more closely to the DPfPC presentation and allows for better QoL when using the homogenous chains.

Also adds the mixed-chain combinators `mixed.left1` and `mixed.right1`. These will need to be integrated into the precedence table in due course.