### PR TITLE
Error pattern combinators

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,6 +41,8 @@ inThisBuild(List(
     ProblemFilters.exclude[MissingFieldProblem]("parsley.token.predicate._CharSet"),
     ProblemFilters.exclude[MissingClassProblem]("parsley.token.errors.ErrorConfig$"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("parsley.errors.combinator#ErrorMethods.unexpected"),
+    ProblemFilters.exclude[MissingClassProblem]("parsley.token.errors.FilterOps"),
+    ProblemFilters.exclude[MissingClassProblem]("parsley.token.errors.FilterOps$"),
   ),
   tlVersionIntroduced := Map(
     "2.13" -> "1.5.0",

--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,7 @@ inThisBuild(List(
     ProblemFilters.exclude[MissingClassProblem]("parsley.token.predicate$_CharSet$"),
     ProblemFilters.exclude[MissingFieldProblem]("parsley.token.predicate._CharSet"),
     ProblemFilters.exclude[MissingClassProblem]("parsley.token.errors.ErrorConfig$"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("parsley.errors.combinator#ErrorMethods.unexpected"),
   ),
   tlVersionIntroduced := Map(
     "2.13" -> "1.5.0",

--- a/parsley/shared/src/main/scala/parsley/errors/combinator.scala
+++ b/parsley/shared/src/main/scala/parsley/errors/combinator.scala
@@ -458,10 +458,11 @@ object combinator {
           *             not exactly the same, `verifiedFail` combinator.
           */
         @deprecated("This combinator will be removed in 5.0.0, without direct replacement", "4.2.0")
-        def !(msggen: A => String): Parsley[Nothing] = //new Parsley(new frontend.FastFail(con(p).internal, msggen))
-            parsley.position.internalOffsetSpan(con(p)).flatMap { case (os, x, oe) =>
+        def !(msggen: A => String): Parsley[Nothing] = partialAmendThenDislodge {
+            parsley.position.internalOffsetSpan(entrench(con(p))).flatMap { case (os, x, oe) =>
                 combinator.fail(oe - os, msggen(x))
             }
+        }
 
         /** This combinator parses this parser and then fails, using the result of this parser to customise the unexpected component
           * of the error message.
@@ -479,10 +480,11 @@ object combinator {
           * @since 4.2.0
           */
         @deprecated("This combinator will be removed in 5.0.0, without direct replacement", "4.2.0")
-        def unexpected(msggen: A => String): Parsley[Nothing] =
-            parsley.position.internalOffsetSpan(con(p)).flatMap { case (os, x, oe) =>
+        def unexpected(msggen: A => String): Parsley[Nothing] = partialAmendThenDislodge {
+            parsley.position.internalOffsetSpan(entrench(con(p))).flatMap { case (os, x, oe) =>
                 combinator.unexpected(oe - os, msggen(x))
             }
+        }
         // $COVERAGE-ON$
     }
 }

--- a/parsley/shared/src/main/scala/parsley/errors/combinator.scala
+++ b/parsley/shared/src/main/scala/parsley/errors/combinator.scala
@@ -455,28 +455,13 @@ object combinator {
           * @note $partialAmend
           * @group fail
           * @deprecated this combinator has not proven to be particularly useful, and will be replaced by a more appropriate,
-          *             not exactly the same, `fail` combinator.
+          *             not exactly the same, `verifyFail` combinator.
           */
         @deprecated("This combinator will be removed in 5.0.0, without direct replacement", "4.2.0")
         def !(msggen: A => String): Parsley[Nothing] = //new Parsley(new frontend.FastFail(con(p).internal, msggen))
             parsley.position.internalOffsetSpan(con(p)).flatMap { case (os, x, oe) =>
                 combinator.fail(oe - os, msggen(x))
             }
-
-        // TODO: I think this can probably be deprecated for future removal soon...
-        // It will be replaced by one that generates reasons too!
-        /** This combinator parses this parser and then fails, using the result of this parser to customise the unexpected component
-          * of the error message.
-          *
-          * @group fail
-          * @see [[unexpectedLegacy `unexpectedLegacy`]]
-          * @deprecated this combinator has not proven to be particularly useful in its current state, and will be replaced by a more
-          *             appropriate, not exactly the same, `unexpected` combinator in 4.4.0. This will be removed from the source API in
-          *             4.3.0 to reduce risk of conflation with the new combinator, and legitimate uses of this combinator should switch
-          *             to `unexpectedLegacy` instead, which will be removed in 5.0.0.
-          */
-        @deprecated("This combinator will be binary removed in 5.0.0 and source removed in 4.3.0, use unexpectedLegacy until 5.0.0", "4.2.0")
-        def unexpected(msggen: A => String): Parsley[Nothing] = this.unexpectedLegacy(msggen)
 
         /** This combinator parses this parser and then fails, using the result of this parser to customise the unexpected component
           * of the error message.
@@ -489,11 +474,12 @@ object combinator {
           * @return a parser that always fails, with the given generator used to produce an unexpected message if this parser succeeded.
           * @note $partialAmend
           * @group fail
-          * @deprecated this combinator has not proven to be particularly useful and will be removed in 5.0.0.
+          * @deprecated this combinator has not proven to be particularly useful and will be removed in 5.0.0. There is a similar, but not
+          *             exact replacement called `verifyUnexpected`.
           * @since 4.2.0
           */
-        @deprecated("This combinator will be removed in 5.0.0", "4.2.0")
-        def unexpectedLegacy(msggen: A => String): Parsley[Nothing] =
+        @deprecated("This combinator will be removed in 5.0.0, without direct replacement", "4.2.0")
+        def unexpected(msggen: A => String): Parsley[Nothing] =
             parsley.position.internalOffsetSpan(con(p)).flatMap { case (os, x, oe) =>
                 combinator.unexpected(oe - os, msggen(x))
             }

--- a/parsley/shared/src/main/scala/parsley/errors/combinator.scala
+++ b/parsley/shared/src/main/scala/parsley/errors/combinator.scala
@@ -455,7 +455,7 @@ object combinator {
           * @note $partialAmend
           * @group fail
           * @deprecated this combinator has not proven to be particularly useful, and will be replaced by a more appropriate,
-          *             not exactly the same, `verifyFail` combinator.
+          *             not exactly the same, `verifiedFail` combinator.
           */
         @deprecated("This combinator will be removed in 5.0.0, without direct replacement", "4.2.0")
         def !(msggen: A => String): Parsley[Nothing] = //new Parsley(new frontend.FastFail(con(p).internal, msggen))
@@ -475,7 +475,7 @@ object combinator {
           * @note $partialAmend
           * @group fail
           * @deprecated this combinator has not proven to be particularly useful and will be removed in 5.0.0. There is a similar, but not
-          *             exact replacement called `verifyUnexpected`.
+          *             exact replacement called `verifiedUnexpected`.
           * @since 4.2.0
           */
         @deprecated("This combinator will be removed in 5.0.0, without direct replacement", "4.2.0")

--- a/parsley/shared/src/main/scala/parsley/errors/combinator.scala
+++ b/parsley/shared/src/main/scala/parsley/errors/combinator.scala
@@ -3,7 +3,7 @@
  */
 package parsley.errors
 
-import parsley.Parsley, Parsley.attempt
+import parsley.Parsley
 
 import parsley.internal.deepembedding.{frontend, singletons}
 
@@ -443,20 +443,6 @@ object combinator {
           */
         def hide: Parsley[A] = this.label("")
 
-        // TODO: move all of these to a `VerifiedErrorWidgets` class?
-        // TODO: it should have the partial amend semantics, because `amendAndDislodge` can restore the other semantics anyway
-        // Document that `attempt` may be used when this is an informative but not terminal error.
-        private [parsley] def fail(msggen: A => Seq[String]): Parsley[Nothing] = {
-            // holy hell, the hoops I jump through to be able to implement things
-            val r = parsley.registers.Reg.make[(Int, A, Int)]
-            val fails = Parsley.notFollowedBy(r.put(parsley.position.internalOffsetSpan(this.hide)))
-            (fails <|> r.get.flatMap { case (os, x, oe) =>
-                val msg0 +: msgs = msggen(x)
-                combinator.fail(oe - os, msg0, msgs: _*)
-            }) *> Parsley.empty
-        }
-        private [parsley] def fail(msg: String, msgs: String*): Parsley[Nothing] = attempt(this.hide).fail(_ => msg +: msgs)
-
         // $COVERAGE-OFF$
         /** This combinator parses this parser and then fails, using the result of this parser to customise the error message.
           *
@@ -473,7 +459,7 @@ object combinator {
           */
         @deprecated("This combinator will be removed in 5.0.0, without direct replacement", "4.2.0")
         def !(msggen: A => String): Parsley[Nothing] = //new Parsley(new frontend.FastFail(con(p).internal, msggen))
-            parsley.position.internalOffsetSpan(p).flatMap { case (os, x, oe) =>
+            parsley.position.internalOffsetSpan(con(p)).flatMap { case (os, x, oe) =>
                 combinator.fail(oe - os, msggen(x))
             }
 
@@ -508,23 +494,9 @@ object combinator {
           */
         @deprecated("This combinator will be removed in 5.0.0", "4.2.0")
         def unexpectedLegacy(msggen: A => String): Parsley[Nothing] =
-            parsley.position.internalOffsetSpan(p).flatMap { case (os, x, oe) =>
+            parsley.position.internalOffsetSpan(con(p)).flatMap { case (os, x, oe) =>
                 combinator.unexpected(oe - os, msggen(x))
             }
         // $COVERAGE-ON$
-
-        // TODO: Documentation and testing ahead of future release
-        // like notFollowedBy, but does consume input on "success" and always fails (FIXME: this needs intrinsic support to get right)
-        // it should also have the partial amend semantics, because `amendAndDislodge` can restore the other semantics anyway
-        // Document that `attempt` may be used when this is an informative but not terminal error.
-        private def unexpected(reason: Option[A => String]) = {
-            // holy hell, the hoops I jump through to be able to implement things
-            val r = parsley.registers.Reg.make[A]
-            val fails = Parsley.notFollowedBy(r.put(this.hide))
-            reason.fold(fails)(rgen => fails <|> r.get.flatMap(x => Parsley.empty.explain(rgen(x)))) *> Parsley.empty
-        }
-        private [parsley] def unexpected: Parsley[Nothing] = this.unexpected(None)
-        private [parsley] def unexpected(reason: String): Parsley[Nothing] = this._unexpected(_ => reason)
-        private [parsley] def _unexpected(reason: A => String): Parsley[Nothing] = this.unexpected(Some(reason))
     }
 }

--- a/parsley/shared/src/main/scala/parsley/errors/patterns.scala
+++ b/parsley/shared/src/main/scala/parsley/errors/patterns.scala
@@ -20,21 +20,21 @@ object patterns {
                 combinator.fail(oe - os, msg0, msgs: _*)
             }) *> Parsley.empty
         }
-        private [parsley] def verifyFail(msg: String, msgs: String*): Parsley[Nothing] = this.verifyFail(_ => msg +: msgs)
+        private [parsley] def verifiedFail(msg: String, msgs: String*): Parsley[Nothing] = this.verifyFail(_ => msg +: msgs)
 
 
         // TODO: Documentation and testing ahead of future release
         // like notFollowedBy, but does consume input on "success" and always fails (FIXME: this needs intrinsic support to get right)
         // it should also have the partial amend semantics, because `amendAndDislodge` can restore the other semantics anyway
         // Document that `attempt` may be used when this is an informative but not terminal error.
-        private def verifyUnexpected(reason: Option[A => String]) = partialAmend {
+        private def verifiedUnexpected(reason: Option[A => String]) = partialAmend {
             // holy hell, the hoops I jump through to be able to implement things
             val r = parsley.registers.Reg.make[A]
             val fails = Parsley.notFollowedBy(r.put(con(p).hide))
             reason.fold(fails)(rgen => fails <|> r.get.flatMap(x => Parsley.empty.explain(rgen(x)))) *> Parsley.empty
         }
-        private [parsley] def verifyUnexpected: Parsley[Nothing] = this.verifyUnexpected(None)
-        private [parsley] def verifyUnexpected(reason: String): Parsley[Nothing] = this.verifyUnexpected(_ => reason)
-        private [parsley] def verifyUnexpected(reason: A => String): Parsley[Nothing] = this.verifyUnexpected(Some(reason))
+        private [parsley] def verifiedUnexpected: Parsley[Nothing] = this.verifiedUnexpected(None)
+        private [parsley] def verifiedUnexpected(reason: String): Parsley[Nothing] = this.verifiedUnexpected(_ => reason)
+        private [parsley] def verifiedUnexpected(reason: A => String): Parsley[Nothing] = this.verifiedUnexpected(Some(reason))
     }
 }

--- a/parsley/shared/src/main/scala/parsley/errors/patterns.scala
+++ b/parsley/shared/src/main/scala/parsley/errors/patterns.scala
@@ -1,0 +1,43 @@
+package parsley.errors
+
+import parsley.Parsley
+
+import combinator.{partialAmend, ErrorMethods}
+
+//import parsley.internal.deepembedding.{frontend, singletons}
+
+// TODO: document
+object patterns {
+    implicit final class VerifiedErrors[P, +A](p: P)(implicit con: P => Parsley[A]) {
+        // TODO: it should have the partial amend semantics, because `amendAndDislodge` can restore the other semantics anyway
+        // Document that `attempt` may be used when this is an informative but not terminal error.
+        private [parsley] def fail(msggen: A => Seq[String]): Parsley[Nothing] = partialAmend {
+            // holy hell, the hoops I jump through to be able to implement things
+            val r = parsley.registers.Reg.make[(Int, A, Int)]
+            val fails = Parsley.notFollowedBy(r.put(parsley.position.internalOffsetSpan(con(p).hide)))
+            (fails <|> r.get.flatMap { case (os, x, oe) =>
+                val msg0 +: msgs = msggen(x)
+                combinator.fail(oe - os, msg0, msgs: _*)
+            }) *> Parsley.empty
+        }
+        private [parsley] def fail(msg: String, msgs: String*): Parsley[Nothing] = this.fail(_ => msg +: msgs)
+
+
+        // TODO: Documentation and testing ahead of future release
+        // like notFollowedBy, but does consume input on "success" and always fails (FIXME: this needs intrinsic support to get right)
+        // it should also have the partial amend semantics, because `amendAndDislodge` can restore the other semantics anyway
+        // Document that `attempt` may be used when this is an informative but not terminal error.
+        @deprecated("this is an interim combinator in place of an `A => String`, which cannot appear until 4.4.0, it will be source removed then", "4.2.0")
+        private [parsley] def unexpected(reason: Option[A => String]) = _unexpected(reason)
+        private def _unexpected(reason: Option[A => String]) = partialAmend {
+            // holy hell, the hoops I jump through to be able to implement things
+            val r = parsley.registers.Reg.make[A]
+            val fails = Parsley.notFollowedBy(r.put(con(p).hide))
+            reason.fold(fails)(rgen => fails <|> r.get.flatMap(x => Parsley.empty.explain(rgen(x)))) *> Parsley.empty
+        }
+        private [parsley] def unexpected: Parsley[Nothing] = this._unexpected(None)
+        private [parsley] def unexpected(reason: String): Parsley[Nothing] = this._unexpected(_ => reason)
+        // TODO: this will be renamed and exposed in 4.4.0
+        private [parsley] def _unexpected(reason: A => String): Parsley[Nothing] = this._unexpected(Some(reason))
+    }
+}

--- a/parsley/shared/src/main/scala/parsley/errors/patterns.scala
+++ b/parsley/shared/src/main/scala/parsley/errors/patterns.scala
@@ -11,7 +11,7 @@ object patterns {
     implicit final class VerifiedErrors[P, +A](p: P)(implicit con: P => Parsley[A]) {
         // TODO: it should have the partial amend semantics, because `amendAndDislodge` can restore the other semantics anyway
         // Document that `attempt` may be used when this is an informative but not terminal error.
-        private [parsley] def fail(msggen: A => Seq[String]): Parsley[Nothing] = partialAmend {
+        private [parsley] def verifyFail(msggen: A => Seq[String]): Parsley[Nothing] = partialAmend {
             // holy hell, the hoops I jump through to be able to implement things
             val r = parsley.registers.Reg.make[(Int, A, Int)]
             val fails = Parsley.notFollowedBy(r.put(parsley.position.internalOffsetSpan(con(p).hide)))
@@ -20,24 +20,21 @@ object patterns {
                 combinator.fail(oe - os, msg0, msgs: _*)
             }) *> Parsley.empty
         }
-        private [parsley] def fail(msg: String, msgs: String*): Parsley[Nothing] = this.fail(_ => msg +: msgs)
+        private [parsley] def verifyFail(msg: String, msgs: String*): Parsley[Nothing] = this.verifyFail(_ => msg +: msgs)
 
 
         // TODO: Documentation and testing ahead of future release
         // like notFollowedBy, but does consume input on "success" and always fails (FIXME: this needs intrinsic support to get right)
         // it should also have the partial amend semantics, because `amendAndDislodge` can restore the other semantics anyway
         // Document that `attempt` may be used when this is an informative but not terminal error.
-        @deprecated("this is an interim combinator in place of an `A => String`, which cannot appear until 4.4.0, it will be source removed then", "4.2.0")
-        private [parsley] def unexpected(reason: Option[A => String]) = _unexpected(reason)
-        private def _unexpected(reason: Option[A => String]) = partialAmend {
+        private def verifyUnexpected(reason: Option[A => String]) = partialAmend {
             // holy hell, the hoops I jump through to be able to implement things
             val r = parsley.registers.Reg.make[A]
             val fails = Parsley.notFollowedBy(r.put(con(p).hide))
             reason.fold(fails)(rgen => fails <|> r.get.flatMap(x => Parsley.empty.explain(rgen(x)))) *> Parsley.empty
         }
-        private [parsley] def unexpected: Parsley[Nothing] = this._unexpected(None)
-        private [parsley] def unexpected(reason: String): Parsley[Nothing] = this._unexpected(_ => reason)
-        // TODO: this will be renamed and exposed in 4.4.0
-        private [parsley] def _unexpected(reason: A => String): Parsley[Nothing] = this._unexpected(Some(reason))
+        private [parsley] def verifyUnexpected: Parsley[Nothing] = this.verifyUnexpected(None)
+        private [parsley] def verifyUnexpected(reason: String): Parsley[Nothing] = this.verifyUnexpected(_ => reason)
+        private [parsley] def verifyUnexpected(reason: A => String): Parsley[Nothing] = this.verifyUnexpected(Some(reason))
     }
 }

--- a/parsley/shared/src/main/scala/parsley/errors/patterns.scala
+++ b/parsley/shared/src/main/scala/parsley/errors/patterns.scala
@@ -2,39 +2,25 @@ package parsley.errors
 
 import parsley.Parsley
 
-import combinator.{partialAmend, ErrorMethods}
-
-//import parsley.internal.deepembedding.{frontend, singletons}
+import parsley.internal.deepembedding.frontend
 
 // TODO: document
 object patterns {
-    implicit final class VerifiedErrors[P, +A](p: P)(implicit con: P => Parsley[A]) {
+    implicit final class VerifiedErrors[P, A](p: P)(implicit con: P => Parsley[A]) {
+        private def verified(msggen: Either[A => Seq[String], Option[A => String]]) = new Parsley(new frontend.VerifiedError(con(p).internal, msggen))
+
         // TODO: it should have the partial amend semantics, because `amendAndDislodge` can restore the other semantics anyway
         // Document that `attempt` may be used when this is an informative but not terminal error.
-        private [parsley] def verifyFail(msggen: A => Seq[String]): Parsley[Nothing] = partialAmend {
-            // holy hell, the hoops I jump through to be able to implement things
-            val r = parsley.registers.Reg.make[(Int, A, Int)]
-            val fails = Parsley.notFollowedBy(r.put(parsley.position.internalOffsetSpan(con(p).hide)))
-            (fails <|> r.get.flatMap { case (os, x, oe) =>
-                val msg0 +: msgs = msggen(x)
-                combinator.fail(oe - os, msg0, msgs: _*)
-            }) *> Parsley.empty
-        }
-        private [parsley] def verifiedFail(msg: String, msgs: String*): Parsley[Nothing] = this.verifyFail(_ => msg +: msgs)
-
+        def verifiedFail(msggen: A => Seq[String]): Parsley[Nothing] = verified(Left(msggen))
+        def verifiedFail(msg: String, msgs: String*): Parsley[Nothing] = this.verifiedFail(_ => msg +: msgs)
 
         // TODO: Documentation and testing ahead of future release
-        // like notFollowedBy, but does consume input on "success" and always fails (FIXME: this needs intrinsic support to get right)
+        // like notFollowedBy, but does consume input on "success" and always fails
         // it should also have the partial amend semantics, because `amendAndDislodge` can restore the other semantics anyway
         // Document that `attempt` may be used when this is an informative but not terminal error.
-        private def verifiedUnexpected(reason: Option[A => String]) = partialAmend {
-            // holy hell, the hoops I jump through to be able to implement things
-            val r = parsley.registers.Reg.make[A]
-            val fails = Parsley.notFollowedBy(r.put(con(p).hide))
-            reason.fold(fails)(rgen => fails <|> r.get.flatMap(x => Parsley.empty.explain(rgen(x)))) *> Parsley.empty
-        }
-        private [parsley] def verifiedUnexpected: Parsley[Nothing] = this.verifiedUnexpected(None)
-        private [parsley] def verifiedUnexpected(reason: String): Parsley[Nothing] = this.verifiedUnexpected(_ => reason)
-        private [parsley] def verifiedUnexpected(reason: A => String): Parsley[Nothing] = this.verifiedUnexpected(Some(reason))
+        private def verifiedUnexpected(reason: Option[A => String]) = verified(Right(reason))
+        def verifiedUnexpected: Parsley[Nothing] = this.verifiedUnexpected(None)
+        def verifiedUnexpected(reason: String): Parsley[Nothing] = this.verifiedUnexpected(_ => reason)
+        def verifiedUnexpected(reason: A => String): Parsley[Nothing] = this.verifiedUnexpected(Some(reason))
     }
 }

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrimitiveEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrimitiveEmbedding.scala
@@ -35,10 +35,10 @@ private [deepembedding] final class Look[A](val p: StrictParsley[A]) extends Sco
     // $COVERAGE-ON$
 }
 private [deepembedding] final class NotFollowedBy[A](val p: StrictParsley[A]) extends Unary[A, Unit] {
-    override def optimise: StrictParsley[Unit] = p match {
+    /*override def optimise: StrictParsley[Unit] = p match {
         case _: MZero => new Pure(())
         case _        => this
-    }
+    }*/
     final override def codeGen[Cont[_, +_]: ContOps, R](implicit instrs: InstrBuffer, state: CodeGenState): Cont[R, Unit] = {
         val handler = state.freshLabel()
         instrs += new instructions.PushHandlerAndState(handler, saveHints = true, hideHints = true)

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/ErrorEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/ErrorEmbedding.scala
@@ -25,3 +25,7 @@ private [parsley] final class ErrorDislodge[A](p: LazyParsley[A]) extends Unary[
 private [parsley] final class ErrorLexical[A](p: LazyParsley[A]) extends Unary[A, A](p) {
     override def make(p: StrictParsley[A]): StrictParsley[A] = new backend.ErrorLexical(p)
 }
+
+private [parsley] final class VerifiedError[A](p: LazyParsley[A], msggen: Either[A => Seq[String], Option[A => String]]) extends Unary[A, Nothing](p) {
+    override def make(p: StrictParsley[A]): StrictParsley[Nothing] = new backend.VerifiedError(p, msggen)
+}

--- a/parsley/shared/src/main/scala/parsley/token/errors/ConfigImplTyped.scala
+++ b/parsley/shared/src/main/scala/parsley/token/errors/ConfigImplTyped.scala
@@ -3,24 +3,10 @@
  */
 package parsley.token.errors
 
+import parsley.XCompat.unused
 import parsley.Parsley, Parsley.pure
 import parsley.errors.combinator, combinator.ErrorMethods
 import parsley.position
-
-private [parsley] object FilterOps {
-    def amendThenDislodge[A](full: Boolean)(p: Parsley[A]): Parsley[A] = {
-        if (full) combinator.amendThenDislodge(p)
-        else p
-    }
-    def amendThenDislodgeOrPartial[A](full: Boolean)(p: Parsley[A]): Parsley[A] = {
-        if (full) combinator.amendThenDislodge(p)
-        else combinator.partialAmendThenDislodge(p)
-    }
-    def entrench[A](full: Boolean)(p: Parsley[A]): Parsley[A] = {
-        if (full) combinator.entrench(p)
-        else p
-    }
-}
 
 /** This trait, and its subclasses, can be used to configure how filters should be used within the `Lexer`.
   * @since 4.1.0
@@ -48,32 +34,29 @@ trait VanillaFilterConfig[A] extends FilterConfig[A]
 
 /** This class ensures that the filter will generate ''specialised'' messages for the given failing parse.
   * @since 4.1.0
-  * @param fullAmend filters usually have partial amend semantics: should this instead do a full amend?
   * @group filters
   */
-abstract class SpecialisedMessage[A](fullAmend: Boolean) extends SpecialisedFilterConfig[A] { self =>
+abstract class SpecialisedMessage[A] extends SpecialisedFilterConfig[A] { self =>
+    @deprecated("filters do not have partial amend semantics, so this does nothing", "4.1.0")  def this(@unused fullAmend: Boolean) = this()
     /** This method produces the messages for the given value.
       * @since 4.1.0
       * @group badchar
       */
     def message(x: A): Seq[String]
 
-    private [parsley] final override def filter(p: Parsley[A])(f: A => Boolean) = FilterOps.amendThenDislodge(fullAmend) {
-        FilterOps.entrench(fullAmend)(p).guardAgainst {
-            case x if !f(x) => message(x)
-        }
+    private [parsley] final override def filter(p: Parsley[A])(f: A => Boolean) = p.guardAgainst {
+        case x if !f(x) => message(x)
     }
-    private [parsley] final override def collect[B](p: Parsley[A])(f: PartialFunction[A, B]) =  FilterOps.amendThenDislodge(fullAmend) {
-        FilterOps.entrench(fullAmend)(p).collectMsg(message(_))(f)
-    }
+
+    private [parsley] final override def collect[B](p: Parsley[A])(f: PartialFunction[A, B]) = p.collectMsg(message(_))(f)
     // $COVERAGE-OFF$
-    private [parsley] final override def injectLeft[B] = new SpecialisedMessage[Either[A, B]](fullAmend) {
+    private [parsley] final override def injectLeft[B] = new SpecialisedMessage[Either[A, B]] {
         def message(xy: Either[A, B]) = {
             val Left(x) = xy
             self.message(x)
         }
     }
-    private [parsley] final override def injectRight[B] = new SpecialisedMessage[Either[B, A]](fullAmend) {
+    private [parsley] final override def injectRight[B] = new SpecialisedMessage[Either[B, A]] {
         def message(xy: Either[B, A]) = {
             val Right(y) = xy
             self.message(y)
@@ -84,29 +67,27 @@ abstract class SpecialisedMessage[A](fullAmend: Boolean) extends SpecialisedFilt
 
 /** This class ensures that the filter will generate a ''vanilla'' unexpected item for the given failing parse.
   * @since 4.1.0
-  * @param fullAmend filters usually have partial amend semantics: should this instead do a full amend?
   * @group filters
   */
-abstract class Unexpected[A](fullAmend: Boolean) extends VanillaFilterConfig[A] { self =>
+abstract class Unexpected[A] extends VanillaFilterConfig[A] { self =>
+    @deprecated("filters do not have partial amend semantics, so this does nothing", "4.1.0")  def this(@unused fullAmend: Boolean) = this()
     /** This method produces the unexpected label for the given value.
       * @since 4.1.0
       * @group badchar
       */
     def unexpected(x: A): String
 
-    private [parsley] final override def filter(p: Parsley[A])(f: A => Boolean) = FilterOps.amendThenDislodge(fullAmend) {
-        FilterOps.entrench(fullAmend)(p).unexpectedWhen {
-            case x if !f(x) => unexpected(x)
-        }
+    private [parsley] final override def filter(p: Parsley[A])(f: A => Boolean) = p.unexpectedWhen {
+        case x if !f(x) => unexpected(x)
     }
     // $COVERAGE-OFF$
-    private [parsley] final override def injectLeft[B] = new Unexpected[Either[A, B]](fullAmend) {
+    private [parsley] final override def injectLeft[B] = new Unexpected[Either[A, B]] {
         def unexpected(xy: Either[A, B]) = {
             val Left(x) = xy
             self.unexpected(x)
         }
     }
-    private [parsley] final override def injectRight[B] = new Unexpected[Either[B, A]](fullAmend) {
+    private [parsley] final override def injectRight[B] = new Unexpected[Either[B, A]] {
         def unexpected(xy: Either[B, A]) = {
             val Right(y) = xy
             self.unexpected(y)
@@ -117,29 +98,27 @@ abstract class Unexpected[A](fullAmend: Boolean) extends VanillaFilterConfig[A] 
 
 /** This class ensures that the filter will generate a ''vanilla'' reason for the given failing parse.
   * @since 4.1.0
-  * @param fullAmend filters usually have partial amend semantics: should this instead do a full amend?
   * @group filters
   */
-abstract class Because[A](fullAmend: Boolean) extends VanillaFilterConfig[A] { self =>
+abstract class Because[A] extends VanillaFilterConfig[A] { self =>
+    @deprecated("filters do not have partial amend semantics, so this does nothing", "4.1.0")  def this(@unused fullAmend: Boolean) = this()
     /** This method produces the reason for the given value.
       * @since 4.1.0
       * @group badchar
       */
     def reason(x: A): String
 
-    private [parsley] final override def filter(p: Parsley[A])(f: A => Boolean) = FilterOps.amendThenDislodge(fullAmend) {
-        FilterOps.entrench(fullAmend)(p).filterOut {
-            case x if !f(x) => reason(x)
-        }
+    private [parsley] final override def filter(p: Parsley[A])(f: A => Boolean) = p.filterOut {
+        case x if !f(x) => reason(x)
     }
     // $COVERAGE-OFF$
-    private [parsley] final override def injectLeft[B] = new Because[Either[A, B]](fullAmend) {
+    private [parsley] final override def injectLeft[B] = new Because[Either[A, B]] {
         def reason(xy: Either[A, B]) = {
             val Left(x) = xy
             self.reason(x)
         }
     }
-    private [parsley] final override def injectRight[B] = new Because[Either[B, A]](fullAmend) {
+    private [parsley] final override def injectRight[B] = new Because[Either[B, A]] {
         def reason(xy: Either[B, A]) = {
             val Right(y) = xy
             self.reason(y)
@@ -150,10 +129,10 @@ abstract class Because[A](fullAmend: Boolean) extends VanillaFilterConfig[A] { s
 
 /** This class ensures that the filter will generate a ''vanilla'' unexpected item and a reason for the given failing parse.
   * @since 4.1.0
-  * @param fullAmend filters usually have partial amend semantics: should this instead do a full amend?
   * @group filters
   */
-abstract class UnexpectedBecause[A](fullAmend: Boolean) extends VanillaFilterConfig[A] { self =>
+abstract class UnexpectedBecause[A] extends VanillaFilterConfig[A] { self =>
+    @deprecated("filters do not have partial amend semantics, so this does nothing", "4.1.0")  def this(@unused fullAmend: Boolean) = this()
     /** This method produces the unexpected label for the given value.
       * @since 4.1.0
       * @group badchar
@@ -166,14 +145,14 @@ abstract class UnexpectedBecause[A](fullAmend: Boolean) extends VanillaFilterCon
     def reason(x: A): String
 
     // TODO: factor this combinator out with the "Great Move" in 4.2
-    private [parsley] final override def filter(p: Parsley[A])(f: A => Boolean) = FilterOps.amendThenDislodgeOrPartial(fullAmend) {
+    private [parsley] final override def filter(p: Parsley[A])(f: A => Boolean) = combinator.amendThenDislodge {
         position.internalOffsetSpan(combinator.entrench(p)).flatMap { case (os, x, oe) =>
             if (f(x)) combinator.unexpected(oe - os, this.unexpected(x)).explain(reason(x))
             else pure(x)
         }
     }
     // $COVERAGE-OFF$
-    private [parsley] final override def injectLeft[B] = new UnexpectedBecause[Either[A, B]](fullAmend) {
+    private [parsley] final override def injectLeft[B] = new UnexpectedBecause[Either[A, B]] {
         def unexpected(xy: Either[A, B]) = {
             val Left(x) = xy
             self.unexpected(x)
@@ -183,7 +162,7 @@ abstract class UnexpectedBecause[A](fullAmend: Boolean) extends VanillaFilterCon
             self.reason(x)
         }
     }
-    private [parsley] final override def injectRight[B] = new UnexpectedBecause[Either[B, A]](fullAmend) {
+    private [parsley] final override def injectRight[B] = new UnexpectedBecause[Either[B, A]] {
         def unexpected(xy: Either[B, A]) = {
             val Right(y) = xy
             self.unexpected(y)

--- a/parsley/shared/src/main/scala/parsley/token/errors/ErrorConfig.scala
+++ b/parsley/shared/src/main/scala/parsley/token/errors/ErrorConfig.scala
@@ -361,7 +361,7 @@ class ErrorConfig {
       * @note defaults to a ''specialised'' error describing what the min and max bounds are.
       * @group numeric
       */
-    def filterIntegerOutOfBounds(min: BigInt, max: BigInt, nativeRadix: Int): FilterConfig[BigInt] = new SpecialisedMessage[BigInt](fullAmend = false) {
+    def filterIntegerOutOfBounds(min: BigInt, max: BigInt, nativeRadix: Int): FilterConfig[BigInt] = new SpecialisedMessage[BigInt] {
         def message(n: BigInt) = Seq(s"literal is not within the range ${min.toString(nativeRadix)} to ${max.toString(nativeRadix)}")
     }
 
@@ -371,7 +371,7 @@ class ErrorConfig {
       * @note defaults to a ''specialised'' error stating that the literal is not exactly representable.
       * @group numeric
       */
-    def filterRealNotExact(name: String): FilterConfig[BigDecimal] = new SpecialisedMessage[BigDecimal](fullAmend = false) {
+    def filterRealNotExact(name: String): FilterConfig[BigDecimal] = new SpecialisedMessage[BigDecimal] {
         def message(n: BigDecimal) = Seq(s"literal cannot be represented exactly as an $name")
     }
 
@@ -384,7 +384,7 @@ class ErrorConfig {
       * @group numeric
       */
     def filterRealOutOfBounds(name: String, min: BigDecimal, max: BigDecimal): FilterConfig[BigDecimal] =
-        new SpecialisedMessage[BigDecimal](fullAmend = false) {
+        new SpecialisedMessage[BigDecimal] {
             def message(n: BigDecimal) = Seq(s"literal is not within the range $min to $max and is not an $name")
         }
 
@@ -453,7 +453,7 @@ class ErrorConfig {
       * @note defaults to unexpected "identifier v"
       * @group names
       */
-    def filterNameIllFormedIdentifier: FilterConfig[String] = new Unexpected[String](fullAmend = false) {
+    def filterNameIllFormedIdentifier: FilterConfig[String] = new Unexpected[String] {
         def unexpected(v: String) = s"identifer $v"
     }
     /** When parsing operators that are required to have specific start/end characters, how bad operators should be reported.
@@ -461,7 +461,7 @@ class ErrorConfig {
       * @note defaults to unexpected "operator v"
       * @group names
       */
-    def filterNameIllFormedOperator: FilterConfig[String] = new Unexpected[String](fullAmend = false) {
+    def filterNameIllFormedOperator: FilterConfig[String] = new Unexpected[String] {
         def unexpected(v: String) = s"operator $v"
     }
 
@@ -632,7 +632,7 @@ class ErrorConfig {
       * @note defaults to a filter generating the reason "non-BMP character"
       * @group text
       */
-    def filterCharNonBasicMultilingualPlane: VanillaFilterConfig[Int] = new Because[Int](fullAmend = false) {
+    def filterCharNonBasicMultilingualPlane: VanillaFilterConfig[Int] = new Because[Int] {
         def reason(@unused x: Int) = "non-BMP character"
     }
     /** When a non-ASCII character is found in a ASCII-only character literal, specifies how this should be reported.
@@ -640,7 +640,7 @@ class ErrorConfig {
       * @note defaults to a filter generating the reason "non-ascii character"
       * @group text
       */
-    def filterCharNonAscii: VanillaFilterConfig[Int] = new Because[Int](fullAmend = false) {
+    def filterCharNonAscii: VanillaFilterConfig[Int] = new Because[Int] {
         def reason(@unused x: Int) = "non-ascii character"
     }
     /** When a non-Latin1 character is found in a Latin1-only character literal, specifies how this should be reported.
@@ -648,7 +648,7 @@ class ErrorConfig {
       * @note defaults to a filter generating the reason "non-latin1 character"
       * @group text
       */
-    def filterCharNonLatin1: VanillaFilterConfig[Int] = new Because[Int](fullAmend = false) {
+    def filterCharNonLatin1: VanillaFilterConfig[Int] = new Because[Int] {
         def reason(@unused x: Int) = "non-latin1 character"
     }
 
@@ -657,7 +657,7 @@ class ErrorConfig {
       * @note defaults to a filter generating a ''specialised'' message of "non-ascii characters in string literal, this is not allowed"
       * @group text
       */
-    def filterStringNonAscii: SpecialisedFilterConfig[StringBuilder] = new SpecialisedMessage[StringBuilder](fullAmend = false) {
+    def filterStringNonAscii: SpecialisedFilterConfig[StringBuilder] = new SpecialisedMessage[StringBuilder] {
         def message(@unused s: StringBuilder) = Seq("non-ascii characters in string literal, this is not allowed")
     }
 
@@ -666,7 +666,7 @@ class ErrorConfig {
       * @note defaults to a filter generating a ''specialised'' message of "non-latin1 characters in string literal, this is not allowed"
       * @group text
       */
-    def filterStringNonLatin1: SpecialisedFilterConfig[StringBuilder] = new SpecialisedMessage[StringBuilder](fullAmend = false) {
+    def filterStringNonLatin1: SpecialisedFilterConfig[StringBuilder] = new SpecialisedMessage[StringBuilder] {
         def message(@unused s: StringBuilder) = Seq("non-latin1 characters in string literal, this is not allowed")
     }
 
@@ -679,7 +679,7 @@ class ErrorConfig {
       * @group text
       */
     def filterEscapeCharRequiresExactDigits(@unused radix: Int, needed: Seq[Int]): SpecialisedFilterConfig[Int] =
-        new SpecialisedMessage[Int](fullAmend = false) {
+        new SpecialisedMessage[Int] {
             def message(got: Int) = Seq(
                 s"numeric escape requires ${parsley.errors.helpers.combineAsList(needed.toList.map(_.toString))} digits, but only got $got"
             )
@@ -693,7 +693,7 @@ class ErrorConfig {
       * @group text
       */
     def filterEscapeCharNumericSequenceIllegal(maxEscape: Int, radix: Int): SpecialisedFilterConfig[BigInt] =
-        new SpecialisedMessage[BigInt](fullAmend = false) {
+        new SpecialisedMessage[BigInt] {
             def message(escapeChar: BigInt) = Seq(
                 if (escapeChar > BigInt(maxEscape)) {
                     s"${escapeChar.toString(radix)} is greater than the maximum character value of ${BigInt(maxEscape).toString(radix)}"

--- a/parsley/shared/src/main/scala/parsley/token/errors/VerifiedAndPreventativeErrors.scala
+++ b/parsley/shared/src/main/scala/parsley/token/errors/VerifiedAndPreventativeErrors.scala
@@ -73,7 +73,7 @@ sealed abstract class VerifiedBadChars {
     private [token] def checkBadChar: Parsley[Nothing]
 }
 private final class BadCharsFail private (cs: Map[Int, Seq[String]]) extends VerifiedBadChars {
-    private [token] def checkBadChar: Parsley[Nothing] = satisfyUtf16(cs.contains).fail(cs.apply(_))
+    private [token] def checkBadChar: Parsley[Nothing] = satisfyUtf16(cs.contains).verifyFail(cs.apply(_))
 }
 /** This object makes "bad literal chars" generate a bunch of given messages in a ''specialised'' error. Requires a map from bad characters to their messages.
   * @since 4.1.0
@@ -84,7 +84,7 @@ object BadCharsFail {
 }
 
 private final class BadCharsReason private (cs: Map[Int, String]) extends VerifiedBadChars {
-    private [token] def checkBadChar: Parsley[Nothing] = satisfyUtf16(cs.contains)._unexpected(cs.apply)
+    private [token] def checkBadChar: Parsley[Nothing] = satisfyUtf16(cs.contains).verifyUnexpected(cs.apply(_))
 }
 /** This object makes "bad literal chars" generate a reason in a ''vanilla'' error. Requires a map from bad characters to their reasons.
   * @since 4.1.0

--- a/parsley/shared/src/main/scala/parsley/token/errors/VerifiedAndPreventativeErrors.scala
+++ b/parsley/shared/src/main/scala/parsley/token/errors/VerifiedAndPreventativeErrors.scala
@@ -73,7 +73,7 @@ sealed abstract class VerifiedBadChars {
     private [token] def checkBadChar: Parsley[Nothing]
 }
 private final class BadCharsFail private (cs: Map[Int, Seq[String]]) extends VerifiedBadChars {
-    private [token] def checkBadChar: Parsley[Nothing] = satisfyUtf16(cs.contains).verifyFail(cs.apply(_))
+    private [token] def checkBadChar: Parsley[Nothing] = satisfyUtf16(cs.contains).verifiedFail(cs.apply(_))
 }
 /** This object makes "bad literal chars" generate a bunch of given messages in a ''specialised'' error. Requires a map from bad characters to their messages.
   * @since 4.1.0

--- a/parsley/shared/src/main/scala/parsley/token/errors/VerifiedAndPreventativeErrors.scala
+++ b/parsley/shared/src/main/scala/parsley/token/errors/VerifiedAndPreventativeErrors.scala
@@ -5,7 +5,7 @@ package parsley.token.errors
 
 import parsley.Parsley, Parsley.{pure, empty}
 import parsley.character.satisfyUtf16
-import parsley.errors.combinator, combinator.ErrorMethods
+import parsley.errors.{combinator, patterns}, combinator.ErrorMethods, patterns.VerifiedErrors
 import parsley.position
 
 /** This class is used to configure what error is generated when `.` is parsed as a real number.

--- a/parsley/shared/src/main/scala/parsley/token/errors/VerifiedAndPreventativeErrors.scala
+++ b/parsley/shared/src/main/scala/parsley/token/errors/VerifiedAndPreventativeErrors.scala
@@ -84,7 +84,7 @@ object BadCharsFail {
 }
 
 private final class BadCharsReason private (cs: Map[Int, String]) extends VerifiedBadChars {
-    private [token] def checkBadChar: Parsley[Nothing] = satisfyUtf16(cs.contains).verifyUnexpected(cs.apply(_))
+    private [token] def checkBadChar: Parsley[Nothing] = satisfyUtf16(cs.contains).verifiedUnexpected(cs.apply(_))
 }
 /** This object makes "bad literal chars" generate a reason in a ''vanilla'' error. Requires a map from bad characters to their reasons.
   * @since 4.1.0


### PR DESCRIPTION
Adds support for _Verified Errors_ combinators, to `parsley.errors.patterns`.