### PR TITLE
Remove unnecessary `clear` during sequence merging

### DIFF
--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/SequenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/SequenceEmbedding.scala
@@ -137,8 +137,6 @@ private [deepembedding] final class Seq[A](private [backend] var before: DoublyL
     }
 
     private def mergeFromRight(p: Seq[_], into: DoublyLinkedList[StrictParsley[_]]): this.type = {
-        assume(after.isEmpty || after.size == 1 && (after.head eq p), "after can only contain just p, which is going to get flattened")
-        after.clear()
         into.stealAll(p.before)
         Seq.whenNonPure(p.res, into.addOne(_))
         into.stealAll(p.after)
@@ -173,6 +171,7 @@ private [deepembedding] final class Seq[A](private [backend] var before: DoublyL
                     before = rs1
                     res = rr
                     assume(!rr.isInstanceOf[Pure[_]] || rs2.isEmpty, "rs2 is empty when rr is Pure")
+                    assume(after.size == 1 && (after.head eq p), "after can only contain just p, which is going to get flattened, so it can be dropped")
                     after = rs2
                     val into = chooseInto(rr)
                     p match {


### PR DESCRIPTION
Fixes #156. Removed a bad clear that is performed after the corresponding list has already been reassigned. It turns out it doesn't need to be cleared anyway: either it's already empty, or it's reassigned and GC'd immediately.