### PR TITLE
Lifting register restriction

### DIFF
--- a/jvm-native/src/main/scala/parsley/io.scala
+++ b/jvm-native/src/main/scala/parsley/io.scala
@@ -50,7 +50,8 @@ object io {
                 }
             } yield {
                 src.close()
-                new Context(con(p).internal.instrs, input, Some(file.getName)).runParser()
+                val internal = con(p).internal
+                new Context(internal.instrs, input, internal.numRegs, Some(file.getName)).runParser()
             }
         }
     }

--- a/src/main/scala/parsley/Parsley.scala
+++ b/src/main/scala/parsley/Parsley.scala
@@ -124,7 +124,7 @@ final class Parsley[+A] private [parsley] (private [parsley] val internal: front
       * @since 3.0.0
       * @group run
       */
-    def parse[Err: ErrorBuilder](input: String): Result[Err, A] = new Context(internal.instrs, input).runParser()
+    def parse[Err: ErrorBuilder](input: String): Result[Err, A] = new Context(internal.instrs, input, internal.numRegs).runParser()
 
     // RESULT CHANGING COMBINATORS
     /** This combinator allows the result of this parser to be changed using a given function.

--- a/src/main/scala/parsley/internal/deepembedding/backend/SequenceEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/backend/SequenceEmbedding.scala
@@ -109,7 +109,7 @@ private [deepembedding] final class >>=[A, B](val p: StrictParsley[A], private [
     }
     override def codeGen[Cont[_, +_]: ContOps, R](implicit instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
         suspend(p.codeGen[Cont, R]) |>
-        (instrs += instructions.DynCall[A](x => f(x).demandCalleeSave().instrs))
+        (instrs += instructions.DynCall[A](x => f(x).demandCalleeSave(state.numRegs).instrs))
     }
     // $COVERAGE-OFF$
     final override def pretty(p: String): String = s"$p.flatMap(?)"

--- a/src/main/scala/parsley/internal/deepembedding/frontend/PrimitiveEmbedding.scala
+++ b/src/main/scala/parsley/internal/deepembedding/frontend/PrimitiveEmbedding.scala
@@ -25,6 +25,10 @@ private [parsley] final class NotFollowedBy[A](p: LazyParsley[A]) extends Unary[
 private [parsley] final class Put[S](val reg: Reg[S], _p: LazyParsley[S]) extends Unary[S, Unit](_p) with UsesRegister {
     override def make(p: StrictParsley[S]): StrictParsley[Unit] = new backend.Put(reg, p)
 }
+private [parsley] final class NewReg[S, A](val reg: Reg[S], init: LazyParsley[S], body: =>LazyParsley[A])
+    extends Binary[S, A, A](init, body) with UsesRegister {
+    override def make(init: StrictParsley[S], body: StrictParsley[A]): StrictParsley[A] = new backend.NewReg(reg, init, body)
+}
 // $COVERAGE-OFF$
 private [parsley] final class Debug[A](p: LazyParsley[A], name: String, ascii: Boolean, break: Breakpoint) extends Unary[A, A](p) {
     override def make(p: StrictParsley[A]): StrictParsley[A] = new backend.Debug(p, name, ascii, break)

--- a/src/main/scala/parsley/internal/machine/Context.scala
+++ b/src/main/scala/parsley/internal/machine/Context.scala
@@ -21,13 +21,9 @@ import parsley.internal.machine.errors.{
 import instructions.Instr
 import stacks.{ArrayStack, CallStack, CheckStack, ErrorStack, HandlerStack, HintStack, Stack, StateStack}, Stack.StackExt
 
-private [parsley] object Context {
-    private [Context] val NumRegs = 4
-    private [parsley] def empty: Context = new Context(null, "")
-}
-
 private [parsley] final class Context(private [machine] var instrs: Array[Instr],
                                       private [machine] var input: String,
+                                      numRegs: Int,
                                       private val sourceFile: Option[String] = None) {
     /** This is the operand stack, where results go to live  */
     private [machine] val stack: ArrayStack[Any] = new ArrayStack()
@@ -36,7 +32,6 @@ private [parsley] final class Context(private [machine] var instrs: Array[Instr]
     /** The length of the input, stored for whatever reason */
     private [machine] var inputsz: Int = input.length
     /** Call stack consisting of Frames that track the return position and the old instructions */
-    //private var calls: FastStack[Frame] = FastStack.empty
     private var calls: CallStack = Stack.empty
     /** State stack consisting of offsets and positions that can be rolled back */
     private [machine] var states: StateStack = Stack.empty
@@ -55,7 +50,7 @@ private [parsley] final class Context(private [machine] var instrs: Array[Instr]
     /** Current column number */
     private [machine] var col: Int = 1
     /** State held by the registers, AnyRef to allow for `null` */
-    private [machine] val regs: Array[AnyRef] = new Array[AnyRef](Context.NumRegs)
+    private [machine] var regs: Array[AnyRef] = new Array[AnyRef](numRegs)
     /** Amount of indentation to apply to debug combinators output */
     private [machine] var debuglvl: Int = 0
 

--- a/src/main/scala/parsley/internal/machine/instructions/PrimitiveInstrs.scala
+++ b/src/main/scala/parsley/internal/machine/instructions/PrimitiveInstrs.scala
@@ -96,33 +96,33 @@ private [internal] final class PutAndFail(reg: Int) extends Instr {
 
 // This instruction holds mutate state, but it is safe to do so, because it's always the first instruction of a DynCall.
 private [parsley] final class CalleeSave(var label: Int, reqSize: Int, slots: List[(Int, Int)], saveArray: Array[AnyRef]) extends InstrWithLabel {
-    def this(label: Int, reqSize: Int, slots: List[Int]) = this(label, reqSize, slots.zipWithIndex, new Array[AnyRef](slots.length))
+    private def this(label: Int, reqSize: Int, slots: List[Int]) = this(label, reqSize, slots.zipWithIndex, new Array[AnyRef](slots.length))
+    // this filters out the slots to ensure we only do callee-save on registers that might exist in the parent
+    def this(label: Int, reqSize: Int, slots: List[Int], numRegsInContext: Int) = this(label, reqSize, slots.takeWhile(_ < numRegsInContext))
     private var inUse = false
     private var oldRegs: Array[AnyRef] = null
 
     private def save(ctx: Context): Unit = {
+        for ((slot, idx) <- slots) {
+            saveArray(idx) = ctx.regs(slot)
+            ctx.regs(slot) = null
+        }
         // If this is known to increase the size of the register pool, then we need to keep the old array to the side
         if (reqSize > ctx.regs.size) {
             oldRegs = ctx.regs
             ctx.regs = java.util.Arrays.copyOf(oldRegs, reqSize)
         }
-        // TODO: it's wasteful doing the resize first, we could cut the slots off so that
-        //       it doesn't do callee-save wider than the array itself!
-        for ((slot, idx) <- slots) {
-            saveArray(idx) = ctx.regs(slot)
-            ctx.regs(slot) = null
-        }
     }
 
     private def restore(ctx: Context): Unit = {
-        for ((slot, idx) <- slots) {
-            ctx.regs(slot) = saveArray(idx)
-            saveArray(idx) = null
-        }
         if (oldRegs != null) {
             java.lang.System.arraycopy(ctx.regs, 0, oldRegs, 0, oldRegs.size)
             ctx.regs = oldRegs
             oldRegs = null
+        }
+        for ((slot, idx) <- slots) {
+            ctx.regs(slot) = saveArray(idx)
+            saveArray(idx) = null
         }
     }
 

--- a/src/main/scala/parsley/internal/machine/instructions/PrimitiveInstrs.scala
+++ b/src/main/scala/parsley/internal/machine/instructions/PrimitiveInstrs.scala
@@ -84,6 +84,16 @@ private [internal] final class Put(reg: Int) extends Instr {
     // $COVERAGE-ON$
 }
 
+private [internal] final class PutAndFail(reg: Int) extends Instr {
+    override def apply(ctx: Context): Unit = {
+        ctx.writeReg(reg, ctx.stack.upeek)
+        ctx.fail()
+    }
+    // $COVERAGE-OFF$
+    override def toString: String = s"PutAndFail($reg)"
+    // $COVERAGE-ON$
+}
+
 // This instruction holds mutate state, but it is safe to do so, because it's always the first instruction of a DynCall.
 private [parsley] final class CalleeSave(var label: Int, reqSize: Int, slots: List[(Int, Int)], saveArray: Array[AnyRef]) extends InstrWithLabel {
     def this(label: Int, reqSize: Int, slots: List[Int]) = this(label, reqSize, slots.zipWithIndex, new Array[AnyRef](slots.length))

--- a/src/main/scala/parsley/internal/machine/instructions/PrimitiveInstrs.scala
+++ b/src/main/scala/parsley/internal/machine/instructions/PrimitiveInstrs.scala
@@ -94,7 +94,7 @@ private [parsley] final class CalleeSave(var label: Int, reqSize: Int, slots: Li
         // If this is known to increase the size of the register pool, then we need to keep the old array to the side
         if (reqSize > ctx.regs.size) {
             oldRegs = ctx.regs
-            ctx.regs = Array.copyOf(oldRegs, reqSize)
+            ctx.regs = java.util.Arrays.copyOf(oldRegs, reqSize)
         }
         // TODO: it's wasteful doing the resize first, we could cut the slots off so that
         //       it doesn't do callee-save wider than the array itself!
@@ -110,7 +110,7 @@ private [parsley] final class CalleeSave(var label: Int, reqSize: Int, slots: Li
             saveArray(idx) = null
         }
         if (oldRegs != null) {
-            Array.copy(ctx.regs, 0, oldRegs, 0, oldRegs.size)
+            java.lang.System.arraycopy(ctx.regs, 0, oldRegs, 0, oldRegs.size)
             ctx.regs = oldRegs
             oldRegs = null
         }

--- a/src/main/scala/parsley/registers.scala
+++ b/src/main/scala/parsley/registers.scala
@@ -309,7 +309,9 @@ object registers {
     implicit final class RegisterMethods[P, A](p: P)(implicit con: P => Parsley[A]) {
         def fillReg[B](body: Reg[A] => Parsley[B]): Parsley[B] = {
             val reg = Reg.make[A]
-            reg.put(con(p)) *> body(reg)
+            reg.local(con(p)) {
+              body(reg)
+            }
         }
         /** This combinator allows for the result of this parser to be used multiple times within a function,
           * without needing to reparse or recompute.
@@ -361,7 +363,9 @@ object registers {
         val reg = Reg.make[A]
         lazy val _cond = reg.gets(cond)
         lazy val _step = reg.modify(step)
-        reg.put(init) *> when(_cond, whileP(body(reg.get) *> _step *> _cond))
+        reg.local(init) {
+          when(_cond, whileP(body(reg.get) *> _step *> _cond))
+        }
         /*lazy val _cond = cond
         lazy val _step = step
         def loop(x: A): Parsley[Unit] =

--- a/src/main/scala/parsley/registers.scala
+++ b/src/main/scala/parsley/registers.scala
@@ -394,6 +394,17 @@ object registers {
         }
     }
 
+    /*def forYieldP_[A, B](init: Parsley[A], cond: =>Parsley[A => Boolean], step: =>Parsley[A => A])(body: Parsley[A] => Parsley[B]): Parsley[List[B]] = {
+        import parsley.Parsley.fresh
+        import scala.collection.mutable
+        import parsley.implicits.zipped.Zipped2
+        fresh(mutable.ListBuffer.empty[B]).fillReg { acc =>
+            forP_(init, cond, step) { x =>
+                acc.put((acc.get, body(x)).zipped(_ += _))
+            } *> acc.gets(_.toList)
+        }
+    }*/
+
     /** This combinator allows for the repeated execution of a parser in a stateful loop.
       *
       * `forP(init, cond, step)(body)` behaves much like a traditional for loop using `init`, `cond`, `step` and `body` as parsers
@@ -424,4 +435,15 @@ object registers {
             _body
         }
     }
+
+    /*def forYieldP[A, B](init: Parsley[A], cond: =>Parsley[A => Boolean], step: =>Parsley[A => A])(body: =>Parsley[B]): Parsley[List[B]] = {
+        import parsley.Parsley.fresh
+        import scala.collection.mutable
+        import parsley.implicits.zipped.Zipped2
+        fresh(mutable.ListBuffer.empty[B]).fillReg { acc =>
+            forP(init, cond, step) {
+                acc.put((acc.get, body).zipped(_ += _))
+            } *> acc.gets(_.toList)
+        }
+    }*/
 }

--- a/src/main/scala/parsley/registers.scala
+++ b/src/main/scala/parsley/registers.scala
@@ -38,13 +38,6 @@ import parsley.internal.deepembedding.{frontend, singletons}
   */
 object registers {
     /** This class is used to index registers within the mutable state.
-      * Currently, there are only '''four''' available registers, so use them wisely!
-      *
-      * If you need more than four registers but know that they will be used
-      * at different times you can rename your register, as long as they point
-      * to the same reference. You may find the
-      * [[parsley.Parsley.cast[B]* `Parsley[A].cast[B: ClassTag]: Parsley[B]` ]]
-      * combinator useful to change the type of a `Reg[Any]`.
       *
       * @note it is undefined behaviour to use a register in multiple different
       *       independent parsers. You should be careful to parameterise the

--- a/src/main/scala/parsley/registers.scala
+++ b/src/main/scala/parsley/registers.scala
@@ -314,10 +314,10 @@ object registers {
       * @group ext
       */
     implicit final class RegisterMethods[P, A](p: P)(implicit con: P => Parsley[A]) {
-        /*def fillReg[B](body: Reg[A] => Parsley[B]): Parsley[B] = {
+        def fillReg[B](body: Reg[A] => Parsley[B]): Parsley[B] = {
             val reg = Reg.make[A]
             reg.put(con(p)) *> body(reg)
-        }*/
+        }
         /** This combinator allows for the result of this parser to be used multiple times within a function,
           * without needing to reparse or recompute.
           *
@@ -333,12 +333,12 @@ object registers {
           * @param f a function to generate a new parser that can observe the result of this parser many times without reparsing.
           * @since 3.2.0
           */
-        def persist[B](f: Parsley[A] => Parsley[B]): Parsley[B] = con(p).flatMap(x => f(pure(x)))//this.fillReg(reg => f(get(reg)))
+        def persist[B](f: Parsley[A] => Parsley[B]): Parsley[B] = this.fillReg(reg => f(reg.get))
     }
 
-    /*implicit final class RegisterMaker[A](x: A) {
+    implicit final class RegisterMaker[A](x: A) {
         def makeReg[B](body: Reg[A] => Parsley[B]): Parsley[B] = pure(x).fillReg(body)
-    }*/
+    }
 
     /** This combinator allows for the repeated execution of a parser `body` in a stateful loop, `body` will have access to the current value of the state.
       *
@@ -365,11 +365,11 @@ object registers {
       * @group comb
       */
     private def forP_[A](init: Parsley[A], cond: =>Parsley[A => Boolean], step: =>Parsley[A => A])(body: Parsley[A] => Parsley[_]): Parsley[Unit] = {
-        /*val reg = Reg.make[A]
+        val reg = Reg.make[A]
         lazy val _cond = reg.gets(cond)
         lazy val _step = reg.modify(step)
-        reg.put(init) *> when(_cond, whileP(body(reg) *> _step *> _cond))*/
-        lazy val _cond = cond
+        reg.put(init) *> when(_cond, whileP(body(reg.get) *> _step *> _cond))
+        /*lazy val _cond = cond
         lazy val _step = step
         def loop(x: A): Parsley[Unit] =
             _cond.flatMap { p =>
@@ -380,7 +380,7 @@ object registers {
                     }
                 }
             }
-        init.flatMap(loop)
+        init.flatMap(loop)*/
     }
 
     /** This combinator allows for the repeated execution of a parser in a stateful loop.

--- a/src/main/scala/parsley/registers.scala
+++ b/src/main/scala/parsley/registers.scala
@@ -312,9 +312,9 @@ object registers {
           *
           * This allows for a more controlled way of creating registers during a parse,
           * without explicitly creating them with `Reg.make[A]` and using `put`. These
-          * registers are intended to be fresh every time they are "created", which is
-          * accomplished by using `local` to populate it. In other words, a recursive
-          * call with a `fillReg` call inside will appear to modify a different register.
+          * registers are intended to be fresh every time they are "created", in other
+          * words, a recursive call with a `fillReg` call inside will modify a different
+          * register each time.
           *
           * @example {{{
           * // this is an efficient implementation for persist.
@@ -351,9 +351,9 @@ object registers {
           *
           * This allows for a more controlled way of creating registers during a parse,
           * without explicitly creating them with `Reg.make[A]` and using `put`. These
-          * registers are intended to be fresh every time they are "created", which is
-          * accomplished by using `local` to populate it. In other words, a recursive
-          * call with a `makeReg` call inside will appear to modify a different register.
+          * registers are intended to be fresh every time they are "created", in other
+          * words, a recursive call with a `makeReg` call inside will modify a different
+          * register.
           *
           * @param body a function to generate a parser that can interact with the freshly created register.
           * @see [[parsley.registers.RegisterMethods.fillReg `fillReg`]] for a version that uses the result of a parser to fill the register instead.

--- a/src/test/scala/parsley/CoreTests.scala
+++ b/src/test/scala/parsley/CoreTests.scala
@@ -181,22 +181,12 @@ class CoreTests extends ParsleyTest {
        an [Exception] should be thrownBy many(pure(5)).parse("")
     }
 
-    implicit final class RegisterMaker[A](x: A) {
-        def makeReg[B](body: Reg[A] => Parsley[B]): Parsley[B] = pure(x).fillReg(body)
-    }
-
-    implicit final class RegisterMethods[P, A](p: =>P)(implicit con: P => Parsley[A]) {
-        def fillReg[B](body: Reg[A] => Parsley[B]): Parsley[B] = {
-            val reg = Reg.make[A]
-            reg.put(con(p)) *> body(reg)
-        }
-    }
-
     "stateful parsers" should "allow for persistent state" in {
-        val p = 5.makeReg(r1 =>
-                7.makeReg(r2 =>
-                 r1.put(lift2[Int, Int, Int](_+_, r1.get, r2.get))
-              *> (r1.get zip r2.gets(_+1))))
+        val p = 5.makeReg { r1 =>
+            7.makeReg { r2 =>
+                r1.put(lift2[Int, Int, Int](_+_, r1.get, r2.get)) *> (r1.get zip r2.gets(_+1))
+            }
+        }
         p.parse("") should be (Success((12, 8)))
     }
     they should "be modifiable" in {


### PR DESCRIPTION
This lifts the existing limit of 4 registers in simultaneous use, closing #33. It introduces new combinators for creating fresh registers during parse and also ensures the register array is correctly sized to accommodate more than (or less than) 4 registers.

It consists of the following work items:

- [x] restrict the size of the register array to the number of registers used
- [x] allow `flatMap` (via `CalleeSave`) to expand the size of the registers if required
- [x] allow more than 4 registers to be used at once
- [x] add new methods for generating registers on the fly, and switch to efficient implementations for `forP` and `persist`
- [x] ensure that `CalleeSave` does not unnecessarily perform callee-save on registers that didn't exist in the caller
- [x] ensure that fresh registers from `fillReg` and `forP` appear to be independent in recursive calls for successful parsers
- [x] ensure that fresh registers from `fillReg` and `forP` appear to be independent in recursive calls for failing parsers
- [x] add additional tests that do not assume the restriction    