### PR TITLE
AST Normalisation

### DIFF
--- a/src/main/scala-3.x/parsley/internal/deepembedding/Cont.scala
+++ b/src/main/scala-3.x/parsley/internal/deepembedding/Cont.scala
@@ -23,7 +23,7 @@ private [deepembedding] abstract class ContOps[Cont[_, +_]] {
     def flatMap[R, A, B](c: Cont[R, A], f: A => Cont[R, B]): Cont[R, B]
     def suspend[R, A](x: =>Cont[R, A]): Cont[R, A]
     // $COVERAGE-OFF$
-    def >>[R, A, B](c: Cont[R, A], k: Cont[R, B]): Cont[R, B] = flatMap[R, A, B](c, _ => k)
+    def >>[R, A, B](c: Cont[R, A], k: =>Cont[R, B]): Cont[R, B] = flatMap[R, A, B](c, _ => k)
     def |>[R, A, B](c: Cont[R, A], x: =>B): Cont[R, B] = map[R, A, B](c, _ => x)
     // $COVERAGE-ON$
 }
@@ -57,7 +57,7 @@ private [deepembedding] object Cont {
             new Cont(k => new Thunk(() => mx.cont(x => f(x).cont(k))))
         }
         override def suspend[R, A](x: =>Cont[R, A]): Cont[R, A] = new Cont(k => new Thunk(() => x.cont(k)))
-        override def >>[R, A, B](mx: Cont[R, A], my: Cont[R, B]): Cont[R, B] = {
+        override def >>[R, A, B](mx: Cont[R, A], my: =>Cont[R, B]): Cont[R, B] = {
             new Cont(k => new Thunk(() => mx.cont(_ => my.cont(k))))
         }
     }
@@ -71,7 +71,7 @@ private [deepembedding] object Id {
         override def map[R, A, B](c: Id[R, A], f: A => B): Id[R, B] = new Id(f(c.x))
         override def flatMap[R, A, B](c: Id[R, A], f: A => Id[R, B]): Id[R, B] = f(c.x)
         override def suspend[R, A](x: =>Id[R, A]): Id[R, A] = x
-        override def >>[R, A, B](c: Id[R, A], k: Id[R, B]): Id[R, B] = k
+        override def >>[R, A, B](c: Id[R, A], k: =>Id[R, B]): Id[R, B] = k
         override def |>[R, A, B](c: Id[R, A], x: =>B): Id[R, B] = new Id(x)
     }
 }

--- a/src/main/scala-3.x/parsley/internal/deepembedding/Cont.scala
+++ b/src/main/scala-3.x/parsley/internal/deepembedding/Cont.scala
@@ -43,6 +43,10 @@ private [deepembedding] object ContOps {
         try task(Id.ops.asInstanceOf[GenOps])
         catch { case _: StackOverflowError => task(Cont.ops.asInstanceOf[GenOps]) }
     }
+    def sequence[Cont[_, +_]: ContOps, R, A](mxs: List[Cont[R, A]]): Cont[R, List[A]] = mxs match {
+        case Nil => result(Nil)
+        case mx :: mxs => for { x <- mx; xs <- sequence(mxs) } yield x :: xs
+    }
 }
 
 private [deepembedding] class Cont[R, +A](val cont: (A => Bounce[R]) => Bounce[R]) extends AnyVal

--- a/src/main/scala/parsley/internal/LinkedList.scala
+++ b/src/main/scala/parsley/internal/LinkedList.scala
@@ -59,6 +59,9 @@ private [internal] class LinkedList[A] private [LinkedList]
 
     override def isEmpty: Boolean = start == null
 
+    override def lastOption: Option[A] = if (end != null) Some(end.x) else None
+    override def headOption: Option[A] = if (start != null) Some(start.x) else None
+
     override def iterator: LinkedListIterator[A] = new LinkedListIterator[A] {
         override var current = start
         override val end = LinkedList.this.end

--- a/src/main/scala/parsley/internal/LinkedList.scala
+++ b/src/main/scala/parsley/internal/LinkedList.scala
@@ -27,8 +27,8 @@ private [internal] class LinkedList[A] extends Iterable[A] {
     }
     def +=(x: A): this.type = addOne(x)
 
-    def addAll(xs: IterableOnce[A]): this.type = {
-        val it = xs.iterator
+    def addAll(xs: Iterable[A]): this.type = addAll(xs.iterator)
+    def addAll(it: Iterator[A]): this.type = {
         if (it.hasNext) {
             addOne(it.next())
             for (x <- it) {

--- a/src/main/scala/parsley/internal/LinkedList.scala
+++ b/src/main/scala/parsley/internal/LinkedList.scala
@@ -1,0 +1,77 @@
+/* SPDX-FileCopyrightText: © 2022 Parsley Contributors <https://github.com/j-mie6/Parsley/graphs/contributors>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package parsley.internal
+
+import LinkedList.Node
+import scala.collection.AbstractIterator
+
+private [internal] class LinkedList[A] extends Iterable[A] {
+    var start: Node[A] = null
+    var end: Node[A] = null
+
+    // This method assumes that this list is non-empty
+    private [LinkedList] def unsafeAddOne(x: A): this.type = {
+        val next = new Node(x, null)
+        if (this.end != null) this.end.next = next
+        this.end = next
+        this
+    }
+    def addOne(x: A): this.type = {
+        if (this.start == null) {
+            this.start = new Node(x, null)
+            this.end = this.start
+            this
+        }
+        else unsafeAddOne(x)
+    }
+    def +=(x: A): this.type = addOne(x)
+
+    def addAll(xs: IterableOnce[A]): this.type = {
+        val it = xs.iterator
+        if (it.hasNext) {
+            addOne(it.next())
+            for (x <- it) {
+                unsafeAddOne(x)
+            }
+        }
+        this
+    }
+
+    def prependOne(x: A): this.type = {
+        val start = new Node(x, this.start)
+        this.start = start
+        if (this.end == null) this.end = this.start
+        this
+    }
+
+    def stealAll(other: LinkedList[A]): this.type = if (other.nonEmpty) {
+        if (this.end != null) this.end.next = other.start
+        else this.start = other.start
+        this.end = other.end
+        other.start = null
+        other.end = null
+        this
+    } else this
+
+    override def isEmpty: Boolean = start == null
+
+    override def iterator: Iterator[A] = new AbstractIterator[A] {
+        private[this] var current = start
+        def hasNext = current != null
+        def next() = { val r = current.x; current = current.next; r }
+    }
+}
+
+private [internal] object LinkedList {
+    private [LinkedList] class Node[A](val x: A, var next: Node[A])
+    def empty[A]: LinkedList[A] = new LinkedList[A]
+    def apply[A](x: A, xs: A*): LinkedList[A] = {
+        val list = new LinkedList[A]
+        list += x
+        for (x <- xs) list.unsafeAddOne(x)
+        list
+    }
+    // This is pretty inefficient tbh!
+    def unapplySeq[A](xs: LinkedList[A]): Some[Seq[A]] = Some(xs.toSeq)
+}

--- a/src/main/scala/parsley/internal/collection/mutable/DoublyLinkedList.scala
+++ b/src/main/scala/parsley/internal/collection/mutable/DoublyLinkedList.scala
@@ -14,8 +14,8 @@ private [internal] class DoublyLinkedList[A] private [DoublyLinkedList]
 
     // This method assumes that this list is non-empty
     private [DoublyLinkedList] def unsafeAddOne(x: A): this.type = {
-        val next = new Node(x, null, this.start)
-        if (this.end != null) this.end.next = next
+        val next = new Node(x, null, this.end)
+        this.end.next = next
         this.end = next
         this
     }
@@ -63,6 +63,14 @@ private [internal] class DoublyLinkedList[A] private [DoublyLinkedList]
 
     override def lastOption: Option[A] = if (end != null) Some(end.x) else None
     override def headOption: Option[A] = if (start != null) Some(start.x) else None
+
+    def initInPlace(): this.type = {
+        if (this.end == null) throw new IllegalStateException("Cannot take init of the empty list")
+        this.end = this.end.prev
+        if (this.end != null) this.end.next = null
+        else this.start = null
+        this
+    }
 
     override def iterator: Iterator[A] = new AbstractIterator[A] {
         var current: Node[A] = start

--- a/src/main/scala/parsley/internal/collection/mutable/DoublyLinkedList.scala
+++ b/src/main/scala/parsley/internal/collection/mutable/DoublyLinkedList.scala
@@ -1,0 +1,89 @@
+/* SPDX-FileCopyrightText: © 2022 Parsley Contributors <https://github.com/j-mie6/Parsley/graphs/contributors>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+package parsley.internal.collection.mutable
+
+import DoublyLinkedList.Node
+import scala.collection.AbstractIterator
+
+private [internal] class DoublyLinkedList[A] private [DoublyLinkedList]
+    (private [DoublyLinkedList] var start: Node[A],
+     private [DoublyLinkedList] var end: Node[A]) extends Iterable[A] {
+
+    private [DoublyLinkedList] def this() = this(null, null)
+
+    // This method assumes that this list is non-empty
+    private [DoublyLinkedList] def unsafeAddOne(x: A): this.type = {
+        val next = new Node(x, null, this.start)
+        if (this.end != null) this.end.next = next
+        this.end = next
+        this
+    }
+    def addOne(x: A): this.type = {
+        if (this.start == null) {
+            this.start = new Node(x, null, null)
+            this.end = this.start
+            this
+        }
+        else unsafeAddOne(x)
+    }
+    def +=(x: A): this.type = addOne(x)
+
+    def addAll(xs: Iterable[A]): this.type = addAll(xs.iterator)
+    def addAll(it: Iterator[A]): this.type = {
+        if (it.hasNext) {
+            addOne(it.next())
+            for (x <- it) {
+                unsafeAddOne(x)
+            }
+        }
+        this
+    }
+
+    def prependOne(x: A): this.type = {
+        val start = new Node(x, this.start, null)
+        this.start = start
+        if (this.end == null) this.end = this.start
+        this
+    }
+
+    def stealAll(other: DoublyLinkedList[A]): this.type = if (other.nonEmpty) {
+        if (this.end != null) {
+            this.end.next = other.start
+            other.start.prev = this.end
+        }
+        else this.start = other.start
+        this.end = other.end
+        other.start = null
+        other.end = null
+        this
+    } else this
+
+    override def isEmpty: Boolean = start == null
+
+    override def lastOption: Option[A] = if (end != null) Some(end.x) else None
+    override def headOption: Option[A] = if (start != null) Some(start.x) else None
+
+    override def iterator: Iterator[A] = new AbstractIterator[A] {
+        var current: Node[A] = start
+        def hasNext = current != null
+        def next() = { val r = current.x; current = current.next; r }
+    }
+
+    def reverseIterator: Iterator[A] = new AbstractIterator[A] {
+        var current: Node[A] = end
+        def hasNext = current != null
+        def next() = { val r = current.x; current = current.prev; r }
+    }
+}
+
+private [internal] object DoublyLinkedList {
+    private [DoublyLinkedList] class Node[A](val x: A, var next: Node[A], var prev: Node[A])
+    def empty[A]: DoublyLinkedList[A] = new DoublyLinkedList[A]
+    def apply[A](x: A, xs: A*): DoublyLinkedList[A] = {
+        val list = new DoublyLinkedList[A]
+        list += x
+        for (x <- xs) list.unsafeAddOne(x)
+        list
+    }
+}

--- a/src/main/scala/parsley/internal/collection/mutable/Radix.scala
+++ b/src/main/scala/parsley/internal/collection/mutable/Radix.scala
@@ -1,7 +1,7 @@
-/* SPDX-FileCopyrightText: © 2021 Parsley Contributors <https://github.com/j-mie6/Parsley/graphs/contributors>
+/* SPDX-FileCopyrightText: © 2022 Parsley Contributors <https://github.com/j-mie6/Parsley/graphs/contributors>
  * SPDX-License-Identifier: BSD-3-Clause
  */
-package parsley.internal
+package parsley.internal.collection.mutable
 
 import scala.annotation.tailrec
 import scala.collection.{mutable, BufferedIterator}

--- a/src/main/scala/parsley/internal/collection/mutable/SinglyLinkedList.scala
+++ b/src/main/scala/parsley/internal/collection/mutable/SinglyLinkedList.scala
@@ -1,18 +1,18 @@
 /* SPDX-FileCopyrightText: © 2022 Parsley Contributors <https://github.com/j-mie6/Parsley/graphs/contributors>
  * SPDX-License-Identifier: BSD-3-Clause
  */
-package parsley.internal
+package parsley.internal.collection.mutable
 
-import LinkedList.{Node, LinkedListIterator}
+import SinglyLinkedList.{Node, LinkedListIterator}
 
-private [internal] class LinkedList[A] private [LinkedList]
-    (private [LinkedList] var start: Node[A],
-     private [LinkedList] var end: Node[A]) extends Iterable[A] {
+private [internal] class SinglyLinkedList[A] private [SinglyLinkedList]
+    (private [SinglyLinkedList] var start: Node[A],
+     private [SinglyLinkedList] var end: Node[A]) extends Iterable[A] {
 
-    private [LinkedList] def this() = this(null, null)
+    private [SinglyLinkedList] def this() = this(null, null)
 
     // This method assumes that this list is non-empty
-    private [LinkedList] def unsafeAddOne(x: A): this.type = {
+    private [SinglyLinkedList] def unsafeAddOne(x: A): this.type = {
         val next = new Node(x, null)
         if (this.end != null) this.end.next = next
         this.end = next
@@ -28,7 +28,7 @@ private [internal] class LinkedList[A] private [LinkedList]
     }
     def +=(x: A): this.type = addOne(x)
 
-    def ::(x: A): LinkedList[A] = new LinkedList(new Node(x, this.start), this.end)
+    def ::(x: A): SinglyLinkedList[A] = new SinglyLinkedList(new Node(x, this.start), this.end)
 
     def addAll(xs: Iterable[A]): this.type = addAll(xs.iterator)
     def addAll(it: Iterator[A]): this.type = {
@@ -48,7 +48,7 @@ private [internal] class LinkedList[A] private [LinkedList]
         this
     }
 
-    def stealAll(other: LinkedList[A]): this.type = if (other.nonEmpty) {
+    def stealAll(other: SinglyLinkedList[A]): this.type = if (other.nonEmpty) {
         if (this.end != null) this.end.next = other.start
         else this.start = other.start
         this.end = other.end
@@ -64,33 +64,31 @@ private [internal] class LinkedList[A] private [LinkedList]
 
     override def iterator: LinkedListIterator[A] = new LinkedListIterator[A] {
         override var current = start
-        override val end = LinkedList.this.end
+        override val end = SinglyLinkedList.this.end
     }
 }
 
-private [internal] object LinkedList {
-    private [LinkedList] class Node[A](val x: A, var next: Node[A])
-    def empty[A]: LinkedList[A] = new LinkedList[A]
-    def apply[A](x: A, xs: A*): LinkedList[A] = {
-        val list = new LinkedList[A]
+private [internal] object SinglyLinkedList {
+    private [SinglyLinkedList] class Node[A](val x: A, var next: Node[A])
+    def empty[A]: SinglyLinkedList[A] = new SinglyLinkedList[A]
+    def apply[A](x: A, xs: A*): SinglyLinkedList[A] = {
+        val list = new SinglyLinkedList[A]
         list += x
         for (x <- xs) list.unsafeAddOne(x)
         list
     }
-    // This is pretty inefficient tbh!
-    def unapplySeq[A](xs: LinkedList[A]): Some[Seq[A]] = Some(xs.toSeq)
 
     abstract class LinkedListIterator[A] extends Iterator[A] {
         protected var current: Node[A]
         protected val end: Node[A]
         def hasNext = current != null
         def next() = { val r = current.x; current = current.next; r }
-        def remaining: LinkedList[A] = {
+        def remaining: SinglyLinkedList[A] = {
             if (hasNext) {
-                new LinkedList(current, end)
+                new SinglyLinkedList(current, end)
             }
             else {
-                new LinkedList
+                new SinglyLinkedList
             }
         }
     }

--- a/src/main/scala/parsley/internal/deepembedding/backend/AlternativeEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/backend/AlternativeEmbedding.scala
@@ -251,10 +251,8 @@ private [backend] object Choice {
         case Lift2(_, t, _)                      => tablable(t, backtracks)
         case Lift3(_, t, _, _)                   => tablable(t, backtracks)
         case t <*> _                             => tablable(t, backtracks)
-        case t *> _                              => tablable(t, backtracks)
         case t <* _                              => tablable(t, backtracks)
-        // TODO: This doesn't check for leading pure! (normal form should have the pure as the second element anyway)
-        case NormSeq(before, r, _)               => tablable(before.headOption.getOrElse(r), backtracks)
+        case Seq(before, r, _)               => tablable(before.headOption.getOrElse(r), backtracks)
         case _                                   => None
     }
 }

--- a/src/main/scala/parsley/internal/deepembedding/backend/AlternativeEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/backend/AlternativeEmbedding.scala
@@ -251,8 +251,7 @@ private [backend] object Choice {
         case Lift2(_, t, _)                      => tablable(t, backtracks)
         case Lift3(_, t, _, _)                   => tablable(t, backtracks)
         case t <*> _                             => tablable(t, backtracks)
-        case t <* _                              => tablable(t, backtracks)
-        case Seq(before, r, _)               => tablable(before.headOption.getOrElse(r), backtracks)
+        case Seq(before, r, _)                   => tablable(before.headOption.getOrElse(r), backtracks)
         case _                                   => None
     }
 }

--- a/src/main/scala/parsley/internal/deepembedding/backend/AlternativeEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/backend/AlternativeEmbedding.scala
@@ -20,7 +20,7 @@ private [deepembedding] final class <|>[A](var left: StrictParsley[A], var right
 
     override def optimise: StrictParsley[A] = (left, right) match {
         // left catch law: pure x <|> p = pure x
-        case (u: Pure[A @unchecked], _) => u
+        case (u: Pure[_], _) => u
         // alternative law: empty <|> p = p
         case (Empty, v)                 => v
         // alternative law: p <|> empty = p

--- a/src/main/scala/parsley/internal/deepembedding/backend/AlternativeEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/backend/AlternativeEmbedding.scala
@@ -102,6 +102,15 @@ private [deepembedding] final class Choice[A](private [backend] val alt1: Strict
             }
         case p => (acc += ((p, tablable(p, backtracks = false)))).toList
     }
+
+    // $COVERAGE-OFF$
+    final override def pretty[Cont[_, +_]: ContOps, R]: Cont[R,String] =
+        for {
+            s1 <- alt1.pretty
+            s2 <- alt2.pretty
+            ss <- ContOps.sequence(alts.map(_.pretty[Cont, R]).toList)
+        } yield (s1::s2::ss).mkString("choice(", ", ", ")")
+    // $COVERAGE-ON$
 }
 
 private [backend] object Choice {

--- a/src/main/scala/parsley/internal/deepembedding/backend/AlternativeEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/backend/AlternativeEmbedding.scala
@@ -251,5 +251,8 @@ private [backend] object Choice {
 
 private [deepembedding] object <|> {
     def apply[A](left: StrictParsley[A], right: StrictParsley[A]): Choice[A] = new Choice(left, right, LinkedList.empty)
-    private [backend] def unapply[A](self: Choice[A]): Some[(StrictParsley[A], StrictParsley[A])] = Some((self.alt1, self.alt2))
+    private [backend] def unapply[A](self: Choice[A]): Some[(StrictParsley[A], StrictParsley[A])] = {
+        if (self.alts.nonEmpty) throw new IllegalStateException("<|> assumed, but full Choice given")
+        Some((self.alt1, self.alt2))
+    }
 }

--- a/src/main/scala/parsley/internal/deepembedding/backend/AlternativeEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/backend/AlternativeEmbedding.scala
@@ -253,6 +253,8 @@ private [backend] object Choice {
         case t <*> _                             => tablable(t, backtracks)
         case t *> _                              => tablable(t, backtracks)
         case t <* _                              => tablable(t, backtracks)
+        // TODO: This doesn't check for leading pure! (normal form should have the pure as the second element anyway)
+        case NormSeq(before, r, _)               => tablable(before.headOption.getOrElse(r), backtracks)
         case _                                   => None
     }
 }

--- a/src/main/scala/parsley/internal/deepembedding/backend/ErrorEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/backend/ErrorEmbedding.scala
@@ -18,24 +18,37 @@ private [deepembedding] final class ErrorLabel[A](val p: StrictParsley[A], priva
         case ErrorLabel(p, label2) if label2 != "" => ErrorLabel(p, label)
         case _ => this
     }
+
+    // $COVERAGE-OFF$
+    final override def pretty(p: String): String = s"$p.label($label)"
+    // $COVERAGE-ON$
 }
 private [deepembedding] final class ErrorExplain[A](val p: StrictParsley[A], reason: String) extends ScopedUnary[A, A] {
     override def setup(label: Int): instructions.Instr = new instructions.PushHandlerAndCheck(label, saveHints = false)
     override def instr: instructions.Instr = instructions.PopHandlerAndCheck
     override def instrNeedsLabel: Boolean = false
     override def handlerLabel(state: CodeGenState): Int  = state.getLabelForApplyReason(reason)
+    // $COVERAGE-OFF$
+    final override def pretty(p: String): String = s"$p.explain($reason)"
+    // $COVERAGE-ON$
 }
 
 private [deepembedding] final class ErrorAmend[A](val p: StrictParsley[A]) extends ScopedUnaryWithState[A, A](false) {
     override val instr: instructions.Instr = instructions.PopHandlerAndState
     override def instrNeedsLabel: Boolean = false
     override def handlerLabel(state: CodeGenState): Int  = state.getLabel(instructions.AmendAndFail)
+    // $COVERAGE-OFF$
+    final override def pretty(p: String): String = s"amend($p)"
+    // $COVERAGE-ON$
 }
 private [deepembedding] final class ErrorEntrench[A](val p: StrictParsley[A]) extends ScopedUnary[A, A] {
     override def setup(label: Int): instructions.Instr = new instructions.PushHandler(label)
     override val instr: instructions.Instr = instructions.PopHandler
     override def instrNeedsLabel: Boolean = false
     override def handlerLabel(state: CodeGenState): Int  = state.getLabel(instructions.EntrenchAndFail)
+    // $COVERAGE-OFF$
+    final override def pretty(p: String): String = s"entrench($p)"
+    // $COVERAGE-ON$
 }
 
 private [backend] object ErrorLabel {

--- a/src/main/scala/parsley/internal/deepembedding/backend/GeneralisedEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/backend/GeneralisedEmbedding.scala
@@ -14,6 +14,10 @@ import StrictParsley.InstrBuffer
 private [backend] abstract class Unary[A, B] extends StrictParsley[B] {
     protected val p: StrictParsley[A]
     def inlinable: Boolean = false
+    // $COVERAGE-OFF$
+    final override def pretty[Cont[_, +_]: ContOps, R]: Cont[R,String] = for (c <- p.pretty) yield pretty(c)
+    protected def pretty(p: String): String
+    // $COVERAGE-ON$
 }
 
 private [backend] abstract class ScopedUnary[A, B] extends Unary[A, B] {

--- a/src/main/scala/parsley/internal/deepembedding/backend/GeneralisedEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/backend/GeneralisedEmbedding.scala
@@ -25,7 +25,7 @@ private [backend] abstract class ScopedUnary[A, B] extends Unary[A, B] {
     def setup(label: Int): instructions.Instr
     def handlerLabel(state: CodeGenState): Int
     def instrNeedsLabel: Boolean
-    final override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
+    final override def codeGen[Cont[_, +_]: ContOps, R](implicit instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
         val handler = handlerLabel(state)
         instrs += setup(handler)
         suspend[Cont, R, Unit](p.codeGen) |> {

--- a/src/main/scala/parsley/internal/deepembedding/backend/IntrinsicEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/backend/IntrinsicEmbedding.scala
@@ -16,7 +16,7 @@ import StrictParsley.InstrBuffer
 private [deepembedding] final class Lift2[A, B, C](private [Lift2] val f: (A, B) => C, val left: StrictParsley[A], val right: StrictParsley[B])
     extends StrictParsley[C] {
     def inlinable: Boolean = false
-    override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont],  instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
+    override def codeGen[Cont[_, +_]: ContOps, R](implicit instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
         suspend(left.codeGen[Cont, R]) >>
         suspend(right.codeGen[Cont, R]) |>
         (instrs += instructions.Lift2(f))
@@ -32,7 +32,7 @@ private [deepembedding] final class Lift2[A, B, C](private [Lift2] val f: (A, B)
 private [deepembedding] final class Lift3[A, B, C, D](val f: (A, B, C) => D, val p: StrictParsley[A], val q: StrictParsley[B], val r: StrictParsley[C])
     extends StrictParsley[D] {
     def inlinable: Boolean = false
-    override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
+    override def codeGen[Cont[_, +_]: ContOps, R](implicit instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
         suspend(p.codeGen[Cont, R]) >>
         suspend(q.codeGen[Cont, R]) >>
         suspend(r.codeGen[Cont, R]) |>
@@ -50,7 +50,7 @@ private [deepembedding] final class Lift3[A, B, C, D](val f: (A, B, C) => D, val
 
 private [deepembedding] final class Local[S, A](reg: Reg[S], left: StrictParsley[S], right: StrictParsley[A]) extends StrictParsley[A] {
     def inlinable: Boolean = false
-    override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
+    override def codeGen[Cont[_, +_]: ContOps, R](implicit instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
         suspend(left.codeGen[Cont, R]) >> {
             instrs += new instructions.Get(reg.addr)
             instrs += new instructions.SwapAndPut(reg.addr)

--- a/src/main/scala/parsley/internal/deepembedding/backend/IntrinsicEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/backend/IntrinsicEmbedding.scala
@@ -21,6 +21,13 @@ private [deepembedding] final class Lift2[A, B, C](private [Lift2] val f: (A, B)
         suspend(right.codeGen[Cont, R]) |>
         (instrs += instructions.Lift2(f))
     }
+    // $COVERAGE-OFF$
+    final override def pretty[Cont[_, +_]: ContOps, R]: Cont[R,String] =
+        for {
+            s1 <- left.pretty
+            s2 <- right.pretty
+        } yield s"lift2(?, $s1, $s2)"
+    // $COVERAGE-ON$
 }
 private [deepembedding] final class Lift3[A, B, C, D](val f: (A, B, C) => D, val p: StrictParsley[A], val q: StrictParsley[B], val r: StrictParsley[C])
     extends StrictParsley[D] {
@@ -31,6 +38,14 @@ private [deepembedding] final class Lift3[A, B, C, D](val f: (A, B, C) => D, val
         suspend(r.codeGen[Cont, R]) |>
         (instrs += instructions.Lift3(f))
     }
+    // $COVERAGE-OFF$
+    final override def pretty[Cont[_, +_]: ContOps, R]: Cont[R,String] =
+        for {
+            s1 <- p.pretty
+            s2 <- q.pretty
+            s3 <- r.pretty
+        } yield s"lift3(?, $s1, $s2, $s3)"
+    // $COVERAGE-ON$
 }
 
 private [deepembedding] final class Local[S, A](reg: Reg[S], left: StrictParsley[S], right: StrictParsley[A]) extends StrictParsley[A] {
@@ -44,6 +59,13 @@ private [deepembedding] final class Local[S, A](reg: Reg[S], left: StrictParsley
             }
         }
     }
+    // $COVERAGE-OFF$
+    final override def pretty[Cont[_, +_]: ContOps, R]: Cont[R,String] =
+        for {
+            s1 <- left.pretty
+            s2 <- right.pretty
+        } yield s"local(r${reg.addr}, $s1, $s2)"
+    // $COVERAGE-ON$
 }
 
 private [backend] object Lift2 {

--- a/src/main/scala/parsley/internal/deepembedding/backend/IterativeEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/backend/IterativeEmbedding.scala
@@ -36,10 +36,16 @@ private [backend] sealed abstract class ManyLike[A, B](name: String, unit: B) ex
 private [deepembedding] final class Many[A](val p: StrictParsley[A]) extends ManyLike[A, List[A]]("many", Nil) {
     override def instr(label: Int): instructions.Instr = new instructions.Many(label)
     override def preamble(instrs: InstrBuffer): Unit = instrs += new instructions.Fresh(mutable.ListBuffer.empty[Any])
+    // $COVERAGE-OFF$
+    final override def pretty(p: String): String = s"many($p)"
+    // $COVERAGE-ON$
 }
 private [deepembedding] final class SkipMany[A](val p: StrictParsley[A]) extends ManyLike[A, Unit]("skipMany", ()) {
     override def instr(label: Int): instructions.Instr = new instructions.SkipMany(label)
     override def preamble(instrs: InstrBuffer): Unit = ()
+    // $COVERAGE-OFF$
+    final override def pretty(p: String): String = s"skipMany($p)"
+    // $COVERAGE-ON$
 }
 private [backend] sealed abstract class ChainLike[A](p: StrictParsley[A], op: StrictParsley[A => A]) extends StrictParsley[A] {
     def inlinable: Boolean = false
@@ -48,6 +54,10 @@ private [backend] sealed abstract class ChainLike[A](p: StrictParsley[A], op: St
         case _: MZero   => p
         case _          => this
     }
+    // $COVERAGE-OFF$
+    final override def pretty[Cont[_, +_]: ContOps, R]: Cont[R,String] = for (c1 <- p.pretty; c2 <- op.pretty) yield pretty(c1, c2)
+    protected def pretty(p: String, op: String): String
+    // $COVERAGE-ON$
 }
 private [deepembedding] final class ChainPost[A](p: StrictParsley[A], op: StrictParsley[A => A]) extends ChainLike[A](p, op) {
     override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
@@ -62,6 +72,9 @@ private [deepembedding] final class ChainPost[A](p: StrictParsley[A], op: Strict
             }
         }
     }
+    // $COVERAGE-OFF$
+    final override def pretty(p: String, op: String): String = s"chainPost($p, $op)"
+    // $COVERAGE-ON$
 }
 private [deepembedding] final class ChainPre[A](p: StrictParsley[A], op: StrictParsley[A => A]) extends ChainLike[A](p, op) {
     override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
@@ -77,6 +90,9 @@ private [deepembedding] final class ChainPre[A](p: StrictParsley[A], op: StrictP
             (instrs += instructions.Apply)
         }
     }
+    // $COVERAGE-OFF$
+    final override def pretty(p: String, op: String): String = s"chainPre($op, $p)"
+    // $COVERAGE-ON$
 }
 private [deepembedding] final class Chainl[A, B](init: StrictParsley[B], p: StrictParsley[A], op: StrictParsley[(B, A) => B]) extends StrictParsley[B] {
     def inlinable: Boolean = false
@@ -93,6 +109,14 @@ private [deepembedding] final class Chainl[A, B](init: StrictParsley[B], p: Stri
             }
         }
     }
+    // $COVERAGE-OFF$
+    final override def pretty[Cont[_, +_]: ContOps, R]: Cont[R,String] =
+        for {
+            s1 <- init.pretty
+            s2 <- p.pretty
+            s3 <- op.pretty
+        } yield s"chainl1($s1, $s2, $s3)"
+    // $COVERAGE-ON$
 }
 private [deepembedding] final class Chainr[A, B](p: StrictParsley[A], op: StrictParsley[(A, B) => B], private [Chainr] val wrap: A => B)
     extends StrictParsley[B] {
@@ -111,6 +135,13 @@ private [deepembedding] final class Chainr[A, B](p: StrictParsley[A], op: Strict
             }
         }
     }
+    // $COVERAGE-OFF$
+    final override def pretty[Cont[_, +_]: ContOps, R]: Cont[R,String] =
+        for {
+            s1 <- p.pretty
+            s2 <- op.pretty
+        } yield s"chainr1($s1, $s2)"
+    // $COVERAGE-ON$
 }
 private [deepembedding] final class SepEndBy1[A, B](p: StrictParsley[A], sep: StrictParsley[B]) extends StrictParsley[List[A]] {
     def inlinable: Boolean = false
@@ -128,6 +159,13 @@ private [deepembedding] final class SepEndBy1[A, B](p: StrictParsley[A], sep: St
             }
         }
     }
+    // $COVERAGE-OFF$
+    final override def pretty[Cont[_, +_]: ContOps, R]: Cont[R,String] =
+        for {
+            s1 <- p.pretty
+            s2 <- sep.pretty
+        } yield s"sepEndBy1($s1, $s2)"
+    // $COVERAGE-ON$
 }
 private [deepembedding] final class ManyUntil[A](val p: StrictParsley[Any]) extends Unary[Any, List[A]] {
     override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
@@ -141,4 +179,7 @@ private [deepembedding] final class ManyUntil[A](val p: StrictParsley[Any]) exte
             instrs += new instructions.ManyUntil(start)
         }
     }
+    // $COVERAGE-OFF$
+    final override def pretty(p: String): String = s"manyUntil($p)"
+    // $COVERAGE-ON$
 }

--- a/src/main/scala/parsley/internal/deepembedding/backend/IterativeEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/backend/IterativeEmbedding.scala
@@ -21,7 +21,7 @@ private [backend] sealed abstract class ManyLike[A, B](name: String, unit: B) ex
         case _: MZero   => new Pure(unit)
         case _          => this
     }
-    final override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
+    final override def codeGen[Cont[_, +_]: ContOps, R](implicit instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
         val body = state.freshLabel()
         val handler = state.freshLabel()
         preamble(instrs)
@@ -60,7 +60,7 @@ private [backend] sealed abstract class ChainLike[A](p: StrictParsley[A], op: St
     // $COVERAGE-ON$
 }
 private [deepembedding] final class ChainPost[A](p: StrictParsley[A], op: StrictParsley[A => A]) extends ChainLike[A](p, op) {
-    override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
+    override def codeGen[Cont[_, +_]: ContOps, R](implicit instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
         val body = state.freshLabel()
         val handler = state.freshLabel()
         suspend(p.codeGen[Cont, R]) >> {
@@ -77,7 +77,7 @@ private [deepembedding] final class ChainPost[A](p: StrictParsley[A], op: Strict
     // $COVERAGE-ON$
 }
 private [deepembedding] final class ChainPre[A](p: StrictParsley[A], op: StrictParsley[A => A]) extends ChainLike[A](p, op) {
-    override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
+    override def codeGen[Cont[_, +_]: ContOps, R](implicit instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
         val body = state.freshLabel()
         val handler = state.freshLabel()
         instrs += new instructions.Push(identity[Any] _)
@@ -96,7 +96,7 @@ private [deepembedding] final class ChainPre[A](p: StrictParsley[A], op: StrictP
 }
 private [deepembedding] final class Chainl[A, B](init: StrictParsley[B], p: StrictParsley[A], op: StrictParsley[(B, A) => B]) extends StrictParsley[B] {
     def inlinable: Boolean = false
-    override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
+    override def codeGen[Cont[_, +_]: ContOps, R](implicit instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
         val body = state.freshLabel()
         val handler = state.freshLabel()
         suspend(init.codeGen[Cont, R]) >> {
@@ -121,7 +121,7 @@ private [deepembedding] final class Chainl[A, B](init: StrictParsley[B], p: Stri
 private [deepembedding] final class Chainr[A, B](p: StrictParsley[A], op: StrictParsley[(A, B) => B], private [Chainr] val wrap: A => B)
     extends StrictParsley[B] {
     def inlinable: Boolean = false
-    override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit]= {
+    override def codeGen[Cont[_, +_]: ContOps, R](implicit instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit]= {
         val body = state.freshLabel()
         val handler = state.freshLabel()
         instrs += new instructions.Push(identity[Any] _)
@@ -145,7 +145,7 @@ private [deepembedding] final class Chainr[A, B](p: StrictParsley[A], op: Strict
 }
 private [deepembedding] final class SepEndBy1[A, B](p: StrictParsley[A], sep: StrictParsley[B]) extends StrictParsley[List[A]] {
     def inlinable: Boolean = false
-    override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
+    override def codeGen[Cont[_, +_]: ContOps, R](implicit instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
         val body = state.freshLabel()
         val handler = state.freshLabel()
         instrs += new instructions.Fresh(mutable.ListBuffer.empty[Any])
@@ -168,7 +168,7 @@ private [deepembedding] final class SepEndBy1[A, B](p: StrictParsley[A], sep: St
     // $COVERAGE-ON$
 }
 private [deepembedding] final class ManyUntil[A](val p: StrictParsley[Any]) extends Unary[Any, List[A]] {
-    override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
+    override def codeGen[Cont[_, +_]: ContOps, R](implicit instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
         val start = state.freshLabel()
         val loop = state.freshLabel()
         instrs += new instructions.Fresh(mutable.ListBuffer.empty[Any])

--- a/src/main/scala/parsley/internal/deepembedding/backend/PrimitiveEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/backend/PrimitiveEmbedding.scala
@@ -21,7 +21,7 @@ private [deepembedding] final class Attempt[A](val p: StrictParsley[A]) extends 
     override def handlerLabel(state: CodeGenState): Int  = state.getLabel(instructions.RestoreAndFail)
     override def optimise: StrictParsley[A] = p match {
         case p: CharTok => p
-        case p: Attempt[A] => p
+        case p: Attempt[_] => p
         case StringTok(s) if s.size == 1 => p
         case _ => this
     }

--- a/src/main/scala/parsley/internal/deepembedding/backend/PrimitiveEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/backend/PrimitiveEmbedding.scala
@@ -25,11 +25,17 @@ private [deepembedding] final class Attempt[A](val p: StrictParsley[A]) extends 
         case StringTok(s) if s.size == 1 => p
         case _ => this
     }
+    // $COVERAGE-OFF$
+    final override def pretty(p: String): String = s"attempt($p)"
+    // $COVERAGE-ON$
 }
 private [deepembedding] final class Look[A](val p: StrictParsley[A]) extends ScopedUnaryWithState[A, A](true) {
     override val instr: instructions.Instr = instructions.RestoreHintsAndState
     override def instrNeedsLabel: Boolean = false
     override def handlerLabel(state: CodeGenState): Int  = state.getLabel(instructions.PopStateAndFail)
+    // $COVERAGE-OFF$
+    final override def pretty(p: String): String = s"lookAhead($p)"
+    // $COVERAGE-ON$
 }
 private [deepembedding] final class NotFollowedBy[A](val p: StrictParsley[A]) extends Unary[A, Unit] {
     override def optimise: StrictParsley[Unit] = p match {
@@ -45,6 +51,9 @@ private [deepembedding] final class NotFollowedBy[A](val p: StrictParsley[A]) ex
             instrs += instructions.NegLookGood
         }
     }
+    // $COVERAGE-OFF$
+    final override def pretty(p: String): String = s"notFollowedBy($p)"
+    // $COVERAGE-ON$
 }
 
 private [deepembedding] final class Rec[A](val call: instructions.Call) extends StrictParsley[A] with Binding {
@@ -66,6 +75,9 @@ private [deepembedding] final class Put[S](reg: Reg[S], val p: StrictParsley[S])
         suspend(p.codeGen[Cont, R]) |>
         (instrs += new instructions.Put(reg.addr))
     }
+    // $COVERAGE-OFF$
+    final override def pretty(p: String): String = s"put(r${reg.addr}, $p)"
+    // $COVERAGE-ON$
 }
 
 // $COVERAGE-OFF$
@@ -78,6 +90,9 @@ private [deepembedding] final class Debug[A](val p: StrictParsley[A], name: Stri
             instrs += new instructions.LogEnd(name, ascii, (break eq ExitBreak) || (break eq FullBreak))
         }
     }
+    // $COVERAGE-OFF$
+    final override def pretty(p: String): String = p
+    // $COVERAGE-ON$
 }
 // $COVERAGE-ON$
 

--- a/src/main/scala/parsley/internal/deepembedding/backend/SelectiveEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/backend/SelectiveEmbedding.scala
@@ -19,7 +19,7 @@ private [backend] sealed abstract class BranchLike[A, B, C, D](finaliser: Option
     def instr(label: Int): instructions.Instr
 
     def inlinable: Boolean = false
-    final override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
+    final override def codeGen[Cont[_, +_]: ContOps, R](implicit instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
         val toP = state.freshLabel()
         val end = state.freshLabel()
         suspend(b.codeGen[Cont, R]) >> {
@@ -108,7 +108,7 @@ private [backend] sealed abstract class FilterLike[A](fail: A => StrictParsley[N
         case z: MZero => z
         case _ => this
     }
-    final override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont], instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
+    final override def codeGen[Cont[_, +_]: ContOps, R](implicit instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
         suspend(p.codeGen[Cont, R]) |> (instrs += instr)
     }
 }

--- a/src/main/scala/parsley/internal/deepembedding/backend/SelectiveEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/backend/SelectiveEmbedding.scala
@@ -48,6 +48,14 @@ private [deepembedding] final class Branch[A, B, C](val b: StrictParsley[Either[
             case _ => this
         }
     }
+    // $COVERAGE-OFF$
+    final override def pretty[Cont[_, +_]: ContOps, R]: Cont[R,String] =
+        for {
+            s1 <- b.pretty
+            s2 <- p.pretty
+            s3 <- q.pretty
+        } yield s"branch($s1, $s2, $s3)"
+    // $COVERAGE-ON$
 }
 
 private [deepembedding] final class If[A](val b: StrictParsley[Boolean], val p: StrictParsley[A], val q: StrictParsley[A])
@@ -58,6 +66,14 @@ private [deepembedding] final class If[A](val b: StrictParsley[Boolean], val p: 
         case Pure(false) => q
         case _ => this
     }
+    // $COVERAGE-OFF$
+    final override def pretty[Cont[_, +_]: ContOps, R]: Cont[R,String] =
+        for {
+            s1 <- b.pretty
+            s2 <- p.pretty
+            s3 <- q.pretty
+        } yield s"if($s1, $s2, $s3)"
+    // $COVERAGE-ON$
 }
 
 private [backend] sealed abstract class FastZero[A](fail: A => StrictParsley[Nothing], instr: instructions.Instr) extends Unary[A, Nothing] {
@@ -72,9 +88,17 @@ private [backend] sealed abstract class FastZero[A](fail: A => StrictParsley[Not
     }
 }
 private [deepembedding] final class FastFail[A](val p: StrictParsley[A], msggen: A => String)
-    extends FastZero[A](x => new Fail(msggen(x)), instructions.FastFail(msggen)) with MZero
+    extends FastZero[A](x => new Fail(msggen(x)), instructions.FastFail(msggen)) with MZero {
+    // $COVERAGE-OFF$
+    final override def pretty(p: String): String = s"$p.fail(?)"
+    // $COVERAGE-ON$
+}
 private [deepembedding] final class FastUnexpected[A](val p: StrictParsley[A], msggen: A => String)
-    extends FastZero[A](x => new Unexpected(msggen(x)), new instructions.FastUnexpected(msggen)) with MZero
+    extends FastZero[A](x => new Unexpected(msggen(x)), new instructions.FastUnexpected(msggen)) with MZero {
+    // $COVERAGE-OFF$
+    final override def pretty(p: String): String = s"$p.unexpected(?)"
+    // $COVERAGE-ON$
+}
 
 private [backend] sealed abstract class FilterLike[A](fail: A => StrictParsley[Nothing], instr: instructions.Instr, pred: A => Boolean)
     extends Unary[A, A] {
@@ -89,11 +113,23 @@ private [backend] sealed abstract class FilterLike[A](fail: A => StrictParsley[N
     }
 }
 private [deepembedding] final class Filter[A](val p: StrictParsley[A], pred: A => Boolean)
-    extends FilterLike[A](_ => Empty, new instructions.Filter(pred), !pred(_))
+    extends FilterLike[A](_ => Empty, new instructions.Filter(pred), !pred(_)) {
+    // $COVERAGE-OFF$
+    final override def pretty(p: String): String = s"$p.filter(?)"
+    // $COVERAGE-ON$
+}
 private [deepembedding] final class FilterOut[A](val p: StrictParsley[A], pred: PartialFunction[A, String])
-    extends FilterLike[A](x => ErrorExplain(Empty, pred(x)), new instructions.FilterOut(pred), pred.isDefinedAt(_))
+    extends FilterLike[A](x => ErrorExplain(Empty, pred(x)), new instructions.FilterOut(pred), pred.isDefinedAt(_)) {
+    // $COVERAGE-OFF$
+    final override def pretty(p: String): String = s"$p.filterOut(?)"
+    // $COVERAGE-ON$
+}
 private [deepembedding] final class GuardAgainst[A](val p: StrictParsley[A], pred: PartialFunction[A, scala.Seq[String]])
-    extends FilterLike[A](x => new Fail(pred(x): _*), instructions.GuardAgainst(pred), pred.isDefinedAt(_))
+    extends FilterLike[A](x => new Fail(pred(x): _*), instructions.GuardAgainst(pred), pred.isDefinedAt(_)) {
+    // $COVERAGE-OFF$
+    final override def pretty(p: String): String = s"$p.guardAgainst(?)"
+    // $COVERAGE-ON$
+}
 
 private [backend] object Branch {
     val FlipApp = instructions.Lift2[Any, Any => Any, Any]((x, f) => f(x))

--- a/src/main/scala/parsley/internal/deepembedding/backend/SequenceEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/backend/SequenceEmbedding.scala
@@ -10,9 +10,6 @@ import scala.language.higherKinds
 import parsley.internal.LinkedList, LinkedList.LinkedListIterator
 import parsley.internal.deepembedding.ContOps, ContOps.{result, suspend, ContAdapter}
 import parsley.internal.deepembedding.frontend
-/* SPDX-FileCopyrightText: © 2022 Parsley Contributors <https://github.com/j-mie6/Parsley/graphs/contributors>
- * SPDX-License-Identifier: BSD-3-Clause
- */
 import parsley.internal.deepembedding.singletons._
 import parsley.internal.machine.instructions
 

--- a/src/main/scala/parsley/internal/deepembedding/backend/SequenceEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/backend/SequenceEmbedding.scala
@@ -49,7 +49,7 @@ private [deepembedding] final class <*>[A, B](var left: StrictParsley[A => B], v
         /* RE-ASSOCIATION LAWS */
         // re-association law 1: (q *> left) <*> right = q *> (left <*> right)
         case (q *> uf, ux) => *>(q, <*>(uf, ux).optimise)
-        case (uf, seq: Seq[_, _, A @unchecked]) => seq match {
+        case (uf, seq: Seq[A @unchecked]) => seq match {
             // re-association law 2: left <*> (right <* q) = (left <*> right) <* q
             case ux <* v => <*(<*>(uf, ux).optimise, v).optimise
             // re-association law 3: p *> pure x = pure x <* p
@@ -116,13 +116,13 @@ private [deepembedding] final class >>=[A, B](val p: StrictParsley[A], private [
     // $COVERAGE-ON$
 }
 
-private [deepembedding] final class NormSeq[A](private [backend] var before: DoublyLinkedList[StrictParsley[_]],
-                                               private [backend] var res: StrictParsley[A],
-                                               private [backend] var after: DoublyLinkedList[StrictParsley[_]]) extends StrictParsley[A] {
+private [deepembedding] final class Seq[A](private [backend] var before: DoublyLinkedList[StrictParsley[_]],
+                                           private [backend] var res: StrictParsley[A],
+                                           private [backend] var after: DoublyLinkedList[StrictParsley[_]]) extends StrictParsley[A] {
     def inlinable: Boolean = false
 
     private def mergeIntoRight(p: StrictParsley[A]): this.type = p match {
-        case NormSeq(rs1, rr, rs2) =>
+        case Seq(rs1, rr, rs2) =>
             before.stealAll(rs1)
             // if rr is pure, then rs2 is empty, which retains normalisation
             after = rs2
@@ -131,9 +131,9 @@ private [deepembedding] final class NormSeq[A](private [backend] var before: Dou
         case _ => this
     }
 
-    private def mergeFromRight(p: NormSeq[_], into: DoublyLinkedList[StrictParsley[_]]): this.type = {
+    private def mergeFromRight(p: Seq[_], into: DoublyLinkedList[StrictParsley[_]]): this.type = {
         into.stealAll(p.before)
-        NormSeq.whenNonPure(p.res, into.addOne(_))
+        Seq.whenNonPure(p.res, into.addOne(_))
         into.stealAll(p.after)
         this
     }
@@ -149,17 +149,17 @@ private [deepembedding] final class NormSeq[A](private [backend] var before: Dou
         case (p: MZero) **> _ => p
         case u <** (_: Pure[_]) => u
         case (p: MZero) <** _ => p
-        case u@NormSeq(bs1, br, bs2) **> r =>
+        case u@Seq(bs1, br, bs2) **> r =>
             bs2.lastOption match {
                 case Some(_: MZero) => u
                 case _ =>
                     before = bs1
-                    NormSeq.whenNonPure(br, before.addOne(_))
+                    Seq.whenNonPure(br, before.addOne(_))
                     before.stealAll(bs2)
                     mergeIntoRight(r)
             }
         case _ **> q => mergeIntoRight(q)
-        case u@NormSeq(rs1, rr, rs2) <** p =>
+        case u@Seq(rs1, rr, rs2) <** p =>
             rs2.lastOption match {
                 case Some(_: MZero) => u
                 case _ =>
@@ -168,13 +168,13 @@ private [deepembedding] final class NormSeq[A](private [backend] var before: Dou
                     after = rs2 /*empty when rr is Pure*/
                     val into = chooseInto(rr)
                     p match {
-                        case p: NormSeq[_] => mergeFromRight(p, into)
+                        case p: Seq[_] => mergeFromRight(p, into)
                         case p =>
                             into.addOne(p)
                             this
                     }
             }
-        case r <** (p: NormSeq[_]) => mergeFromRight(p, chooseInto(r))
+        case r <** (p: Seq[_]) => mergeFromRight(p, chooseInto(r))
         // shift pure to the right by swapping before and after (before is empty linked list!)
         case (_: Pure[_]) <** _ =>
             val tmp = before /*empty*/
@@ -190,7 +190,7 @@ private [deepembedding] final class NormSeq[A](private [backend] var before: Dou
             // The pure in question is normalised to the end: if result is pure, after is empty.
             val last = before.last
             before.initInPlace()
-            suspend(NormSeq.codeGenMany[Cont, R](before.iterator)) >> {
+            suspend(Seq.codeGenMany[Cont, R](before.iterator)) >> {
                 last match {
                     case ct@CharTok(c) => result(instrs += instructions.CharTokFastPerform[Char, A](c, _ => x, ct.expected))
                     case st@StringTok(s) => result(instrs += instructions.StringTokFastPerform(s, _ => x, st.expected))
@@ -202,9 +202,9 @@ private [deepembedding] final class NormSeq[A](private [backend] var before: Dou
                 }
             }
         case _ =>
-            suspend(NormSeq.codeGenMany[Cont, R](before.iterator)) >> {
+            suspend(Seq.codeGenMany[Cont, R](before.iterator)) >> {
                 suspend(res.codeGen[Cont, R]) >> {
-                    suspend(NormSeq.codeGenMany(after.iterator))
+                    suspend(Seq.codeGenMany(after.iterator))
                 }
             }
     }
@@ -218,13 +218,13 @@ private [deepembedding] final class NormSeq[A](private [backend] var before: Dou
     // $COVERAGE-ON$
 }
 
-object NormSeq {
+object Seq {
 
-    private [backend] def unapply[A](self: NormSeq[A]): Some[(DoublyLinkedList[StrictParsley[_]], StrictParsley[A], DoublyLinkedList[StrictParsley[_]])] = {
+    private [backend] def unapply[A](self: Seq[A]): Some[(DoublyLinkedList[StrictParsley[_]], StrictParsley[A], DoublyLinkedList[StrictParsley[_]])] = {
         Some((self.before, self.res, self.after))
     }
 
-    private [NormSeq] def codeGenMany[Cont[_, +_]: ContOps, R](it: Iterator[StrictParsley[_]])
+    private [Seq] def codeGenMany[Cont[_, +_]: ContOps, R](it: Iterator[StrictParsley[_]])
                                                               (implicit instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
         if (it.hasNext) {
             suspend(it.next().codeGen[Cont, R]) >> {
@@ -234,129 +234,10 @@ object NormSeq {
         } else result(())
     }
 
-    private [NormSeq] def whenNonPure(p: StrictParsley[_], f: StrictParsley[_] => Unit): Unit = p match {
+    private [Seq] def whenNonPure(p: StrictParsley[_], f: StrictParsley[_] => Unit): Unit = p match {
         case _: Pure[_] =>
         case p          => f(p)
     }
-}
-
-private [backend] sealed abstract class Seq[A, B, Res] extends StrictParsley[Res] {
-    def result: StrictParsley[Res]
-    def discard: StrictParsley[_]
-    def result_=(p: StrictParsley[Res]): Unit
-    def discard_=(p: StrictParsley[_]): Unit
-    def inlinable: Boolean = false
-    // The type parameter R here is for /some/ reason necessary because Scala can't infer that Res =:= Char/String in `optimiseStringResult`...
-    private def buildResult[R](s: String, r: R, ex1: Option[String], ex2: Option[String]) = {
-        makeSeq(new StringTok(s, if (ex1.nonEmpty) ex1 else ex2), new Pure(r.asInstanceOf[Res]))
-    }
-    private def optimiseStringResult(s: String, ex: Option[String]): StrictParsley[Res] = result match {
-        case ct@CharTok(c) => buildResult(combineSeq(s, c.toString), c, ex, ct.expected)
-        case st@StringTok(t) => buildResult(combineSeq(s, t), t, ex, st.expected)
-    }
-    protected def makeSeq(str: StrictParsley[String], res: Pure[Res]): StrictParsley[Res]
-    protected def combineSeq(sdis: String, sres: String): String
-    final protected def optimiseSeq: Option[StrictParsley[Res]] = discard match {
-        // pure _ *> p = p = p <* pure _
-        case _: Pure[_] => Some(result)
-        // p *> pure _ *> q = p *> q, p <* (q *> pure _) = p <* q
-        case u *> (_: Pure[_]) =>
-            discard = u
-            Some(this.optimise.asInstanceOf[StrictParsley[Res]])
-        case ct@CharTok(c) if result.isInstanceOf[CharTok] || result.isInstanceOf[StringTok] => Some(this.optimiseStringResult(c.toString, ct.expected))
-        case st@StringTok(s) if result.isInstanceOf[CharTok] || result.isInstanceOf[StringTok] => Some(this.optimiseStringResult(s, st.expected))
-        case _ => None
-    }
-    final protected def codeGenSeq[Cont[_, +_]: ContOps, R](default: =>Cont[R, Unit])(implicit instrs: InstrBuffer,
-                                                                                               state: CodeGenState): Cont[R, Unit] = (result, discard) match {
-        case (Pure(x), ct@CharTok(c)) => ContOps.result(instrs += instructions.CharTokFastPerform[Char, Res](c, _ => x, ct.expected))
-        case (Pure(x), st@StringTok(s)) => ContOps.result(instrs += instructions.StringTokFastPerform(s, _ => x, st.expected))
-        case (Pure(x), st@Satisfy(f)) => ContOps.result(instrs += new instructions.SatisfyExchange(f, x, st.expected))
-        case (Pure(x), v) =>
-            suspend(v.codeGen[Cont, R]) |>
-            (instrs += new instructions.Exchange(x))
-        case _ => default
-    }
-}
-private [deepembedding] final class *>[A](var left: StrictParsley[Any], var right: StrictParsley[A]) extends Seq[Any, A, A] {
-    override def result: StrictParsley[A] = right
-    override def discard: StrictParsley[_] = left
-    override def result_=(p: StrictParsley[A]): Unit = right = p
-    override def discard_=(p: StrictParsley[_]): Unit = left = p
-    def makeSeq(str: StrictParsley[String], res: Pure[A]): StrictParsley[A] = {
-        discard = str
-        result = res
-        optimise
-    }
-    def combineSeq(sdis: String, sres: String): String = sdis + sres
-    override def optimise: StrictParsley[A] = optimiseSeq match {
-        case Some(p) => p
-        case None => discard match {
-            // mzero *> p = mzero (left zero and definition of *> in terms of >>=)
-            case z: MZero => z
-            case u => result match {
-                // re-association - normal form of Then chain is to have result at the top of tree
-                case v *> w =>
-                    discard = new *>(u, v).optimiseDefinitelyNotTailRec
-                    result = w
-                    optimise
-                case _ => this
-            }
-        }
-    }
-    override def codeGen[Cont[_, +_]: ContOps, R](implicit instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = codeGenSeq {
-        suspend(discard.codeGen[Cont, R]) >> {
-            instrs += instructions.Pop
-            suspend(result.codeGen[Cont, R])
-        }
-    }
-    // $COVERAGE-OFF$
-    final override def pretty[Cont[_, +_]: ContOps, R]: Cont[R,String] =
-        for {
-            s1 <- left.pretty
-            s2 <- right.pretty
-        } yield s"($s1 *> $s2)"
-    // $COVERAGE-ON$
-}
-private [deepembedding] final class <*[A](var left: StrictParsley[A], var right: StrictParsley[Any]) extends Seq[A, Any, A] {
-    override def result: StrictParsley[A] = left
-    override def discard: StrictParsley[_] = right
-    override def result_=(p: StrictParsley[A]): Unit = left = p
-    override def discard_=(p: StrictParsley[_]): Unit = right = p
-
-    def makeSeq(str: StrictParsley[String], res: Pure[A]): StrictParsley[A] = *>(str, res)
-    def combineSeq(sdis: String, sres: String): String = sres + sdis
-    override def optimise: StrictParsley[A] = optimiseSeq match {
-        case Some(p) => p
-        case None => discard match {
-            // p <* mzero = p *> mzero (by preservation of error messages and failure properties) - This moves the pop instruction after the failure
-            case z: MZero => *>(result, z)
-            case w => result match {
-                // re-association law 3: pure x <* p = p *> pure x
-                case u: Pure[_] => *>(w, u).optimise
-                // mzero <* p = mzero (left zero law and definition of <* in terms of >>=)
-                case z: MZero => z
-                // re-association - normal form of Prev chain is to have result at the top of tree
-                case u <* v =>
-                    result = u
-                    discard = new <*(v, w).optimiseDefinitelyNotTailRec
-                    optimise
-                case _ => this
-            }
-        }
-    }
-    override def codeGen[Cont[_, +_]: ContOps, R](implicit instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = codeGenSeq {
-        suspend(result.codeGen[Cont, R]) >>
-        suspend(discard.codeGen[Cont, R]) |>
-        (instrs += instructions.Pop)
-    }
-    // $COVERAGE-OFF$
-    final override def pretty[Cont[_, +_]: ContOps, R]: Cont[R,String] =
-        for {
-            s1 <- left.pretty
-            s2 <- right.pretty
-        } yield s"($s1 <* $s2)"
-    // $COVERAGE-ON$
 }
 
 private [backend] object <*> {
@@ -367,38 +248,41 @@ private [backend] object >>= {
     def apply[A, B](p: StrictParsley[A], f: A => frontend.LazyParsley[B]): >>=[A, B] = new >>=(p, f)
     def unapply[A, B](self: >>=[A, B]): Some[(StrictParsley[A], A => frontend.LazyParsley[B])] = Some((self.p, self.f))
 }
-private [backend] object Seq {
-    def unapply[A, B, Res](self: Seq[A, B, Res]): Some[(StrictParsley[_], StrictParsley[Res])] = Some((self.discard, self.result))
-}
 private [deepembedding] object *> {
-    //def apply[A](left: StrictParsley[_], right: StrictParsley[A]): *>[A] = new *>(left, right)
-    def apply[A](left: StrictParsley[_], right: StrictParsley[A]): NormSeq[A] = {
+    def apply[A](left: StrictParsley[_], right: StrictParsley[A]): Seq[A] = {
         val before = DoublyLinkedList.empty[StrictParsley[_]]
         before.addOne(left)
-        new NormSeq(before, right, DoublyLinkedList.empty)
+        *>(before, right)
     }
-    private [backend] def unapply[A](self: *>[A]): Some[(StrictParsley[_], StrictParsley[A])] = Some((self.discard, self.result))
+    private [backend] def unapply[A](self: Seq[A]): Option[(DoublyLinkedList[StrictParsley[_]], StrictParsley[A])] = {
+        if (self.after.isEmpty) Some((self.before, self.res))
+        else None
+    }
+    private [backend] def apply[A](before: DoublyLinkedList[StrictParsley[_]], res: StrictParsley[A]): Seq[A] = new Seq(before, res, DoublyLinkedList.empty)
 }
 private [backend] object **> {
-    private [backend] def unapply[A](self: NormSeq[A]): Option[(StrictParsley[_], StrictParsley[A])] = {
-        if (self.before.size == 1) Some((self.before.head, self.res))
+    private [backend] def unapply[A](self: Seq[A]): Option[(StrictParsley[_], StrictParsley[A])] = {
+        if (self.before.size == 1 && self.after.isEmpty) Some((self.before.head, self.res))
         else None
     }
 }
 
 private [deepembedding]  object <* {
-    //def apply[A](left: StrictParsley[A], right: StrictParsley[_]): <*[A] = new <*(left, right)
-    def apply[A](left: StrictParsley[A], right: StrictParsley[_]): NormSeq[A] = {
+    def apply[A](left: StrictParsley[A], right: StrictParsley[_]): Seq[A] = {
         val after = DoublyLinkedList.empty[StrictParsley[_]]
         after.addOne(right)
-        new NormSeq(DoublyLinkedList.empty, left, after)
+        <*(left, after)
     }
-    private [backend] def unapply[A](self: <*[A]): Some[(StrictParsley[A], StrictParsley[_])] = Some((self.result, self.discard))
+    private [backend] def unapply[A](self: Seq[A]): Option[(StrictParsley[A], DoublyLinkedList[StrictParsley[_]])] = {
+        if (self.before.isEmpty) Some((self.res, self.after))
+        else None
+    }
+    private [backend] def apply[A](res: StrictParsley[A], after: DoublyLinkedList[StrictParsley[_]]): Seq[A] = new Seq(DoublyLinkedList.empty, res, after)
 }
 
 private [backend] object <** {
-    private [backend] def unapply[A](self: NormSeq[A]): Option[(StrictParsley[A], StrictParsley[_])] = {
-        if (self.after.size == 1) Some((self.res, self.after.head))
+    private [backend] def unapply[A](self: Seq[A]): Option[(StrictParsley[A], StrictParsley[_])] = {
+        if (self.after.size == 1 && self.before.isEmpty) Some((self.res, self.after.head))
         else None
     }
 }

--- a/src/main/scala/parsley/internal/deepembedding/backend/SequenceEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/backend/SequenceEmbedding.scala
@@ -219,13 +219,12 @@ private [deepembedding] final class Seq[A](private [backend] var before: DoublyL
 }
 
 object Seq {
-
     private [backend] def unapply[A](self: Seq[A]): Some[(DoublyLinkedList[StrictParsley[_]], StrictParsley[A], DoublyLinkedList[StrictParsley[_]])] = {
         Some((self.before, self.res, self.after))
     }
 
     private [Seq] def codeGenMany[Cont[_, +_]: ContOps, R](it: Iterator[StrictParsley[_]])
-                                                              (implicit instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
+                                                          (implicit instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
         if (it.hasNext) {
             suspend(it.next().codeGen[Cont, R]) >> {
                 instrs += instructions.Pop
@@ -254,11 +253,11 @@ private [deepembedding] object *> {
         before.addOne(left)
         *>(before, right)
     }
+    private [backend] def apply[A](before: DoublyLinkedList[StrictParsley[_]], res: StrictParsley[A]): Seq[A] = new Seq(before, res, DoublyLinkedList.empty)
     private [backend] def unapply[A](self: Seq[A]): Option[(DoublyLinkedList[StrictParsley[_]], StrictParsley[A])] = {
         if (self.after.isEmpty) Some((self.before, self.res))
         else None
     }
-    private [backend] def apply[A](before: DoublyLinkedList[StrictParsley[_]], res: StrictParsley[A]): Seq[A] = new Seq(before, res, DoublyLinkedList.empty)
 }
 private [backend] object **> {
     private [backend] def unapply[A](self: Seq[A]): Option[(StrictParsley[_], StrictParsley[A])] = *>.unapply(self).collect {
@@ -272,11 +271,11 @@ private [deepembedding]  object <* {
         after.addOne(right)
         <*(left, after)
     }
+    private [backend] def apply[A](res: StrictParsley[A], after: DoublyLinkedList[StrictParsley[_]]): Seq[A] = new Seq(DoublyLinkedList.empty, res, after)
     private [backend] def unapply[A](self: Seq[A]): Option[(StrictParsley[A], DoublyLinkedList[StrictParsley[_]])] = {
         if (self.before.isEmpty) Some((self.res, self.after))
         else None
     }
-    private [backend] def apply[A](res: StrictParsley[A], after: DoublyLinkedList[StrictParsley[_]]): Seq[A] = new Seq(DoublyLinkedList.empty, res, after)
 }
 
 private [backend] object <** {

--- a/src/main/scala/parsley/internal/deepembedding/backend/SequenceEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/backend/SequenceEmbedding.scala
@@ -261,9 +261,8 @@ private [deepembedding] object *> {
     private [backend] def apply[A](before: DoublyLinkedList[StrictParsley[_]], res: StrictParsley[A]): Seq[A] = new Seq(before, res, DoublyLinkedList.empty)
 }
 private [backend] object **> {
-    private [backend] def unapply[A](self: Seq[A]): Option[(StrictParsley[_], StrictParsley[A])] = {
-        if (self.before.size == 1 && self.after.isEmpty) Some((self.before.head, self.res))
-        else None
+    private [backend] def unapply[A](self: Seq[A]): Option[(StrictParsley[_], StrictParsley[A])] = *>.unapply(self).collect {
+        case (before, res) if self.before.size == 1 => (before.head, res)
     }
 }
 
@@ -281,8 +280,7 @@ private [deepembedding]  object <* {
 }
 
 private [backend] object <** {
-    private [backend] def unapply[A](self: Seq[A]): Option[(StrictParsley[A], StrictParsley[_])] = {
-        if (self.after.size == 1 && self.before.isEmpty) Some((self.res, self.after.head))
-        else None
+    private [backend] def unapply[A](self: Seq[A]): Option[(StrictParsley[A], StrictParsley[_])] = <*.unapply(self).collect {
+        case (res, after) if after.size == 1 => (res, after.head)
     }
 }

--- a/src/main/scala/parsley/internal/deepembedding/backend/StrictParsley.scala
+++ b/src/main/scala/parsley/internal/deepembedding/backend/StrictParsley.scala
@@ -52,7 +52,9 @@ private [deepembedding] trait StrictParsley[+A] {
     // Peephole optimisation and code generation - Top-down
     private [backend] def codeGen[Cont[_, +_]: ContOps, R](implicit instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit]
 
-    private [deepembedding] def pretty[Cont[_, +_]: ContOps, R]() = ???
+    // $COVERAGE-OFF$
+    private [deepembedding] def pretty[Cont[_, +_]: ContOps, R]: Cont[R, String]
+    // $COVERAGE-ON$
 }
 
 private [deepembedding] object StrictParsley {
@@ -158,12 +160,16 @@ private [deepembedding] object StrictParsley {
     }
 }
 
-private [backend] trait Binding {
+private [backend] trait Binding { self: StrictParsley[_] =>
     // When these are used by tco, the call instructions labels have already been shifted, but lets have not
     final def location(labelMap: Array[Int])(implicit state: CodeGenState): Int = this match {
         case self: Rec[_] => self.label
         case self: Let[_] => labelMap(self.label)
     }
+
+    // $COVERAGE-OFF$
+    def pretty[Cont[_, +_]: ContOps, R]: Cont[R, String] = result(this.toString())
+    // $COVERAGE-ON$
 }
 private [deepembedding] trait MZero extends StrictParsley[Nothing]
 

--- a/src/main/scala/parsley/internal/deepembedding/frontend/AlternativeEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/frontend/AlternativeEmbedding.scala
@@ -14,5 +14,5 @@ private [parsley] final class <|>[A](p: LazyParsley[A], q: =>LazyParsley[A]) ext
     // $COVERAGE-OFF$
     override def pretty(l: String, r: String): String = s"($l <|> $r)"
     // $COVERAGE-ON$
-    override def make(p: StrictParsley[A], q: StrictParsley[A]): StrictParsley[A] = new backend.<|>(p, q)
+    override def make(p: StrictParsley[A], q: StrictParsley[A]): StrictParsley[A] = backend.<|>(p, q)
 }

--- a/src/main/scala/parsley/internal/deepembedding/frontend/AlternativeEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/frontend/AlternativeEmbedding.scala
@@ -11,8 +11,5 @@ import parsley.internal.deepembedding.backend, backend.StrictParsley
 import parsley.internal.errors.{Desc, ErrorItem, Raw}
 
 private [parsley] final class <|>[A](p: LazyParsley[A], q: =>LazyParsley[A]) extends Binary[A, A, A](p, q) {
-    // $COVERAGE-OFF$
-    override def pretty(l: String, r: String): String = s"($l <|> $r)"
-    // $COVERAGE-ON$
     override def make(p: StrictParsley[A], q: StrictParsley[A]): StrictParsley[A] = backend.<|>(p, q)
 }

--- a/src/main/scala/parsley/internal/deepembedding/frontend/ErrorEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/frontend/ErrorEmbedding.scala
@@ -5,28 +5,16 @@ package parsley.internal.deepembedding.frontend
 
 import parsley.internal.deepembedding.backend, backend.StrictParsley
 
-private [parsley] final class ErrorLabel[A](p: LazyParsley[A], private [ErrorLabel] val label: String) extends ScopedUnary[A, A](p) {
-    // $COVERAGE-OFF$
-    override def name: String = s"label($label)"
-    // $COVERAGE-ON$
+private [parsley] final class ErrorLabel[A](p: LazyParsley[A], private [ErrorLabel] val label: String) extends Unary[A, A](p) {
     override def make(p: StrictParsley[A]): StrictParsley[A] = new backend.ErrorLabel(p, label)
 }
-private [parsley] final class ErrorExplain[A](p: LazyParsley[A], reason: String) extends ScopedUnary[A, A](p) {
-    // $COVERAGE-OFF$
-    override def name: String = s"explain($reason)"
-    // $COVERAGE-ON$
+private [parsley] final class ErrorExplain[A](p: LazyParsley[A], reason: String) extends Unary[A, A](p) {
     override def make(p: StrictParsley[A]): StrictParsley[A] = new backend.ErrorExplain(p, reason)
 }
 
-private [parsley] final class ErrorAmend[A](p: LazyParsley[A]) extends ScopedUnary[A, A](p) {
-    // $COVERAGE-OFF$
-    override val name: String = "amend"
-    // $COVERAGE-ON$
+private [parsley] final class ErrorAmend[A](p: LazyParsley[A]) extends Unary[A, A](p) {
     override def make(p: StrictParsley[A]): StrictParsley[A] = new backend.ErrorAmend(p)
 }
-private [parsley] final class ErrorEntrench[A](p: LazyParsley[A]) extends ScopedUnary[A, A](p) {
-    // $COVERAGE-OFF$
-    override val name: String = "entrench"
-    // $COVERAGE-ON$
+private [parsley] final class ErrorEntrench[A](p: LazyParsley[A]) extends Unary[A, A](p) {
     override def make(p: StrictParsley[A]): StrictParsley[A] = new backend.ErrorEntrench(p)
 }

--- a/src/main/scala/parsley/internal/deepembedding/frontend/GeneralisedEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/frontend/GeneralisedEmbedding.scala
@@ -10,69 +10,42 @@ import parsley.internal.deepembedding.backend, backend.StrictParsley
 
 // Core Embedding
 private [frontend] abstract class Unary[A, B](p: LazyParsley[A]) extends LazyParsley[B] {
-    def pretty(p: String): String
     def make(p: StrictParsley[A]): StrictParsley[B]
 
-    final override def findLetsAux[Cont[_, +_], R](seen: Set[LazyParsley[_]])(implicit ops: ContOps[Cont], state: LetFinderState): Cont[R,Unit] =
+    final override def findLetsAux[Cont[_, +_]: ContOps, R](seen: Set[LazyParsley[_]])(implicit state: LetFinderState): Cont[R,Unit] =
         suspend(p.findLets(seen))
-    override def preprocess[Cont[_, +_], R, B_ >: B](implicit ops: ContOps[Cont], lets: LetMap, recs: RecMap): Cont[R, StrictParsley[B_]] =
+    override def preprocess[Cont[_, +_]: ContOps, R, B_ >: B](implicit lets: LetMap, recs: RecMap): Cont[R, StrictParsley[B_]] =
         for (p <- suspend(p.optimised[Cont, R, A])) yield make(p)
-    // $COVERAGE-OFF$
-    final override def prettyASTAux[Cont[_, +_]](implicit ops: ContOps[Cont]): Cont[String, String] = for (c <- suspend(p.prettyASTAux)) yield pretty(c)
-    // $COVERAGE-ON$
-}
-
-private [frontend] abstract class ScopedUnary[A, B](p: LazyParsley[A]) extends Unary[A, B](p) {
-    def name: String
-    final def pretty(c: String): String = s"$name($c)"
 }
 
 private [frontend] abstract class Binary[A, B, C](left: LazyParsley[A], _right: =>LazyParsley[B]) extends LazyParsley[C] {
     private lazy val right = _right
 
-    def pretty(p: String, q: String): String
     def make(p: StrictParsley[A], q: StrictParsley[B]): StrictParsley[C]
 
-    final override def findLetsAux[Cont[_, +_], R](seen: Set[LazyParsley[_]])(implicit ops: ContOps[Cont], state: LetFinderState): Cont[R,Unit] = {
+    final override def findLetsAux[Cont[_, +_]: ContOps, R](seen: Set[LazyParsley[_]])(implicit state: LetFinderState): Cont[R,Unit] = {
         suspend(left.findLets[Cont, R](seen)) >> suspend(right.findLets(seen))
     }
-    final override def preprocess[Cont[_, +_], R, C_ >: C](implicit ops: ContOps[Cont], lets: LetMap, recs: RecMap): Cont[R, StrictParsley[C_]] =
+    final override def preprocess[Cont[_, +_]: ContOps, R, C_ >: C](implicit lets: LetMap, recs: RecMap): Cont[R, StrictParsley[C_]] =
         for {
             left <- suspend(left.optimised[Cont, R, A])
             right <- suspend(right.optimised[Cont, R, B])
         } yield make(left, right)
-    // $COVERAGE-OFF$
-    final override def prettyASTAux[Cont[_, +_]](implicit ops: ContOps[Cont]): Cont[String, String] = {
-        for {
-            l <- suspend(left.prettyASTAux)
-            r <- suspend(right.prettyASTAux)
-        } yield pretty(l, r)
-    }
-    // $COVERAGE-ON$
 }
 
 private [frontend] abstract class Ternary[A, B, C, D](first: LazyParsley[A], _second: =>LazyParsley[B], _third: =>LazyParsley[C]) extends LazyParsley[D] {
     private lazy val second: LazyParsley[B] = _second
     private lazy val third: LazyParsley[C] = _third
 
-    def pretty(p: String, q: String, r: String): String
     def make(p: StrictParsley[A], q: StrictParsley[B], r: StrictParsley[C]): StrictParsley[D]
 
-    final override def findLetsAux[Cont[_, +_], R](seen: Set[LazyParsley[_]])(implicit ops: ContOps[Cont], state: LetFinderState): Cont[R, Unit] = {
+    final override def findLetsAux[Cont[_, +_]: ContOps, R](seen: Set[LazyParsley[_]])(implicit state: LetFinderState): Cont[R, Unit] = {
         suspend(first.findLets[Cont, R](seen)) >> suspend(second.findLets(seen)) >> suspend(third.findLets(seen))
     }
-    final override def preprocess[Cont[_, +_], R, D_ >: D](implicit ops: ContOps[Cont], lets: LetMap, recs: RecMap): Cont[R, StrictParsley[D_]] =
+    final override def preprocess[Cont[_, +_]: ContOps, R, D_ >: D](implicit lets: LetMap, recs: RecMap): Cont[R, StrictParsley[D_]] =
         for {
             first <- suspend(first.optimised[Cont, R, A])
             second <- suspend(second.optimised[Cont, R, B])
             third <- suspend(third.optimised[Cont, R, C])
         } yield make(first, second, third)
-    // $COVERAGE-OFF$
-    final override def prettyASTAux[Cont[_, +_]](implicit ops: ContOps[Cont]): Cont[String, String] =
-        for {
-            f <- suspend(first.prettyASTAux)
-            s <- suspend(second.prettyASTAux)
-            t <- suspend(third.prettyASTAux)
-        } yield pretty(f, s, t)
-    // $COVERAGE-ON$
 }

--- a/src/main/scala/parsley/internal/deepembedding/frontend/IntrinsicEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/frontend/IntrinsicEmbedding.scala
@@ -10,21 +10,12 @@ import parsley.registers.Reg
 import parsley.internal.deepembedding.backend, backend.StrictParsley
 
 private [parsley] final class Lift2[A, B, C](private [Lift2] val f: (A, B) => C, p: LazyParsley[A], q: =>LazyParsley[B]) extends Binary[A, B, C](p, q) {
-    // $COVERAGE-OFF$
-    override def pretty(l: String, r: String): String = s"lift2(f, $l, $r)"
-    // $COVERAGE-ON$
     override def make(p: StrictParsley[A], q: StrictParsley[B]): StrictParsley[C] = new backend.Lift2(f, p, q)
 }
 private [parsley] final class Lift3[A, B, C, D](private [Lift3] val f: (A, B, C) => D, p: LazyParsley[A], q: =>LazyParsley[B], r: =>LazyParsley[C])
     extends Ternary[A, B, C, D](p, q, r) {
-    // $COVERAGE-OFF$
-    override def pretty(f: String, s: String, t: String): String = s"lift3(f, $f, $s, $t)"
-    // $COVERAGE-ON$
     override def make(p: StrictParsley[A], q: StrictParsley[B], r: StrictParsley[C]): StrictParsley[D] = new backend.Lift3(f, p, q, r)
 }
 private [parsley] final class Local[S, A](val reg: Reg[S], p: LazyParsley[S], q: =>LazyParsley[A]) extends Binary[S, A, A](p, q) with UsesRegister {
-    // $COVERAGE-OFF$
-    override def pretty(l: String, r: String): String = s"local($reg, $l, $r)"
-    // $COVERAGE-ON$
     override def make(p: StrictParsley[S], q: StrictParsley[A]): StrictParsley[A] = new backend.Local(reg, p, q)
 }

--- a/src/main/scala/parsley/internal/deepembedding/frontend/IterativeEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/frontend/IterativeEmbedding.scala
@@ -10,62 +10,36 @@ import scala.language.higherKinds
 import parsley.internal.deepembedding.ContOps, ContOps.{result, suspend, ContAdapter}
 import parsley.internal.deepembedding.backend, backend.StrictParsley
 
-private [parsley] final class Many[A](p: LazyParsley[A]) extends ScopedUnary[A, List[A]](p) {
-    // $COVERAGE-OFF$
-    override val name: String = "many"
+private [parsley] final class Many[A](p: LazyParsley[A]) extends Unary[A, List[A]](p) {
     override def make(p: StrictParsley[A]): StrictParsley[List[A]] = new backend.Many(p)
 }
-private [parsley] final class SkipMany[A](p: LazyParsley[A]) extends ScopedUnary[A, Unit](p) {
-    // $COVERAGE-OFF$
-    override val name: String = "skipMany"
+private [parsley] final class SkipMany[A](p: LazyParsley[A]) extends Unary[A, Unit](p) {
     override def make(p: StrictParsley[A]): StrictParsley[Unit] = new backend.SkipMany(p)
 }
 private [parsley] final class ChainPost[A](p: LazyParsley[A], _op: =>LazyParsley[A => A]) extends Binary[A, A => A, A](p, _op) {
-    // $COVERAGE-OFF$
-    override def pretty(l: String, r: String): String = s"chainPost($l, $r)"
     override def make(p: StrictParsley[A], op: StrictParsley[A => A]): StrictParsley[A] = new backend.ChainPost(p, op)
 }
 private [parsley] final class ChainPre[A](p: LazyParsley[A], op: LazyParsley[A => A]) extends LazyParsley[A] {
-    final override def findLetsAux[Cont[_, +_], R](seen: Set[LazyParsley[_]])(implicit ops: ContOps[Cont], state: LetFinderState): Cont[R, Unit] = {
+    final override def findLetsAux[Cont[_, +_]: ContOps, R](seen: Set[LazyParsley[_]])(implicit state: LetFinderState): Cont[R, Unit] = {
         suspend(p.findLets[Cont, R](seen)) >> suspend(op.findLets(seen))
     }
-    final override def preprocess[Cont[_, +_], R, A_ >: A](implicit ops: ContOps[Cont], lets: LetMap, recs: RecMap): Cont[R, StrictParsley[A_]] =
+    final override def preprocess[Cont[_, +_]: ContOps, R, A_ >: A](implicit lets: LetMap, recs: RecMap): Cont[R, StrictParsley[A_]] =
         for {
             p <- suspend(p.optimised[Cont, R, A])
             op <- suspend(op.optimised[Cont, R, A => A])
         } yield new backend.ChainPre(p, op)
-    // $COVERAGE-OFF$
-    final override def prettyASTAux[Cont[_, +_]](implicit ops: ContOps[Cont]): Cont[String, String] = {
-        for {
-            p <- suspend(p.prettyASTAux)
-            op <- suspend(op.prettyASTAux)
-        } yield s"chainPre($p, $op)"
-    }
-    // $COVERAGE-ON$
 }
 private [parsley] final class Chainl[A, B](init: LazyParsley[B], p: =>LazyParsley[A], op: =>LazyParsley[(B, A) => B])
     extends Ternary[B, A, (B, A) => B, B](init, p, op) {
-    // $COVERAGE-OFF$
-    override def pretty(f: String, s: String, t: String): String = s"chainl1($s, $t)"
-    // $COVERAGE-ON$
     override def make(init: StrictParsley[B], p: StrictParsley[A], op: StrictParsley[(B, A) => B]): StrictParsley[B] = new backend.Chainl(init, p, op)
 }
 private [parsley] final class Chainr[A, B](p: LazyParsley[A], op: =>LazyParsley[(A, B) => B], private [Chainr] val wrap: A => B)
     extends Binary[A, (A, B) => B, B](p, op)  {
-    // $COVERAGE-OFF$
-    override def pretty(l: String, r: String): String = s"chainl1($l, $r)"
-    // $COVERAGE-ON$
     override def make(p: StrictParsley[A], op: StrictParsley[(A, B) => B]): StrictParsley[B] = new backend.Chainr(p, op, wrap)
 }
 private [parsley] final class SepEndBy1[A, B](p: LazyParsley[A], sep: =>LazyParsley[B]) extends Binary[A, B, List[A]](p, sep) {
-    // $COVERAGE-OFF$
-    override def pretty(l: String, r: String): String = s"sepEndBy1($r, $l)"
-    // $COVERAGE-ON$
     override def make(p: StrictParsley[A], sep: StrictParsley[B]): StrictParsley[List[A]] = new backend.SepEndBy1(p, sep)
 }
 private [parsley] final class ManyUntil[A](body: LazyParsley[Any]) extends Unary[Any, List[A]](body) {
-    // $COVERAGE-OFF$
-    override def pretty(c: String): String = s"manyUntil($c)"
-    // $COVERAGE-ON$
     override def make(p: StrictParsley[Any]): StrictParsley[List[A]] = new backend.ManyUntil(p)
 }

--- a/src/main/scala/parsley/internal/deepembedding/frontend/PrimitiveEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/frontend/PrimitiveEmbedding.scala
@@ -13,35 +13,20 @@ import parsley.registers.Reg
 import parsley.internal.deepembedding.backend, backend.StrictParsley
 import parsley.internal.machine.instructions
 
-private [parsley] final class Attempt[A](p: LazyParsley[A]) extends ScopedUnary[A, A](p) {
-    // $COVERAGE-OFF$
-    override val name: String = "attempt"
-    // $COVERAGE-ON$
+private [parsley] final class Attempt[A](p: LazyParsley[A]) extends Unary[A, A](p) {
     override def make(p: StrictParsley[A]): StrictParsley[A] = new backend.Attempt(p)
 }
-private [parsley] final class Look[A](p: LazyParsley[A]) extends ScopedUnary[A, A](p) {
-    // $COVERAGE-OFF$
-    override val name: String = "lookAhead"
-    // $COVERAGE-ON$
+private [parsley] final class Look[A](p: LazyParsley[A]) extends Unary[A, A](p) {
     override def make(p: StrictParsley[A]): StrictParsley[A] = new backend.Look(p)
 }
-private [parsley] final class NotFollowedBy[A](p: LazyParsley[A]) extends ScopedUnary[A, Unit](p) {
-    // $COVERAGE-OFF$
-    override val name: String = "notFollowedBy"
-    // $COVERAGE-ON$
+private [parsley] final class NotFollowedBy[A](p: LazyParsley[A]) extends Unary[A, Unit](p) {
     override def make(p: StrictParsley[A]): StrictParsley[Unit] = new backend.NotFollowedBy(p)
 }
 private [parsley] final class Put[S](val reg: Reg[S], _p: LazyParsley[S]) extends Unary[S, Unit](_p) with UsesRegister {
-    // $COVERAGE-OFF$
-    def pretty(c: String): String = s"put($reg, $c)"
-    // $COVERAGE-ON$
     override def make(p: StrictParsley[S]): StrictParsley[Unit] = new backend.Put(reg, p)
 }
 // $COVERAGE-OFF$
 private [parsley] final class Debug[A](p: LazyParsley[A], name: String, ascii: Boolean, break: Breakpoint) extends Unary[A, A](p) {
-    // $COVERAGE-OFF$
-    def pretty(p: String): String = p
-    // $COVERAGE-ON$
     override def make(p: StrictParsley[A]): StrictParsley[A] = new backend.Debug(p, name, ascii, break)
 }
 // $COVERAGE-ON$

--- a/src/main/scala/parsley/internal/deepembedding/frontend/SelectiveEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/frontend/SelectiveEmbedding.scala
@@ -9,47 +9,26 @@ import parsley.internal.deepembedding.backend, backend.StrictParsley
 
 private [parsley] final class Branch[A, B, C](b: LazyParsley[Either[A, B]], p: =>LazyParsley[A => C], q: =>LazyParsley[B => C])
     extends Ternary[Either[A, B], A => C, B => C, C](b, p, q) {
-    // $COVERAGE-OFF$
-    override def pretty(f: String, s: String, t: String): String = s"branch($f, $s, $t)"
-    // $COVERAGE-ON$
     override def make(b: StrictParsley[Either[A, B]], p: StrictParsley[A => C], q: StrictParsley[B => C]): StrictParsley[C] = new backend.Branch(b, p, q)
 }
 
 private [parsley] final class If[A](b: LazyParsley[Boolean], p: =>LazyParsley[A], q: =>LazyParsley[A]) extends Ternary[Boolean, A, A, A](b, p, q) {
-    // $COVERAGE-OFF$
-    override def pretty(f: String, s: String, t: String): String = s"($f ? $s : $t)"
-    // $COVERAGE-ON$
     override def make(b: StrictParsley[Boolean], p: StrictParsley[A], q: StrictParsley[A]): StrictParsley[A] = new backend.If(b, p, q)
 }
 
 private [parsley] final class FastFail[A](p: LazyParsley[A], msggen: A => String) extends Unary[A, Nothing](p) {
-    // $COVERAGE-OFF$
-    override def pretty(c: String): String = s"$c ! ?"
-    // $COVERAGE-ON$
     override def make(p: StrictParsley[A]): StrictParsley[Nothing] = new backend.FastFail(p, msggen)
 }
 private [parsley] final class FastUnexpected[A](p: LazyParsley[A], msggen: A => String) extends Unary[A, Nothing](p) {
-    // $COVERAGE-OFF$
-    override def pretty(c: String): String = s"$c.unexpected(?)"
-    // $COVERAGE-ON$
     override def make(p: StrictParsley[A]): StrictParsley[Nothing] = new backend.FastUnexpected(p, msggen)
 }
 
 private [parsley] final class Filter[A](p: LazyParsley[A], pred: A => Boolean) extends Unary[A, A](p) {
-    // $COVERAGE-OFF$
-    override def pretty(c: String): String = s"$c.filter(?)"
-    // $COVERAGE-ON$
     override def make(p: StrictParsley[A]): StrictParsley[A] = new backend.Filter(p, pred)
 }
 private [parsley] final class FilterOut[A](p: LazyParsley[A], pred: PartialFunction[A, String]) extends Unary[A, A](p) {
-    // $COVERAGE-OFF$
-    override def pretty(c: String): String = s"$c.filterOut(?)"
-    // $COVERAGE-ON$
     override def make(p: StrictParsley[A]): StrictParsley[A] = new backend.FilterOut(p, pred)
 }
 private [parsley] final class GuardAgainst[A](p: LazyParsley[A], pred: PartialFunction[A, Seq[String]]) extends Unary[A, A](p) {
-    // $COVERAGE-OFF$
-    override def pretty(c: String): String = s"$c.guardAgainst(?)"
-    // $COVERAGE-ON$
     override def make(p: StrictParsley[A]): StrictParsley[A] = new backend.GuardAgainst(p, pred)
 }

--- a/src/main/scala/parsley/internal/deepembedding/frontend/SequenceEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/frontend/SequenceEmbedding.scala
@@ -12,28 +12,16 @@ import parsley.internal.machine.instructions
 
 // Core Embedding
 private [parsley] final class <*>[A, B](pf: LazyParsley[A => B], px: =>LazyParsley[A]) extends Binary[A => B, A, B](pf, px) {
-    // $COVERAGE-OFF$
-    override def pretty(l: String, r: String): String = s"($l <*> $r)"
-    // $COVERAGE-ON$
     override def make(pf: StrictParsley[A => B], px: StrictParsley[A]): StrictParsley[B] = new backend.<*>(pf, px)
 }
 
 private [parsley] final class >>=[A, B](p: LazyParsley[A], private [>>=] val f: A => LazyParsley[B]) extends Unary[A, B](p) {
-    // $COVERAGE-OFF$
-    override def pretty(l: String): String = s"($l >>= ?)"
-    // $COVERAGE-ON$
     override def make(p: StrictParsley[A]): StrictParsley[B] = new backend.>>=(p, f)
 }
 
 private [parsley] final class *>[A](_p: LazyParsley[_], _q: =>LazyParsley[A]) extends Binary[Any, A, A](_p, _q) {
-    // $COVERAGE-OFF$
-    override def pretty(l: String, r: String): String = s"($l *> $r)"
-    // $COVERAGE-ON$
     override def make(p: StrictParsley[Any], q: StrictParsley[A]): StrictParsley[A] = new backend.*>(p, q)
 }
 private [parsley] final class <*[A](_p: LazyParsley[A], _q: =>LazyParsley[_]) extends Binary[A, Any, A](_p, _q) {
-    // $COVERAGE-OFF$
-    override def pretty(l: String, r: String): String = s"($l <* $r)"
-    // $COVERAGE-ON$
     override def make(p: StrictParsley[A], q: StrictParsley[Any]): StrictParsley[A] = new backend.<*(p, q)
 }

--- a/src/main/scala/parsley/internal/deepembedding/frontend/SequenceEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/frontend/SequenceEmbedding.scala
@@ -20,8 +20,8 @@ private [parsley] final class >>=[A, B](p: LazyParsley[A], private [>>=] val f: 
 }
 
 private [parsley] final class *>[A](_p: LazyParsley[_], _q: =>LazyParsley[A]) extends Binary[Any, A, A](_p, _q) {
-    override def make(p: StrictParsley[Any], q: StrictParsley[A]): StrictParsley[A] = new backend.*>(p, q)
+    override def make(p: StrictParsley[Any], q: StrictParsley[A]): StrictParsley[A] = backend.*>(p, q)
 }
 private [parsley] final class <*[A](_p: LazyParsley[A], _q: =>LazyParsley[_]) extends Binary[A, Any, A](_p, _q) {
-    override def make(p: StrictParsley[A], q: StrictParsley[Any]): StrictParsley[A] = new backend.<*(p, q)
+    override def make(p: StrictParsley[A], q: StrictParsley[Any]): StrictParsley[A] = backend.<*(p, q)
 }

--- a/src/main/scala/parsley/internal/deepembedding/singletons/Singletons.scala
+++ b/src/main/scala/parsley/internal/deepembedding/singletons/Singletons.scala
@@ -22,4 +22,5 @@ private [singletons] abstract class Singleton[A] extends LazyParsley[A] with Str
     final override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont], instrs: StrictParsley.InstrBuffer, state: backend.CodeGenState): Cont[R, Unit] = {
         result(instrs += instr)
     }
+    final override def pretty[Cont[_, +_]: ContOps, R]: Cont[R, String] = result(pretty)
 }

--- a/src/main/scala/parsley/internal/deepembedding/singletons/Singletons.scala
+++ b/src/main/scala/parsley/internal/deepembedding/singletons/Singletons.scala
@@ -15,14 +15,11 @@ private [singletons] abstract class Singleton[A] extends LazyParsley[A] with Str
     def pretty: String
     def instr: instructions.Instr
 
-    final override def findLetsAux[Cont[_, +_], R](seen: Set[LazyParsley[_]])
-        (implicit ops: ContOps[Cont], state: frontend.LetFinderState): Cont[R, Unit] = result(())
-    final override def preprocess[Cont[_, +_], R, A_ >: A](implicit ops: ContOps[Cont],
-                                                                    lets: frontend.LetMap, recs: frontend.RecMap): Cont[R, StrictParsley[A_]] = result(this)
+    final override def findLetsAux[Cont[_, +_]: ContOps, R](seen: Set[LazyParsley[_]])(implicit state: frontend.LetFinderState): Cont[R, Unit] = result(())
+    final override def preprocess[Cont[_, +_]: ContOps, R, A_ >: A](implicit lets: frontend.LetMap, recs: frontend.RecMap): Cont[R, StrictParsley[A_]] = {
+        result(this)
+    }
     final override def codeGen[Cont[_, +_], R](implicit ops: ContOps[Cont], instrs: StrictParsley.InstrBuffer, state: backend.CodeGenState): Cont[R, Unit] = {
         result(instrs += instr)
     }
-    // $COVERAGE-OFF$
-    final override def prettyASTAux[Cont[_, +_]](implicit ops: ContOps[Cont]): Cont[String, String] = result(pretty)
-    // $COVERAGE-ON$
 }

--- a/src/main/scala/parsley/internal/machine/instructions/IterativeInstrs.scala
+++ b/src/main/scala/parsley/internal/machine/instructions/IterativeInstrs.scala
@@ -112,7 +112,7 @@ private [internal] final class Chainl(var label: Int) extends InstrWithLabel {
 }
 
 private [instructions] object DualHandler {
-    def checkForFirstHandlerAndPop(ctx: Context, otherwise: =>Unit)(action: =>Unit) = {
+    def checkForFirstHandlerAndPop(ctx: Context, otherwise: =>Unit)(action: =>Unit): Unit = {
         if (!ctx.handlers.isEmpty && ctx.handlers.pc == ctx.pc) {
             ctx.handlers = ctx.handlers.tail
             action
@@ -120,7 +120,7 @@ private [instructions] object DualHandler {
         else otherwise
         ctx.checkStack = ctx.checkStack.tail
     }
-    def popSecondHandlerAndJump(ctx: Context, label: Int) = {
+    def popSecondHandlerAndJump(ctx: Context, label: Int): Unit = {
         ctx.handlers = ctx.handlers.tail
         ctx.checkStack = ctx.checkStack.tail
         ctx.updateCheckOffsetAndHints()

--- a/src/main/scala/parsley/internal/machine/instructions/TokenInstrs.scala
+++ b/src/main/scala/parsley/internal/machine/instructions/TokenInstrs.scala
@@ -5,7 +5,7 @@ package parsley.internal.machine.instructions
 
 import scala.annotation.tailrec
 
-import parsley.internal.Radix, Radix.RadixSet
+import parsley.internal.collection.mutable.Radix, Radix.RadixSet
 import parsley.internal.deepembedding.Sign.{DoubleType, IntType, SignType}
 import parsley.internal.errors.{Desc, ErrorItem}
 import parsley.internal.machine.Context

--- a/src/main/scala/parsley/internal/machine/instructions/TokenStringInstrs.scala
+++ b/src/main/scala/parsley/internal/machine/instructions/TokenStringInstrs.scala
@@ -5,7 +5,7 @@ package parsley.internal.machine.instructions
 
 import scala.annotation.tailrec
 
-import parsley.internal.Radix
+import parsley.internal.collection.mutable
 import parsley.internal.errors.{Desc, ErrorItem}
 import parsley.internal.machine.Context
 
@@ -79,7 +79,7 @@ private [instructions] object TokenEscape {
     private [instructions] case object BadCode extends Escape
     private [instructions] case object NoParse extends Escape
 
-    private [TokenEscape] val escRadix = Radix[(Char, Int)](
+    private [TokenEscape] val escRadix = mutable.Radix[(Char, Int)](
         "a"   -> ('\u0007', 1),
         "b"   -> ('\b', 1),
         "f"   -> ('\u000c', 1),

--- a/src/main/scala/parsley/internal/machine/stacks/Stack.scala
+++ b/src/main/scala/parsley/internal/machine/stacks/Stack.scala
@@ -23,7 +23,7 @@ private [machine] object Stack {
             val str = new StringBuilder
             str ++= "["
             while (!inst.isEmpty(ys)) {
-                str ++= inst.show(inst.head(xs))
+                str ++= inst.show(inst.head(ys))
                 ys = inst.tail(ys)
                 if (!inst.isEmpty(ys)) str ++= sep
             }

--- a/src/main/scala/parsley/token/Lexer.scala
+++ b/src/main/scala/parsley/token/Lexer.scala
@@ -111,7 +111,7 @@ class Lexer(lang: LanguageDef)
     /**The non-lexeme parser `maxOp_(name)` parses the symbol `name`, but also checks that the `name`
       * is not part of a larger reserved operator. An `operator` is treated as a single token using
       * `attempt`.*/
-    def maxOp_(name: String): Parsley[Unit] = new Parsley(new singletons.MaxOp(name, lang.operators)).void
+    def maxOp_(name: String): Parsley[Unit] = new Parsley(new singletons.MaxOp(name, lang.operators))
 
     private def isReservedOp(op: String): Boolean = lang.operators.contains(op)
     private lazy val opStart = toParser(lang.opStart)


### PR DESCRIPTION
Both chains of `<|>` and chains of `<*`/`*>` can be converted into a normal form which flattens the structure. This has some benefits, as re-association no longer needs to be performed, which was previously O(n^2). Now the normalisation can occur in O(n) time.