### PR TITLE
Optimised the general unicode combinators for `Lexer`

### DIFF
--- a/parsley/shared/src/main/scala/parsley/character.scala
+++ b/parsley/shared/src/main/scala/parsley/character.scala
@@ -125,7 +125,7 @@ object character {
       */
     private [parsley] def charUtf16(c: Int): Parsley[Int] = { //TODO: release along with the utf combinators
         if (Character.isBmpCodePoint(c)) char(c.toChar) #> c
-        else attempt(string(Character.toChars(c).mkString)) #> c
+        else new Parsley(new singletons.SupplementaryCharTok(c, NotConfigured))
     }
 
     /** This combinator tries to parse a single character from the input that matches the given predicate.

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/AlternativeEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/AlternativeEmbedding.scala
@@ -227,7 +227,8 @@ private [backend] object Choice {
 
     @tailrec private def tablable(p: StrictParsley[_], backtracks: Boolean): Option[(Char, Option[ExpectItem], Int, Boolean)] = p match {
         // CODO: Numeric parsers by leading digit (This one would require changing the foldTablified function a bit)
-        case ct@CharTok(d)                       => Some((d, ct.expected.asExpectItem(d), 1, backtracks))
+        case ct@CharTok(c)                       => Some((c, ct.expected.asExpectItem(c), 1, backtracks))
+        case ct@SupplementaryCharTok(c)          => Some((Character.highSurrogate(c), ct.expected.asExpectItem(Character.toChars(c).mkString), 1, backtracks))
         case st@StringTok(s)                     => Some((s.head, st.expected.asExpectItem(s), s.codePointCount(0, s.length), backtracks))
         //case op@MaxOp(o)                         => Some((o.head, Some(Desc(o)), o.size, backtracks))
         //case _: StringLiteral | RawStringLiteral => Some(('"', Some(Desc("string")), 1, backtracks))

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/ErrorEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/ErrorEmbedding.scala
@@ -19,6 +19,7 @@ private [deepembedding] final class ErrorLabel[A](val p: StrictParsley[A], priva
         case ct@CharTok(c) if ct.expected ne Hidden => new CharTok(c, Label(label)).asInstanceOf[StrictParsley[A]]
         case st@StringTok(s) if st.expected ne Hidden => new StringTok(s, Label(label)).asInstanceOf[StrictParsley[A]]
         case sat@Satisfy(f) if sat.expected ne Hidden => new Satisfy(f, Label(label)).asInstanceOf[StrictParsley[A]]
+        case sat@UniSatisfy(f) if sat.expected ne Hidden => new UniSatisfy(f, Label(label)).asInstanceOf[StrictParsley[A]]
         // TODO: The hide property is required to be checked, but there is no test for it
         case ErrorLabel(p, label2) if label2.nonEmpty => ErrorLabel(p, label)
         case _ => this

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/ErrorEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/ErrorEmbedding.scala
@@ -17,6 +17,7 @@ private [deepembedding] final class ErrorLabel[A](val p: StrictParsley[A], priva
     override def handlerLabel(state: CodeGenState): Int = state.getLabelForRelabelError(label)
     final override def optimise: StrictParsley[A] = p match {
         case ct@CharTok(c) if ct.expected ne Hidden => new CharTok(c, Label(label)).asInstanceOf[StrictParsley[A]]
+        case ct@SupplementaryCharTok(c) if ct.expected ne Hidden => new SupplementaryCharTok(c, Label(label)).asInstanceOf[StrictParsley[A]]
         case st@StringTok(s) if st.expected ne Hidden => new StringTok(s, Label(label)).asInstanceOf[StrictParsley[A]]
         case sat@Satisfy(f) if sat.expected ne Hidden => new Satisfy(f, Label(label)).asInstanceOf[StrictParsley[A]]
         case sat@UniSatisfy(f) if sat.expected ne Hidden => new UniSatisfy(f, Label(label)).asInstanceOf[StrictParsley[A]]

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/SequenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/SequenceEmbedding.scala
@@ -73,6 +73,7 @@ private [deepembedding] final class <*>[A, B](var left: StrictParsley[A => B], v
         // pure f <*> p = f <$> p
         case Pure(f) => right match {
             case ct@CharTok(c) => result(instrs += instructions.CharTokFastPerform[Char, B](c, f.asInstanceOf[Char => B], ct.expected))
+            case ct@SupplementaryCharTok(c) => result(instrs += instructions.SupplementaryCharTokFastPerform[Int, B](c, f.asInstanceOf[Int => B], ct.expected))
             case st@StringTok(s) => result(instrs += instructions.StringTokFastPerform(s, f.asInstanceOf[String => B], st.expected))
             case _ =>
                 suspend(right.codeGen[Cont, R]) |>

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/singletons/IntrinsicEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/singletons/IntrinsicEmbedding.scala
@@ -30,6 +30,13 @@ private [parsley] object Eof extends Singleton[Unit] {
     override val instr: instructions.Instr = instructions.Eof
 }
 
+private [parsley] final class UniSatisfy(private [UniSatisfy] val f: Int => Boolean, val expected: LabelConfig) extends Singleton[Int] {
+    // $COVERAGE-OFF$
+    override def pretty: String = "satisfyUnicode(?)"
+    // $COVERAGE-ON$
+    override def instr: instructions.Instr = new instructions.UniSat(f, expected)
+}
+
 private [parsley] final class Modify[S](val reg: Reg[S], f: S => S) extends Singleton[Unit] with UsesRegister {
     // $COVERAGE-OFF$
     override def pretty: String = s"modify($reg, ?)"
@@ -42,4 +49,7 @@ private [deepembedding] object CharTok {
 }
 private [deepembedding] object StringTok {
     def unapply(self: StringTok): Option[String] = Some(self.s)
+}
+private [deepembedding] object UniSatisfy {
+    def unapply(self: UniSatisfy): Option[Int => Boolean] = Some(self.f)
 }

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/singletons/IntrinsicEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/singletons/IntrinsicEmbedding.scala
@@ -13,14 +13,21 @@ private [parsley] final class CharTok(private [CharTok] val c: Char, val expecte
     // $COVERAGE-OFF$
     override def pretty: String = s"char($c)"
     // $COVERAGE-ON$
-    override def instr: instructions.Instr = instructions.CharTok(c, expected)
+    override def instr: instructions.Instr = new instructions.CharTok(c, expected)
+}
+
+private [parsley] final class SupplementaryCharTok(private [SupplementaryCharTok] val codepoint: Int, val expected: LabelConfig) extends Singleton[Int] {
+    // $COVERAGE-OFF$
+    override def pretty: String = s"char(${Character.toChars(codepoint).mkString})"
+    // $COVERAGE-ON$
+    override def instr: instructions.Instr = new instructions.SupplementaryCharTok(codepoint, expected)
 }
 
 private [parsley] final class StringTok(private [StringTok] val s: String, val expected: LabelConfig) extends Singleton[String] {
     // $COVERAGE-OFF$
     override def pretty: String = s"string($s)"
     // $COVERAGE-ON$
-    override def instr: instructions.Instr = instructions.StringTok(s, expected)
+    override def instr: instructions.Instr = new instructions.StringTok(s, expected)
 }
 
 private [parsley] object Eof extends Singleton[Unit] {
@@ -46,6 +53,9 @@ private [parsley] final class Modify[S](val reg: Reg[S], f: S => S) extends Sing
 
 private [deepembedding] object CharTok {
     def unapply(self: CharTok): Option[Char] = Some(self.c)
+}
+private [deepembedding] object SupplementaryCharTok {
+    def unapply(self: SupplementaryCharTok): Option[Int] = Some(self.codepoint)
 }
 private [deepembedding] object StringTok {
     def unapply(self: StringTok): Option[String] = Some(self.s)

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/singletons/PrimitiveEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/singletons/PrimitiveEmbedding.scala
@@ -12,7 +12,7 @@ private [parsley] final class Satisfy(private [Satisfy] val f: Char => Boolean, 
     // $COVERAGE-OFF$
     override val pretty: String = "satisfy(f)"
     // $COVERAGE-ON$
-    override def instr: instructions.Instr = instructions.Satisfies(f, expected)
+    override def instr: instructions.Instr = new instructions.Satisfies(f, expected)
 }
 
 private [parsley] object Line extends Singleton[Int] {

--- a/parsley/shared/src/main/scala/parsley/internal/machine/Context.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/Context.scala
@@ -235,15 +235,17 @@ private [parsley] final class Context(private [machine] var instrs: Array[Instr]
         inc()
     }
     private [machine] def inc(): Unit = pc += 1
-    private [machine] def nextChar: Char = input.charAt(offset)
+    private [machine] def peekChar: Char = input.charAt(offset)
+    private [machine] def peekChar(lookAhead: Int): Char = input.charAt(offset + lookAhead)
     private [machine] def moreInput: Boolean = offset < inputsz
+    private [machine] def moreInput(n: Int): Boolean = offset + (n - 1) < inputsz
     private [machine] def updatePos(c: Char) = c match {
         case '\n' => line += 1; col = 1
         case '\t' => col = ((col + 3) & -4) | 1//((col - 1) | 3) + 2 // scalastyle:ignore magic.number
         case _    => col += 1
     }
     private [machine] def consumeChar(): Char = {
-        val c = nextChar
+        val c = peekChar
         updatePos(c)
         offset += 1
         c

--- a/parsley/shared/src/main/scala/parsley/internal/machine/instructions/OptInstrs.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/instructions/OptInstrs.scala
@@ -41,7 +41,7 @@ private [internal] final class SatisfyExchange[A](f: Char => Boolean, x: A, _exp
     private [this] final val expected = _expected.asExpectDesc
     override def apply(ctx: Context): Unit = {
         ensureRegularInstruction(ctx)
-        if (ctx.moreInput && f(ctx.nextChar)) {
+        if (ctx.moreInput && f(ctx.peekChar)) {
             ctx.consumeChar()
             ctx.pushAndContinue(x)
         }
@@ -94,7 +94,7 @@ private [internal] final class JumpTable(jumpTable: mutable.LongMap[(Int, Set[Ex
     override def apply(ctx: Context): Unit = {
         ensureRegularInstruction(ctx)
         if (ctx.moreInput) {
-            val (dest, errorItems) = jumpTable.getOrElse(ctx.nextChar.toLong, (default, allErrorItems))
+            val (dest, errorItems) = jumpTable.getOrElse(ctx.peekChar.toLong, (default, allErrorItems))
             ctx.pc = dest
             if (dest != default) {
                 ctx.pushCheck()

--- a/parsley/shared/src/main/scala/parsley/internal/machine/instructions/PrimitiveInstrs.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/instructions/PrimitiveInstrs.scala
@@ -10,17 +10,15 @@ import parsley.internal.machine.Context
 import parsley.internal.machine.XAssert._
 
 private [internal] final class Satisfies(f: Char => Boolean, expected: Option[ExpectDesc]) extends Instr {
+    def this(f: Char => Boolean, expected: LabelConfig) = this(f, expected.asExpectDesc)
     override def apply(ctx: Context): Unit = {
         ensureRegularInstruction(ctx)
-        if (ctx.moreInput && f(ctx.nextChar)) ctx.pushAndContinue(ctx.consumeChar())
+        if (ctx.moreInput && f(ctx.peekChar)) ctx.pushAndContinue(ctx.consumeChar())
         else ctx.expectedFail(expected, unexpectedWidth = 1)
     }
     // $COVERAGE-OFF$
     override def toString: String = "Sat(?)"
     // $COVERAGE-ON$
-}
-private [internal] object Satisfies {
-    def apply(f: Char => Boolean, expected: LabelConfig): Satisfies = new Satisfies(f, expected.asExpectDesc)
 }
 
 private [internal] object RestoreAndFail extends Instr {

--- a/parsley/shared/src/main/scala/parsley/internal/machine/instructions/TokenInstrs.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/instructions/TokenInstrs.scala
@@ -31,7 +31,7 @@ private [instructions] abstract class CommentLexer extends Instr {
 
     @tailrec private final def consumeSingle(ctx: Context): Boolean = {
         if (ctx.moreInput) {
-            if (ctx.nextChar != '\n') {
+            if (ctx.peekChar != '\n') {
                 ctx.consumeChar()
                 consumeSingle(ctx)
             }
@@ -176,7 +176,7 @@ private [internal] final class TokenWhiteSpace private (
              errConfig.labelSpaceEndOfLineComment.asExpectDesc("end of line"))
     }
     override def spaces(ctx: Context): Unit = {
-        while (ctx.moreInput && ws(ctx.nextChar)) {
+        while (ctx.moreInput && ws(ctx.peekChar)) {
             ctx.consumeChar()
         }
     }
@@ -210,7 +210,7 @@ private [internal] final class TokenNonSpecific(name: String, unexpectedIllegal:
 
     override def apply(ctx: Context): Unit = {
         ensureRegularInstruction(ctx)
-        if (ctx.moreInput && start(ctx.nextChar)) {
+        if (ctx.moreInput && start(ctx.peekChar)) {
             val initialOffset = ctx.offset
             ctx.offset += 1
             restOfToken(ctx, initialOffset)
@@ -230,7 +230,7 @@ private [internal] final class TokenNonSpecific(name: String, unexpectedIllegal:
     }
 
     @tailrec private def restOfToken(ctx: Context, initialOffset: Int): Unit = {
-        if (ctx.moreInput && letter(ctx.nextChar)) {
+        if (ctx.moreInput && letter(ctx.peekChar)) {
             ctx.offset += 1
             restOfToken(ctx, initialOffset)
         }

--- a/parsley/shared/src/main/scala/parsley/internal/machine/instructions/TokenNumericInstrs.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/instructions/TokenNumericInstrs.scala
@@ -26,11 +26,11 @@ private [internal] final class TokenSign(ty: SignType, plusPresence: PlusSignPre
     override def apply(ctx: Context): Unit = {
         ensureRegularInstruction(ctx)
         // This could be simplified, but the "fail" branches need to be duplicated...
-        if (ctx.moreInput && ctx.nextChar == '-') {
+        if (ctx.moreInput && ctx.peekChar == '-') {
             ctx.fastUncheckedConsumeChars(1)
             ctx.pushAndContinue(neg)
         }
-        else if ((plusPresence ne PlusSignPresence.Illegal) && ctx.moreInput && ctx.nextChar == '+') {
+        else if ((plusPresence ne PlusSignPresence.Illegal) && ctx.moreInput && ctx.peekChar == '+') {
             ctx.fastUncheckedConsumeChars(1)
             ctx.pushAndContinue(pos)
         }


### PR DESCRIPTION
Optimises the generic combinators used for unicode consumption: `satisfyUtf16` and `charUtf16`. The former was previously using a `flatMap`, so this should be a substantial improvement. 