### PR TITLE
Fixed infinite loop in whitespace with no comments in `LanguageDef`

### DIFF
--- a/src/main/scala/parsley/internal/machine/instructions/TokenInstrs.scala
+++ b/src/main/scala/parsley/internal/machine/instructions/TokenInstrs.scala
@@ -77,8 +77,13 @@ private [instructions] abstract class WhiteSpaceLike(start: String, end: String,
         else ctx.pushAndContinue(())
     }
 
+    final def spacesAndContinue(ctx: Context): Unit = {
+        spaces(ctx)
+        ctx.pushAndContinue(())
+    }
+
     private final val impl = {
-        if (!lineAllowed && !multiAllowed) spaces(_)
+        if (!lineAllowed && !multiAllowed) spacesAndContinue(_)
         else if (!lineAllowed) multisOnly(_)
         else if (!multiAllowed) singlesOnly(_)
         else singlesAndMultis(_)

--- a/src/test/scala/parsley/TokeniserTests.scala
+++ b/src/test/scala/parsley/TokeniserTests.scala
@@ -397,4 +397,10 @@ class TokeniserTests extends ParsleyTest {
         p.parse("bye") shouldBe a [Success[_]]
         p.parse("Bye") shouldBe a [Success[_]]
     }
+
+    "issue #199" should "not regress: whitespace should work without comments defined" in {
+        val lang = token.LanguageDef.plain.copy(space = token.Predicate(_.isWhitespace))
+        val lexer = new token.Lexer(lang)
+        lexer.whiteSpace.parse("[") shouldBe a [Success[_]]
+    }
 }


### PR DESCRIPTION
When no comments are specified for a `LanguageDef`, whitespace consumption enters an infinite loop, since it does not update the program counter when the spaces have been consumed.