### PR TITLE
Corrected sequence normalisation with `pure`

### DIFF
--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/SequenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/SequenceEmbedding.scala
@@ -186,7 +186,7 @@ private [deepembedding] final class Seq[A](private [backend] var before: DoublyL
             after.clear()
             mergeFromRight(p, chooseInto(r))
         // shift pure to the right by swapping before and after (before is empty linked list!)
-        case (_: Pure[_]) <** _ =>
+        case (_: Pure[_]) <* _ =>
             assume(before.isEmpty, "empty can reuse before instead of allocating a new list because before is empty")
             val empty = before
             before = after


### PR DESCRIPTION
Fixes #161, the normalisation that moves all pures to the end of a `Seq` node only fires if there is only one node in the "after" set, it should fire regardless.