### PR TITLE
Removed the type casts within the `expr` machinery

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,14 @@ inThisBuild(List(
     ProblemFilters.exclude[DirectMissingMethodProblem]("parsley.errors.combinator#ErrorMethods.unexpected"),
     ProblemFilters.exclude[MissingClassProblem]("parsley.token.errors.FilterOps"),
     ProblemFilters.exclude[MissingClassProblem]("parsley.token.errors.FilterOps$"),
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("parsley.token.predicate#CharPredicate.asInternalPredicate")
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("parsley.token.predicate#CharPredicate.asInternalPredicate"),
+    // Expression refactor
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("parsley.expr.Fixity.makeOps"),
+    ProblemFilters.exclude[MissingClassProblem]("parsley.expr.Lefts*"),
+    ProblemFilters.exclude[MissingClassProblem]("parsley.expr.Rights*"),
+    ProblemFilters.exclude[MissingClassProblem]("parsley.expr.NonAssocs*"),
+    ProblemFilters.exclude[MissingClassProblem]("parsley.expr.Prefixes*"),
+    ProblemFilters.exclude[MissingClassProblem]("parsley.expr.Postfixes*"),
   ),
   tlVersionIntroduced := Map(
     "2.13" -> "1.5.0",

--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,8 @@ inThisBuild(List(
     ProblemFilters.exclude[MissingClassProblem]("parsley.token.errors.FilterOps$"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("parsley.token.predicate#CharPredicate.asInternalPredicate"),
     // Expression refactor
-    ProblemFilters.exclude[ReversedMissingMethodProblem]("parsley.expr.Fixity.makeOps"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("parsley.expr.Fixity.chain"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("parsley.expr.Ops.chain"),
     ProblemFilters.exclude[MissingClassProblem]("parsley.expr.Lefts*"),
     ProblemFilters.exclude[MissingClassProblem]("parsley.expr.Rights*"),
     ProblemFilters.exclude[MissingClassProblem]("parsley.expr.NonAssocs*"),

--- a/parsley/shared/src/main/scala/parsley/expr/Fixity.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/Fixity.scala
@@ -3,6 +3,8 @@
  */
 package parsley.expr
 
+import parsley.Parsley
+
 /**
   * Denotes the fixity and associativity of an operator. Importantly, it also specifies the type of the
   * of the operations themselves.
@@ -11,6 +13,7 @@ package parsley.expr
   */
 sealed trait Fixity {
     type Op[A, B]
+    private [expr] def makeOps[A, B](op: Parsley[Op[A, B]])(implicit wrap: A => B): Ops[A, B]
 }
 
 /**
@@ -20,6 +23,7 @@ sealed trait Fixity {
   */
 case object InfixL extends Fixity {
     override type Op[-A, B] = (B, A) => B
+    private [expr] def makeOps[A, B](op: Parsley[Op[A, B]])(implicit wrap: A => B): Ops[A, B] = LeftOp(op)
 }
 
 /**
@@ -29,6 +33,7 @@ case object InfixL extends Fixity {
   */
 case object InfixR extends Fixity {
     override type Op[-A, B] = (A, B) => B
+    private [expr] def makeOps[A, B](op: Parsley[Op[A, B]])(implicit wrap: A => B): Ops[A, B] = RightOp(op)
 }
 
 /**
@@ -38,6 +43,7 @@ case object InfixR extends Fixity {
   */
 case object Prefix extends Fixity {
     override type Op[A, B] = B => B
+    private [expr] def makeOps[A, B](op: Parsley[Op[A, B]])(implicit wrap: A => B): Ops[A, B] = PrefixOp(op)
 }
 
 /**
@@ -47,6 +53,7 @@ case object Prefix extends Fixity {
   */
 case object Postfix extends Fixity {
     override type Op[A, B] = B => B
+    private [expr] def makeOps[A, B](op: Parsley[Op[A, B]])(implicit wrap: A => B): Ops[A, B] = PostfixOp(op)
 }
 
 /**
@@ -56,4 +63,5 @@ case object Postfix extends Fixity {
   */
 case object InfixN extends Fixity {
     override type Op[-A, +B] = (A, A) => B
+    private [expr] def makeOps[A, B](op: Parsley[Op[A, B]])(implicit wrap: A => B): Ops[A, B] = NonAssocOp(op)
 }

--- a/parsley/shared/src/main/scala/parsley/expr/Fixity.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/Fixity.scala
@@ -13,7 +13,7 @@ import parsley.Parsley
   */
 sealed trait Fixity {
     type Op[A, B]
-    private [expr] def makeOps[A, B](op: Parsley[Op[A, B]])(implicit wrap: A => B): Ops[A, B]
+    private [expr] def chain[A, B](p: Parsley[A], op: Parsley[Op[A, B]])(implicit wrap: A => B): Parsley[B]
 }
 
 /**
@@ -23,7 +23,7 @@ sealed trait Fixity {
   */
 case object InfixL extends Fixity {
     override type Op[-A, B] = (B, A) => B
-    private [expr] def makeOps[A, B](op: Parsley[Op[A, B]])(implicit wrap: A => B): Ops[A, B] = LeftOp(op)
+    private [expr] def chain[A, B](p: Parsley[A], op: Parsley[Op[A, B]])(implicit wrap: A => B): Parsley[B] = infix.left1(p, op)
 }
 
 /**
@@ -33,7 +33,7 @@ case object InfixL extends Fixity {
   */
 case object InfixR extends Fixity {
     override type Op[-A, B] = (A, B) => B
-    private [expr] def makeOps[A, B](op: Parsley[Op[A, B]])(implicit wrap: A => B): Ops[A, B] = RightOp(op)
+    private [expr] def chain[A, B](p: Parsley[A], op: Parsley[Op[A, B]])(implicit wrap: A => B): Parsley[B] = infix.right1(p, op)
 }
 
 /**
@@ -43,7 +43,7 @@ case object InfixR extends Fixity {
   */
 case object Prefix extends Fixity {
     override type Op[A, B] = B => B
-    private [expr] def makeOps[A, B](op: Parsley[Op[A, B]])(implicit wrap: A => B): Ops[A, B] = PrefixOp(op)
+    private [expr] def chain[A, B](p: Parsley[A], op: Parsley[Op[A, B]])(implicit wrap: A => B): Parsley[B] = infix.prefix(op, p)
 }
 
 /**
@@ -53,7 +53,7 @@ case object Prefix extends Fixity {
   */
 case object Postfix extends Fixity {
     override type Op[A, B] = B => B
-    private [expr] def makeOps[A, B](op: Parsley[Op[A, B]])(implicit wrap: A => B): Ops[A, B] = PostfixOp(op)
+    private [expr] def chain[A, B](p: Parsley[A], op: Parsley[Op[A, B]])(implicit wrap: A => B): Parsley[B] = infix.postfix(p, op)
 }
 
 /**
@@ -63,5 +63,5 @@ case object Postfix extends Fixity {
   */
 case object InfixN extends Fixity {
     override type Op[-A, +B] = (A, A) => B
-    private [expr] def makeOps[A, B](op: Parsley[Op[A, B]])(implicit wrap: A => B): Ops[A, B] = NonAssocOp(op)
+    private [expr] def chain[A, B](p: Parsley[A], op: Parsley[Op[A, B]])(implicit wrap: A => B): Parsley[B] = infix.nonassoc(p, op)
 }

--- a/parsley/shared/src/main/scala/parsley/expr/Ops.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/Ops.scala
@@ -19,11 +19,11 @@ import parsley.Parsley
 sealed abstract class Ops[-A, B] {
     private [expr] val wrap: A => B
 }
-private [expr] case class Lefts[A, B](ops: Parsley[InfixL.Op[A, B]]*)(implicit override val wrap: A => B) extends Ops[A, B]
-private [expr] case class Rights[A, B](ops: Parsley[InfixR.Op[A, B]]*)(implicit override val wrap: A => B) extends Ops[A, B]
-private [expr] case class Prefixes[A, B](ops: Parsley[Prefix.Op[A, B]]*)(implicit override val wrap: A => B) extends Ops[A, B]
-private [expr] case class Postfixes[A, B](ops: Parsley[Postfix.Op[A, B]]*)(implicit override val wrap: A => B) extends Ops[A, B]
-private [expr] case class NonAssocs[A, B](ops: Parsley[InfixN.Op[A, B]]*)(implicit override val wrap: A => B) extends Ops[A, B]
+private [expr] case class LeftOp[A, B](ops: Parsley[InfixL.Op[A, B]])(implicit override val wrap: A => B) extends Ops[A, B]
+private [expr] case class RightOp[A, B](ops: Parsley[InfixR.Op[A, B]])(implicit override val wrap: A => B) extends Ops[A, B]
+private [expr] case class PrefixOp[A, B](ops: Parsley[Prefix.Op[A, B]])(implicit override val wrap: A => B) extends Ops[A, B]
+private [expr] case class PostfixOp[A, B](ops: Parsley[Postfix.Op[A, B]])(implicit override val wrap: A => B) extends Ops[A, B]
+private [expr] case class NonAssocOp[A, B](ops: Parsley[InfixN.Op[A, B]])(implicit override val wrap: A => B) extends Ops[A, B]
 
 /** This helper object is used to build values of `Ops[A, A]`, for homogeneous precedence parsing.
   *

--- a/parsley/shared/src/main/scala/parsley/expr/SmartOps.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/SmartOps.scala
@@ -4,6 +4,7 @@
 package parsley.expr
 
 import parsley.Parsley
+import parsley.combinator.choice
 
 /** This helper object builds values of `Ops[A, B]`, for fully heterogeneous precedence parsing.
   *
@@ -31,13 +32,7 @@ object GOps {
       * @note currently a bug in scaladoc incorrect displays this functions type, it should be: `fixity.Op[A, B]`, NOT `Op[A, B]`.
       * @since 2.2.0
       */
-    def apply[A, B](fixity: Fixity)(ops: Parsley[fixity.Op[A, B]]*)(implicit wrap: A => B): Ops[A, B] = fixity match {
-        case InfixL  => Lefts[A, B](ops.asInstanceOf[Seq[Parsley[InfixL.Op[A, B]]]]: _*)
-        case InfixR  => Rights[A, B](ops.asInstanceOf[Seq[Parsley[InfixR.Op[A, B]]]]: _*)
-        case Prefix  => Prefixes[A, B](ops.asInstanceOf[Seq[Parsley[Prefix.Op[A, B]]]]: _*)
-        case Postfix => Postfixes[A, B](ops.asInstanceOf[Seq[Parsley[Postfix.Op[A, B]]]]: _*)
-        case InfixN  => NonAssocs[A, B](ops.asInstanceOf[Seq[Parsley[InfixN.Op[A, B]]]]: _*)
-    }
+    def apply[A, B](fixity: Fixity)(ops: Parsley[fixity.Op[A, B]]*)(implicit wrap: A => B): Ops[A, B] = fixity.makeOps(choice(ops: _*))
 }
 
 /** This helper object builds values of `Ops[A, B]` where `A <: B`, for subtyped heterogeneous precedence parsing.

--- a/parsley/shared/src/main/scala/parsley/expr/SmartOps.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/SmartOps.scala
@@ -32,7 +32,7 @@ object GOps {
       * @note currently a bug in scaladoc incorrect displays this functions type, it should be: `fixity.Op[A, B]`, NOT `Op[A, B]`.
       * @since 2.2.0
       */
-    def apply[A, B](fixity: Fixity)(ops: Parsley[fixity.Op[A, B]]*)(implicit wrap: A => B): Ops[A, B] = fixity.makeOps(choice(ops: _*))
+    def apply[A, B](fixity: Fixity)(ops: Parsley[fixity.Op[A, B]]*)(implicit wrap: A => B): Ops[A, B] = Ops[A, B](fixity)(choice(ops: _*))(wrap)
 }
 
 /** This helper object builds values of `Ops[A, B]` where `A <: B`, for subtyped heterogeneous precedence parsing.

--- a/parsley/shared/src/main/scala/parsley/expr/precedence.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/precedence.scala
@@ -3,10 +3,8 @@
  */
 package parsley.expr
 
-import parsley.Parsley, Parsley.notFollowedBy
+import parsley.Parsley
 import parsley.combinator.choice
-import parsley.errors.combinator.ErrorMethods
-import parsley.implicits.zipped.Zipped2
 
 /** This object is used to construct precedence parsers from either a `Prec` or many `Ops[A, A]`.
   *
@@ -108,23 +106,9 @@ object precedence {
       */
     def apply[A](table: Prec[A]): Parsley[A] = crushLevels(table)
 
-    private def convertOperators[A, B](atom: Parsley[A], opList: Ops[A, B]): Parsley[B] = {
-        implicit val wrap: A => B = opList.wrap
-        opList match {
-            case LeftOp(op) => infix.left1(atom, op)
-            case RightOp(op) => infix.right1(atom, op)
-            case PrefixOp(op) => chain.prefix(op, parsley.XCompat.applyWrap(wrap)(atom))
-            // FIXME: Postfix operators which are also binary ops may fail, how can we work around this?
-            case PostfixOp(op) => chain.postfix(parsley.XCompat.applyWrap(wrap)(atom), op)
-            case NonAssocOp(op) =>
-                val guardNonAssoc = notFollowedBy(op).explain("non-associative operators cannot be chained together")
-                atom <**> ((op, atom).zipped((f, y) => f(_, y)) </> wrap) <* guardNonAssoc
-        }
-    }
-
     private def crushLevels[A](lvls: Prec[A]): Parsley[A] = lvls match {
         case Atoms(atom0, atoms @ _*) => choice((atom0 +: atoms): _*)
-        case Level(lvls, ops) => convertOperators(crushLevels(lvls), ops)
+        case Level(lvls, ops) => ops.chain(crushLevels(lvls))
     }
 
 }

--- a/parsley/shared/src/main/scala/parsley/expr/precedence.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/precedence.scala
@@ -111,13 +111,12 @@ object precedence {
     private def convertOperators[A, B](atom: Parsley[A], opList: Ops[A, B]): Parsley[B] = {
         implicit val wrap: A => B = opList.wrap
         opList match {
-            case Lefts(ops @ _*) => infix.left1(atom, choice(ops: _*))
-            case Rights(ops @ _*) => infix.right1(atom, choice(ops: _*))
-            case Prefixes(ops @ _*) => chain.prefix(choice(ops: _*), parsley.XCompat.applyWrap(wrap)(atom))
+            case LeftOp(op) => infix.left1(atom, op)
+            case RightOp(op) => infix.right1(atom, op)
+            case PrefixOp(op) => chain.prefix(op, parsley.XCompat.applyWrap(wrap)(atom))
             // FIXME: Postfix operators which are also binary ops may fail, how can we work around this?
-            case Postfixes(ops @ _*) => chain.postfix(parsley.XCompat.applyWrap(wrap)(atom), choice(ops: _*))
-            case NonAssocs(ops @ _*) =>
-                val op = choice(ops: _*)
+            case PostfixOp(op) => chain.postfix(parsley.XCompat.applyWrap(wrap)(atom), op)
+            case NonAssocOp(op) =>
                 val guardNonAssoc = notFollowedBy(op).explain("non-associative operators cannot be chained together")
                 atom <**> ((op, atom).zipped((f, y) => f(_, y)) </> wrap) <* guardNonAssoc
         }


### PR DESCRIPTION
By defining extra private functional on the `Fixity` type itself, it is possible to avoid the `asInstanceOf` and pattern matching previously used to define the logic for precedence (namely, the casts in `GOps`)