### PR TITLE
Added missing depth decrement to multiRet

### DIFF
--- a/src/main/scala/parsley/internal/machine/Context.scala
+++ b/src/main/scala/parsley/internal/machine/Context.scala
@@ -189,6 +189,7 @@ private [parsley] final class Context(private [machine] var instrs: Array[Instr]
             while (calls.tail != null && calls.tail.callId == callId && m > 0) {
                 calls = calls.tail
                 m -= 1
+                depth -= 1
             }
             ret()
             multiRet(m)


### PR DESCRIPTION
The multiRet functionality used to drop multiple call frames on return does not properly decrement the depth count unless each return is a "hard return". This is masked by stateful instructions and the operation of Parsley 3, but you can never be too sure.