### PR TITLE
Optimised Numeric Escape Characters

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,6 +44,7 @@ inThisBuild(List(
     ProblemFilters.exclude[MissingClassProblem]("parsley.token.errors.FilterOps"),
     ProblemFilters.exclude[MissingClassProblem]("parsley.token.errors.FilterOps$"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("parsley.token.predicate#CharPredicate.asInternalPredicate"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("parsley.token.errors.FilterConfig.mkError"),
     // Expression refactor
     ProblemFilters.exclude[ReversedMissingMethodProblem]("parsley.expr.Fixity.chain"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("parsley.expr.Ops.chain"),

--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,7 @@ inThisBuild(List(
     ProblemFilters.exclude[MissingClassProblem]("parsley.token.errors.FilterOps$"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("parsley.token.predicate#CharPredicate.asInternalPredicate"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("parsley.token.errors.FilterConfig.mkError"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("parsley.token.errors.FilterConfig.injectSnd"),
     // Expression refactor
     ProblemFilters.exclude[ReversedMissingMethodProblem]("parsley.expr.Fixity.chain"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("parsley.expr.Ops.chain"),

--- a/parsley/shared/src/main/scala/parsley/character.scala
+++ b/parsley/shared/src/main/scala/parsley/character.scala
@@ -679,7 +679,7 @@ object character {
       * @see [[isHexDigit ``isHexDigit``]]
       * @group spec
       */
-    val hexDigit: Parsley[Char] = satisfy(isHexDigit(_), "hexdecimal digit")
+    val hexDigit: Parsley[Char] = satisfy(isHexDigit(_), "hexadecimal digit")
 
     /** This parser tries to parse an octal digit, and returns it if successful.
       *

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/singletons/token/TextEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/singletons/token/TextEmbedding.scala
@@ -22,13 +22,6 @@ private [parsley] final class EscapeAtMost(n: Int, radix: Int) extends Singleton
     // $COVERAGE-ON$
 }
 
-private [parsley] final class EscapeExactly(n: Int, full: Int, radix: Int, inexactErr: SpecialisedFilterConfig[Int]) extends Singleton[BigInt] {
-    override def instr: instructions.Instr = new instructions.token.EscapeExactly(n, full, radix, inexactErr)
-    // $COVERAGE-OFF$
-    override def pretty: String = "escapeExactly"
-    // $COVERAGE-ON$
-}
-
 private [parsley] final class EscapeOneOfExactly(radix: Int, ns: List[Int], inexactErr: SpecialisedFilterConfig[Int]) extends Singleton[BigInt] {
     override def instr: instructions.Instr = new instructions.token.EscapeOneOfExactly(radix, ns, inexactErr)
     // $COVERAGE-OFF$

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/singletons/token/TextEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/singletons/token/TextEmbedding.scala
@@ -3,12 +3,10 @@
  */
 package parsley.internal.deepembedding.singletons.token
 
-import parsley.registers.Reg
-
 import parsley.internal.collection.immutable.Trie
 import parsley.internal.deepembedding.singletons.Singleton
 import parsley.internal.machine.instructions
-import parsley.internal.deepembedding.frontend.UsesRegister
+import parsley.token.errors.SpecialisedFilterConfig
 
 private [parsley] final class EscapeMapped(escTrie: Trie[Int], escs: Set[String]) extends Singleton[Int] {
     // $COVERAGE-OFF$
@@ -17,9 +15,16 @@ private [parsley] final class EscapeMapped(escTrie: Trie[Int], escs: Set[String]
     override def instr: instructions.Instr = new instructions.token.EscapeMapped(escTrie, escs)
 }
 
-private [parsley] final class EscapeAtMost(n: Int, radix: Int, val reg: Reg[Int]) extends Singleton[BigInt] with UsesRegister {
-    override def instr: instructions.Instr = new instructions.token.EscapeAtMost(n, radix, reg.addr)
+private [parsley] final class EscapeAtMost(n: Int, radix: Int) extends Singleton[BigInt] {
+    override def instr: instructions.Instr = new instructions.token.EscapeAtMost(n, radix)
     // $COVERAGE-OFF$
     override def pretty: String = "escapeAtMost"
+    // $COVERAGE-ON$
+}
+
+private [parsley] final class EscapeExactly(n: Int, full: Int, radix: Int, inexactErr: SpecialisedFilterConfig[Int]) extends Singleton[BigInt] {
+    override def instr: instructions.Instr = new instructions.token.EscapeExactly(n, full, radix, inexactErr)
+    // $COVERAGE-OFF$
+    override def pretty: String = "escapeExactly"
     // $COVERAGE-ON$
 }

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/singletons/token/TextEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/singletons/token/TextEmbedding.scala
@@ -3,10 +3,11 @@
  */
 package parsley.internal.deepembedding.singletons.token
 
+import parsley.token.errors.SpecialisedFilterConfig
+
 import parsley.internal.collection.immutable.Trie
 import parsley.internal.deepembedding.singletons.Singleton
 import parsley.internal.machine.instructions
-import parsley.token.errors.SpecialisedFilterConfig
 
 private [parsley] final class EscapeMapped(escTrie: Trie[Int], escs: Set[String]) extends Singleton[Int] {
     // $COVERAGE-OFF$

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/singletons/token/TextEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/singletons/token/TextEmbedding.scala
@@ -28,3 +28,10 @@ private [parsley] final class EscapeExactly(n: Int, full: Int, radix: Int, inexa
     override def pretty: String = "escapeExactly"
     // $COVERAGE-ON$
 }
+
+private [parsley] final class EscapeOneOfExactly(radix: Int, ns: List[Int], inexactErr: SpecialisedFilterConfig[Int]) extends Singleton[BigInt] {
+    override def instr: instructions.Instr = new instructions.token.EscapeOneOfExactly(radix, ns, inexactErr)
+    // $COVERAGE-OFF$
+    override def pretty: String = "escapeOneOfExactly"
+    // $COVERAGE-ON$
+}

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/singletons/token/TextEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/singletons/token/TextEmbedding.scala
@@ -3,13 +3,23 @@
  */
 package parsley.internal.deepembedding.singletons.token
 
+import parsley.registers.Reg
+
 import parsley.internal.collection.immutable.Trie
 import parsley.internal.deepembedding.singletons.Singleton
 import parsley.internal.machine.instructions
+import parsley.internal.deepembedding.frontend.UsesRegister
 
 private [parsley] final class EscapeMapped(escTrie: Trie[Int], escs: Set[String]) extends Singleton[Int] {
     // $COVERAGE-OFF$
     override def pretty: String = "escapeMapped"
     // $COVERAGE-ON$
     override def instr: instructions.Instr = new instructions.token.EscapeMapped(escTrie, escs)
+}
+
+private [parsley] final class EscapeAtMost(n: Int, radix: Int, val reg: Reg[Int]) extends Singleton[BigInt] with UsesRegister {
+    override def instr: instructions.Instr = new instructions.token.EscapeAtMost(n, radix, reg.addr)
+    // $COVERAGE-OFF$
+    override def pretty: String = "escapeAtMost"
+    // $COVERAGE-ON$
 }

--- a/parsley/shared/src/main/scala/parsley/internal/errors/ErrorItem.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/errors/ErrorItem.scala
@@ -41,7 +41,7 @@ private [parsley] final case class ExpectDesc(msg: String) extends ExpectItem {
     private [internal] def formatExpect(implicit builder: ErrorBuilder[_]): builder.Item = builder.named(msg)
 }
 
-private [internal] final case class UnexpectDesc(msg: String, width: Int) extends UnexpectItem {
+private [parsley] final case class UnexpectDesc(msg: String, width: Int) extends UnexpectItem {
     assert(msg.nonEmpty, "Desc cannot contain empty things!")
     // FIXME: When this is formatted, the width should really be normalised to the number of code points... this information is not readily available
     private [internal] def formatUnexpect(lexicalError: Boolean)(implicit builder: ErrorBuilder[_]): (builder.Item, TokenSpan) =

--- a/parsley/shared/src/main/scala/parsley/internal/machine/Context.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/Context.scala
@@ -108,9 +108,8 @@ private [parsley] final class Context(private [machine] var instrs: Array[Instr]
         this.errs = this.errs.tail
     }
 
-    private [machine] def updateCheckOffsetAndHints() = {
+    private [machine] def updateCheckOffset() = {
         this.checkStack.offset = this.offset
-        //this.hintsValidOffset = this.offset // FIXME: verify that this is ok to remove, it seems stupid now that I think about it
     }
 
     // $COVERAGE-OFF$

--- a/parsley/shared/src/main/scala/parsley/internal/machine/Context.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/Context.scala
@@ -94,8 +94,7 @@ private [parsley] final class Context(private [machine] var instrs: Array[Instr]
         }
     }
 
-    private def addErrorToHints(): Unit = {
-        val err = errs.error
+    private [machine] def addErrorToHints(err: DefuncError): Unit = {
         assume(!(!err.isExpectedEmpty) || err.isTrivialError, "not having an empty expected implies you are a trivial error")
         if (/*err.isTrivialError && */ !err.isExpectedEmpty && err.offset == offset) { // scalastyle:ignore disallow.space.after.token
             // If our new hints have taken place further in the input stream, then they must invalidate the old ones
@@ -104,7 +103,7 @@ private [parsley] final class Context(private [machine] var instrs: Array[Instr]
         }
     }
     private [machine] def addErrorToHintsAndPop(): Unit = {
-        this.addErrorToHints()
+        this.addErrorToHints(errs.error)
         this.errs = this.errs.tail
     }
 

--- a/parsley/shared/src/main/scala/parsley/internal/machine/errors/DefuncError.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/errors/DefuncError.scala
@@ -19,7 +19,7 @@ import parsley.internal.errors.{ExpectDesc, ExpectItem, FancyError, ParseError, 
   * conversion to `ParseError` to make use of mutable collections, which
   * would otherwise be unsound.
   */
-private [machine] sealed abstract class DefuncError {
+private [parsley] sealed abstract class DefuncError {
     // Stores the bit-packed flags below, starting from bit 0 upwards
     private [errors] val flags: Byte
     /** Is this error a trivial error, or is it fancy? */
@@ -64,7 +64,7 @@ private [machine] sealed abstract class DefuncError {
       * @return the error with the reason incorporated
       * @note reasons are kept in-order
       */
-    private [machine] def withReason(reason: String): DefuncError
+    private [parsley] def withReason(reason: String): DefuncError
     /** This operation replaces the expected labels in this error message
       * by the given label. This can only happen when the offset of
       * this error message matches the given offset: this should be the
@@ -170,7 +170,7 @@ private [errors] sealed abstract class TrivialDefuncError extends DefuncError {
         if (hints.nonEmpty) new WithHints(this, hints)
         else this
     }
-    private [machine] final override def withReason(reason: String): TrivialDefuncError = new WithReason(this, reason)
+    private [parsley] final override def withReason(reason: String): TrivialDefuncError = new WithReason(this, reason)
     private [machine] final override def label(label: String, offset: Int): TrivialDefuncError = {
         if (this.offset == offset) new WithLabel(this, label)
         else this
@@ -215,7 +215,7 @@ private [errors] sealed abstract class FancyDefuncError extends DefuncError {
     }
 
     private [machine] final override def withHints(hints: DefuncHints): FancyDefuncError = this
-    private [machine] final override def withReason(reason: String): FancyDefuncError = this
+    private [parsley] final override def withReason(reason: String): FancyDefuncError = this
     private [machine] final override def label(label: String, offset: Int): FancyDefuncError = this
     private [machine] final override def amend(offset: Int, line: Int, col: Int): FancyDefuncError = {
         if (!this.entrenched) new FancyAmended(offset, line, col, this)
@@ -282,7 +282,7 @@ private [machine] final class ClassicExpectedErrorWithReason(val offset: Int, va
         builder += reason
     }
 }
-private [machine] final class ClassicUnexpectedError(val offset: Int, val line: Int, val col: Int, val expected: Option[ExpectItem],
+private [parsley] final class ClassicUnexpectedError(val offset: Int, val line: Int, val col: Int, val expected: Option[ExpectItem],
                                                      val unexpected: UnexpectDesc) extends BaseError {
     override final val flags = if (expected.isEmpty) (DefuncError.ExpectedEmptyMask | DefuncError.TrivialErrorMask).toByte else DefuncError.TrivialErrorMask
     override def expectedIterable: Iterable[ExpectItem] = expected
@@ -292,7 +292,7 @@ private [machine] final class ClassicUnexpectedError(val offset: Int, val line: 
         builder.updateUnexpected(unexpected)
     }
 }
-private [machine] final class ClassicFancyError(val offset: Int, val line: Int, val col: Int, caretWidth: Int, val msgs: String*) extends FancyDefuncError {
+private [parsley] final class ClassicFancyError(val offset: Int, val line: Int, val col: Int, caretWidth: Int, val msgs: String*) extends FancyDefuncError {
     override final val flags = DefuncError.ExpectedEmptyMask
     override def makeFancy(builder: FancyErrorBuilder): Unit = {
         builder.pos_=(line, col)
@@ -300,7 +300,7 @@ private [machine] final class ClassicFancyError(val offset: Int, val line: Int, 
         builder.updateCaretWidth(caretWidth)
     }
 }
-private [machine] final class EmptyError(val offset: Int, val line: Int, val col: Int, val unexpectedWidth: Int) extends BaseError {
+private [parsley] final class EmptyError(val offset: Int, val line: Int, val col: Int, val unexpectedWidth: Int) extends BaseError {
     override final val flags = (DefuncError.ExpectedEmptyMask | DefuncError.TrivialErrorMask).toByte
     override def expectedIterable: Iterable[ExpectItem] = None
     override def makeTrivial(builder: TrivialErrorBuilder): Unit = {
@@ -308,7 +308,7 @@ private [machine] final class EmptyError(val offset: Int, val line: Int, val col
         builder.updateEmptyUnexpected(unexpectedWidth)
     }
 }
-private [machine] final class EmptyErrorWithReason(val offset: Int, val line: Int, val col: Int, val reason: String, val unexpectedWidth: Int)
+private [parsley] final class EmptyErrorWithReason(val offset: Int, val line: Int, val col: Int, val reason: String, val unexpectedWidth: Int)
     extends BaseError {
     override final val flags: Byte = (DefuncError.ExpectedEmptyMask | DefuncError.TrivialErrorMask).toByte
     override def expectedIterable: Iterable[ExpectItem] = None

--- a/parsley/shared/src/main/scala/parsley/internal/machine/instructions/IterativeInstrs.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/instructions/IterativeInstrs.scala
@@ -28,7 +28,7 @@ private [internal] final class Many(var label: Int) extends InstrWithLabel {
         if (ctx.good) {
             val x = ctx.stack.upop()
             ctx.stack.peek[mutable.ListBuffer[Any]] += x
-            ctx.updateCheckOffsetAndHints()
+            ctx.updateCheckOffset()
             ctx.pc = label
         }
         // If the head of input stack is not the same size as the head of check stack, we fail to next handler
@@ -46,7 +46,7 @@ private [internal] final class SkipMany(var label: Int) extends InstrWithLabel {
     override def apply(ctx: Context): Unit = {
         if (ctx.good) {
             ctx.stack.pop_()
-            ctx.updateCheckOffsetAndHints()
+            ctx.updateCheckOffset()
             ctx.pc = label
         }
         // If the head of input stack is not the same size as the head of check stack, we fail to next handler
@@ -65,7 +65,7 @@ private [internal] final class ChainPost(var label: Int) extends InstrWithLabel 
         if (ctx.good) {
             val op = ctx.stack.pop[Any => Any]()
             ctx.stack.exchange(op(ctx.stack.upeek))
-            ctx.updateCheckOffsetAndHints()
+            ctx.updateCheckOffset()
             ctx.pc = label
         }
         // If the head of input stack is not the same size as the head of check stack, we fail to next handler
@@ -84,7 +84,7 @@ private [internal] final class ChainPre(var label: Int) extends InstrWithLabel {
         if (ctx.good) {
             val f = ctx.stack.pop[Any => Any]()
             ctx.stack.exchange(f.andThen(ctx.stack.peek[Any => Any]))
-            ctx.updateCheckOffsetAndHints()
+            ctx.updateCheckOffset()
             ctx.pc = label
         }
         // If the head of input stack is not the same size as the head of check stack, we fail to next handler
@@ -103,7 +103,7 @@ private [internal] final class Chainl(var label: Int) extends InstrWithLabel {
             val y = ctx.stack.upop()
             val op = ctx.stack.pop[(Any, Any) => Any]()
             ctx.stack.exchange(op(ctx.stack.peek[Any], y))
-            ctx.updateCheckOffsetAndHints()
+            ctx.updateCheckOffset()
             ctx.pc = label
         }
         // If the head of input stack is not the same size as the head of check stack, we fail to next handler
@@ -121,7 +121,7 @@ private [instructions] object DualHandler {
     def popSecondHandlerAndJump(ctx: Context, label: Int): Unit = {
         ctx.handlers = ctx.handlers.tail
         ctx.checkStack = ctx.checkStack.tail
-        ctx.updateCheckOffsetAndHints()
+        ctx.updateCheckOffset()
         ctx.pc = label
     }
 }

--- a/parsley/shared/src/main/scala/parsley/internal/machine/instructions/token/TextInstructions.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/instructions/token/TextInstructions.scala
@@ -56,6 +56,7 @@ private [internal] class EscapeMapped(escTrie: Trie[Int], caretWidth: Int, expec
 // TODO: clean up!
 private [internal] class EscapeAtMost(n: Int, radix: Int, atMostReg: Int) extends Instr {
     override def apply(ctx: Context): Unit = {
+        assume(n > 0, "n cannot be zero for EscapeAtMost")
         if (ctx.moreInput && pred(ctx.peekChar)) go(ctx, n - 1, ctx.consumeChar().asDigit)
         else {
             ctx.writeReg(atMostReg, n)

--- a/parsley/shared/src/main/scala/parsley/internal/machine/instructions/token/TextInstructions.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/instructions/token/TextInstructions.scala
@@ -6,6 +6,7 @@ package parsley.internal.machine.instructions.token
 import scala.annotation.tailrec
 
 import parsley.character.{isHexDigit, isOctDigit}
+import parsley.token.errors.SpecialisedFilterConfig
 
 import parsley.internal.collection.immutable.Trie
 import parsley.internal.errors.{ExpectDesc, ExpectItem, ExpectRaw}
@@ -13,7 +14,6 @@ import parsley.internal.machine.Context
 import parsley.internal.machine.XAssert._
 import parsley.internal.machine.errors.{EmptyError, MultiExpectedError}
 import parsley.internal.machine.instructions.Instr
-import parsley.token.errors.SpecialisedFilterConfig
 
 private [internal] final class EscapeMapped(escTrie: Trie[Int], caretWidth: Int, expecteds: Set[ExpectItem]) extends Instr {
     def this(escTrie: Trie[Int], escs: Set[String]) = this(escTrie, escs.view.map(_.length).max, escs.map(ExpectRaw(_)))
@@ -61,10 +61,8 @@ private [machine] abstract class EscapeSomeNumber(radix: Int) extends Instr {
     }
 
     private def go(ctx: Context, n: Int, num: BigInt): EscapeSomeNumber.Result = {
-        if (n > 0) {
-            if (ctx.moreInput && pred(ctx.peekChar)) go(ctx, n - 1, num * radix + ctx.consumeChar().asDigit)
-            else EscapeSomeNumber.NoMoreDigits(n, num)
-        }
+        if (n > 0 && ctx.moreInput && pred(ctx.peekChar)) go(ctx, n - 1, num * radix + ctx.consumeChar().asDigit)
+        else if (n > 0) EscapeSomeNumber.NoMoreDigits(n, num)
         else EscapeSomeNumber.Good(num)
     }
 

--- a/parsley/shared/src/main/scala/parsley/internal/machine/instructions/token/TextInstructions.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/instructions/token/TextInstructions.scala
@@ -11,7 +11,7 @@ import parsley.internal.collection.immutable.Trie
 import parsley.internal.errors.{ExpectDesc, ExpectItem, ExpectRaw}
 import parsley.internal.machine.Context
 import parsley.internal.machine.XAssert._
-import parsley.internal.machine.errors.{EmptyError, MultiExpectedError}
+import parsley.internal.machine.errors.{ClassicExpectedError, EmptyError, MultiExpectedError}
 import parsley.internal.machine.instructions.Instr
 
 private [internal] class EscapeMapped(escTrie: Trie[Int], caretWidth: Int, expecteds: Set[ExpectItem]) extends Instr {
@@ -71,19 +71,13 @@ private [internal] class EscapeAtMost(n: Int, radix: Int, atMostReg: Int) extend
             }
             else {
                 ctx.writeReg(atMostReg, n)
-                ctx.pushHandler(ctx.pc)
-                ctx.expectedFail(expected, unexpectedWidth = 1)
-                ctx.good = true
-                ctx.addErrorToHintsAndPop()
+                ctx.addErrorToHints(new ClassicExpectedError(ctx.offset, ctx.line, ctx.col, expected, unexpectedWidth = 1))
                 ctx.pushAndContinue(num)
             }
         }
         else {
             ctx.writeReg(atMostReg, 0)
-            ctx.pushHandler(ctx.pc)
-            ctx.fail(new EmptyError(ctx.offset, ctx.line, ctx.col, 0))
-            ctx.good = true
-            ctx.addErrorToHintsAndPop()
+            ctx.addErrorToHints(new EmptyError(ctx.offset, ctx.line, ctx.col, 0))
             ctx.pushAndContinue(num)
         }
     }

--- a/parsley/shared/src/main/scala/parsley/internal/machine/instructions/token/TextInstructions.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/instructions/token/TextInstructions.scala
@@ -11,7 +11,7 @@ import parsley.internal.collection.immutable.Trie
 import parsley.internal.errors.{ExpectDesc, ExpectItem, ExpectRaw}
 import parsley.internal.machine.Context
 import parsley.internal.machine.XAssert._
-import parsley.internal.machine.errors.{ClassicExpectedError, EmptyError, MultiExpectedError}
+import parsley.internal.machine.errors.{EmptyError, MultiExpectedError}
 import parsley.internal.machine.instructions.Instr
 
 private [internal] class EscapeMapped(escTrie: Trie[Int], caretWidth: Int, expecteds: Set[ExpectItem]) extends Instr {
@@ -71,13 +71,13 @@ private [internal] class EscapeAtMost(n: Int, radix: Int, atMostReg: Int) extend
             }
             else {
                 ctx.writeReg(atMostReg, n)
-                ctx.addErrorToHints(new ClassicExpectedError(ctx.offset, ctx.line, ctx.col, expected, unexpectedWidth = 1))
+                ctx.addHints(expected.toSet, unexpectedWidth = 1)
                 ctx.pushAndContinue(num)
             }
         }
         else {
             ctx.writeReg(atMostReg, 0)
-            ctx.addErrorToHints(new EmptyError(ctx.offset, ctx.line, ctx.col, 0))
+            assume(new EmptyError(ctx.offset, ctx.line, ctx.col, 0).isExpectedEmpty, "empty errors don't have expecteds, so don't effect hints")
             ctx.pushAndContinue(num)
         }
     }

--- a/parsley/shared/src/main/scala/parsley/internal/machine/instructions/token/TextInstructions.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/instructions/token/TextInstructions.scala
@@ -13,8 +13,9 @@ import parsley.internal.machine.Context
 import parsley.internal.machine.XAssert._
 import parsley.internal.machine.errors.{EmptyError, MultiExpectedError}
 import parsley.internal.machine.instructions.Instr
+import parsley.token.errors.SpecialisedFilterConfig
 
-private [internal] class EscapeMapped(escTrie: Trie[Int], caretWidth: Int, expecteds: Set[ExpectItem]) extends Instr {
+private [internal] final class EscapeMapped(escTrie: Trie[Int], caretWidth: Int, expecteds: Set[ExpectItem]) extends Instr {
     def this(escTrie: Trie[Int], escs: Set[String]) = this(escTrie, escs.view.map(_.length).max, escs.map(ExpectRaw(_)))
     // Do not consume input on failure, it's possible another escape sequence might share a lead
     override def apply(ctx: Context): Unit = {
@@ -54,14 +55,14 @@ private [internal] class EscapeMapped(escTrie: Trie[Int], caretWidth: Int, expec
 }
 
 // TODO: clean up!
-private [internal] class EscapeAtMost(n: Int, radix: Int, atMostReg: Int) extends Instr {
+private [machine] abstract class EscapeSomeNumber(n: Int, radix: Int) extends Instr {
+
+    def noMoreDigits(ctx: Context, n: Int, num: BigInt): Unit
+
     override def apply(ctx: Context): Unit = {
-        assume(n > 0, "n cannot be zero for EscapeAtMost")
+        assume(n > 0, "n cannot be zero for EscapeAtMost or EscapeExactly")
         if (ctx.moreInput && pred(ctx.peekChar)) go(ctx, n - 1, ctx.consumeChar().asDigit)
-        else {
-            ctx.writeReg(atMostReg, n)
-            ctx.expectedFail(expected, unexpectedWidth = 1)
-        }
+        else ctx.expectedFail(expected, unexpectedWidth = 1)
     }
 
     private def go(ctx: Context, n: Int, num: BigInt): Unit = {
@@ -69,31 +70,49 @@ private [internal] class EscapeAtMost(n: Int, radix: Int, atMostReg: Int) extend
             if (ctx.moreInput && pred(ctx.peekChar)) {
                 go(ctx, n - 1, num * radix + ctx.consumeChar().asDigit)
             }
-            else {
-                ctx.writeReg(atMostReg, n)
-                ctx.addHints(expected.toSet, unexpectedWidth = 1)
-                ctx.pushAndContinue(num)
-            }
+            else noMoreDigits(ctx, n, num)
         }
         else {
-            ctx.writeReg(atMostReg, 0)
             assume(new EmptyError(ctx.offset, ctx.line, ctx.col, 0).isExpectedEmpty, "empty errors don't have expecteds, so don't effect hints")
             ctx.pushAndContinue(num)
         }
     }
 
-    private val expected: Some[ExpectDesc] = radix match {
+    protected val expected: Some[ExpectDesc] = radix match {
         case 10 => Some(ExpectDesc("digit"))
         case 16 => Some(ExpectDesc("hexadecimal digit"))
         case 8 => Some(ExpectDesc("octal digit"))
         case 2 => Some(ExpectDesc("bit"))
     }
 
-    private val pred: Char => Boolean = radix match {
+    protected val pred: Char => Boolean = radix match {
         case 10 => _.isDigit
         case 16 => isHexDigit(_)
         case 8 => isOctDigit(_)
         case 2 => c => c == '0' || c == '1'
+    }
+}
+
+private [internal] final class EscapeAtMost(n: Int, radix: Int) extends EscapeSomeNumber(n, radix) {
+    override def noMoreDigits(ctx: Context, n: Int, num: BigInt): Unit = {
+        ctx.addHints(expected.toSet, unexpectedWidth = 1)
+        ctx.pushAndContinue(num)
+    }
+
+    // $COVERAGE-OFF$
+    override def toString: String = "EscapeAtMost"
+    // $COVERAGE-ON$
+}
+
+private [internal] final class EscapeExactly(n: Int, full: Int, radix: Int, inexactErr: SpecialisedFilterConfig[Int]) extends EscapeSomeNumber(n, radix) {
+    override def noMoreDigits(ctx: Context, n: Int, num: BigInt): Unit = {
+        if (n == 0) {
+            ctx.addHints(expected.toSet, unexpectedWidth = 1)
+            ctx.pushAndContinue(num)
+        } else {
+            // will need the original state
+            ctx.fail(inexactErr.mkError(ctx.offset, ctx.line, ctx.col, 0, full - n))
+        }
     }
 
     // $COVERAGE-OFF$

--- a/parsley/shared/src/main/scala/parsley/token/descriptions/TextDesc.scala
+++ b/parsley/shared/src/main/scala/parsley/token/descriptions/TextDesc.scala
@@ -34,6 +34,7 @@ object NumberOfDigits {
     final case class Exactly(n0: Int, ns: Int*) extends NumberOfDigits {
         require(n0 > 0, "Exactly may only be passed a number of digits greater than 0")
         require(ns.forall(_ > 0), "Exactly may only be passed a number of digits greater than 0")
+        require(ns.distinct.lengthCompare(ns) == 0 && !ns.contains(n0), "Exactly may only be provided unique elements")
     }
     /** There is no limit on the number of digits that may appear in this sequence.
       *

--- a/parsley/shared/src/main/scala/parsley/token/descriptions/TextDesc.scala
+++ b/parsley/shared/src/main/scala/parsley/token/descriptions/TextDesc.scala
@@ -34,7 +34,7 @@ object NumberOfDigits {
     final case class Exactly(n0: Int, ns: Int*) extends NumberOfDigits {
         require(n0 > 0, "Exactly may only be passed a number of digits greater than 0")
         require(ns.forall(_ > 0), "Exactly may only be passed a number of digits greater than 0")
-        require(ns.lengthCompare(ns.toSet.size) == 0 && !ns.contains(n0), "Exactly may only be provided unique elements")
+        require(ns.lengthCompare(ns.toSet.size) == 0 && !ns.contains(n0), "Exactly may only be provided unique elements") // FIXME: change post-2.12
     }
     /** There is no limit on the number of digits that may appear in this sequence.
       *

--- a/parsley/shared/src/main/scala/parsley/token/descriptions/TextDesc.scala
+++ b/parsley/shared/src/main/scala/parsley/token/descriptions/TextDesc.scala
@@ -34,7 +34,7 @@ object NumberOfDigits {
     final case class Exactly(n0: Int, ns: Int*) extends NumberOfDigits {
         require(n0 > 0, "Exactly may only be passed a number of digits greater than 0")
         require(ns.forall(_ > 0), "Exactly may only be passed a number of digits greater than 0")
-        require(ns.distinct.lengthCompare(ns) == 0 && !ns.contains(n0), "Exactly may only be provided unique elements")
+        require(ns.lengthCompare(ns.toSet.size) == 0 && !ns.contains(n0), "Exactly may only be provided unique elements")
     }
     /** There is no limit on the number of digits that may appear in this sequence.
       *

--- a/parsley/shared/src/main/scala/parsley/token/errors/ConfigImplTyped.scala
+++ b/parsley/shared/src/main/scala/parsley/token/errors/ConfigImplTyped.scala
@@ -6,12 +6,9 @@ package parsley.token.errors
 import parsley.Parsley
 import parsley.XCompat.unused
 import parsley.errors.combinator, combinator.ErrorMethods
+
 import parsley.internal.errors.UnexpectDesc
-import parsley.internal.machine.errors.DefuncError
-import parsley.internal.machine.errors.ClassicFancyError
-import parsley.internal.machine.errors.ClassicUnexpectedError
-import parsley.internal.machine.errors.EmptyError
-import parsley.internal.machine.errors.EmptyErrorWithReason
+import parsley.internal.machine.errors.{ClassicFancyError, ClassicUnexpectedError, DefuncError, EmptyError, EmptyErrorWithReason}
 
 /** This trait, and its subclasses, can be used to configure how filters should be used within the `Lexer`.
   * @since 4.1.0

--- a/parsley/shared/src/main/scala/parsley/token/errors/ConfigImplTyped.scala
+++ b/parsley/shared/src/main/scala/parsley/token/errors/ConfigImplTyped.scala
@@ -24,6 +24,7 @@ trait FilterConfig[A] {
     private [parsley] def collect[B](p: Parsley[A])(f: PartialFunction[A, B]): Parsley[B] = this.filter(p)(f.isDefinedAt).map(f)
     private [parsley] def injectLeft[B]: FilterConfig[Either[A, B]]
     private [parsley] def injectRight[B]: FilterConfig[Either[B, A]]
+    private [parsley] def injectSnd[B]: FilterConfig[(B, A)]
     // $COVERAGE-ON$
 }
 
@@ -71,6 +72,9 @@ abstract class SpecialisedMessage[A] extends SpecialisedFilterConfig[A] { self =
             self.message(y)
         }
     }
+    private [parsley] final override def injectSnd[B] = new SpecialisedMessage[(B, A)] {
+        def message(xy: (B, A)) = self.message(xy._2)
+    }
     // $COVERAGE-ON$
 }
 
@@ -106,6 +110,9 @@ abstract class Unexpected[A] extends VanillaFilterConfig[A] { self =>
             self.unexpected(y)
         }
     }
+    private [parsley] final override def injectSnd[B] = new Unexpected[(B, A)] {
+        def unexpected(xy: (B, A)) = self.unexpected(xy._2)
+    }
     // $COVERAGE-ON$
 }
 
@@ -140,6 +147,9 @@ abstract class Because[A] extends VanillaFilterConfig[A] { self =>
             val Right(y) = xy
             self.reason(y)
         }
+    }
+    private [parsley] final override def injectSnd[B] = new Because[(B, A)] {
+        def reason(xy: (B, A)) = self.reason(xy._2)
     }
     // $COVERAGE-ON$
 }
@@ -185,9 +195,13 @@ abstract class UnexpectedBecause[A] extends VanillaFilterConfig[A] { self =>
             self.unexpected(y)
         }
         def reason(xy: Either[B, A]) = {
-            val Right(x) = xy
-            self.reason(x)
+            val Right(y) = xy
+            self.reason(y)
         }
+    }
+    private [parsley] final override def injectSnd[B] = new UnexpectedBecause[(B, A)] {
+        def unexpected(xy: (B, A)) = self.unexpected(xy._2)
+        def reason(xy: (B, A)) = self.reason(xy._2)
     }
     // $COVERAGE-ON$
 }
@@ -206,5 +220,6 @@ final class BasicFilter[A] extends SpecialisedFilterConfig[A] with VanillaFilter
     // $COVERAGE-OFF$
     private [parsley] final override def injectLeft[B] = new BasicFilter[Either[A, B]]
     private [parsley] final override def injectRight[B] = new BasicFilter[Either[B, A]]
+    private [parsley] final override def injectSnd[B] = new BasicFilter[(B, A)]
     // $COVERAGE-ON$
 }

--- a/parsley/shared/src/main/scala/parsley/token/errors/ErrorConfig.scala
+++ b/parsley/shared/src/main/scala/parsley/token/errors/ErrorConfig.scala
@@ -680,9 +680,10 @@ class ErrorConfig {
       */
     def filterEscapeCharRequiresExactDigits(@unused radix: Int, needed: Seq[Int]): SpecialisedFilterConfig[Int] =
         new SpecialisedMessage[Int] {
-            def message(got: Int) = Seq(
-                s"numeric escape requires ${parsley.errors.helpers.combineAsList(needed.toList.map(_.toString))} digits, but only got $got"
-            )
+            def message(got: Int) = {
+                assume(needed.nonEmpty, "cannot be empty!")
+                Seq(s"numeric escape requires ${parsley.errors.helpers.combineAsList(needed.toList.map(_.toString)).get} digits, but only got $got")
+            }
         }
 
     /** When a numeric escape sequence is not legal, this describes how to report that error, given the original illegal character.

--- a/parsley/shared/src/main/scala/parsley/token/text/Escape.scala
+++ b/parsley/shared/src/main/scala/parsley/token/text/Escape.scala
@@ -33,16 +33,19 @@ private [token] class Escape(desc: EscapeDesc, err: ErrorConfig, generic: numeri
     }
 
     // this is a really neat trick :)
-    private lazy val atMostReg = parsley.registers.Reg.make[Int]
-    private def atMost(n: Int, radix: Int): Parsley[BigInt] = new Parsley(new token.EscapeAtMost(n, radix, atMostReg))
+    //private lazy val atMostReg = parsley.registers.Reg.make[Int]
+    private def atMost(n: Int, radix: Int): Parsley[BigInt] = new Parsley(new token.EscapeAtMost(n, radix))
     /*private def atMost(n: Int, radix: Int, digit: Parsley[Char]): Parsley[BigInt] = atMost(n, radix){
         atMostReg.put(n) *> ensure(atMostReg.gets(_ > 0),
                                    digit <* atMostReg.modify(_ - 1)).foldLeft1[BigInt](0)((n, d) => n * radix + d.asDigit)
     }*/
 
-    private def exactly(n: Int, full: Int, radix: Int/*, digit: Parsley[Char]*/, reqDigits: Seq[Int]): Parsley[BigInt] = {
-        atMost(n, radix/*, digit*/) <* err.filterEscapeCharRequiresExactDigits(radix, reqDigits).filter(atMostReg.gets(full - _))(_ == full)
+    private def exactly(n: Int, full: Int, radix: Int, reqDigits: Seq[Int]): Parsley[BigInt] = {
+        new Parsley(new token.EscapeExactly(n, full, radix, err.filterEscapeCharRequiresExactDigits(radix, reqDigits)))
     }
+    /*private def exactly(n: Int, full: Int, radix: Int/*, digit: Parsley[Char]*/, reqDigits: Seq[Int]): Parsley[BigInt] = {
+        atMost(n, radix/*, digit*/) <* err.filterEscapeCharRequiresExactDigits(radix, reqDigits).filter(atMostReg.gets(full - _))(_ == full)
+    }*/
 
     private lazy val digitsParsed = parsley.registers.Reg.make[Int]
     private def oneOfExactly(n: Int, ns: List[Int], radix: Int/*, digit: Parsley[Char]*/): Parsley[BigInt] = {

--- a/parsley/shared/src/main/scala/parsley/token/text/Escape.scala
+++ b/parsley/shared/src/main/scala/parsley/token/text/Escape.scala
@@ -3,10 +3,10 @@
  */
 package parsley.token.text
 
-import parsley.Parsley, Parsley.{attempt, empty}
+import parsley.Parsley, Parsley.{/*attempt,*/ empty}
 import parsley.character.{/*bit, */char/*, digit, hexDigit, octDigit*/}
 //import parsley.combinator.ensure
-import parsley.implicits.zipped.Zipped3
+//import parsley.implicits.zipped.Zipped3
 import parsley.token.descriptions.text.{EscapeDesc, NumberOfDigits, NumericEscape}
 import parsley.token.errors.{ErrorConfig, NotConfigured}
 import parsley.token.numeric
@@ -32,29 +32,29 @@ private [token] class Escape(desc: EscapeDesc, err: ErrorConfig, generic: numeri
         }
     }
 
-
     private def atMost(n: Int, radix: Int): Parsley[BigInt] = new Parsley(new token.EscapeAtMost(n, radix))
-    private def exactly(n: Int, full: Int, radix: Int, reqDigits: Seq[Int]): Parsley[BigInt] = {
+    /*private def exactly(n: Int, full: Int, radix: Int, reqDigits: Seq[Int]): Parsley[BigInt] = {
         new Parsley(new token.EscapeExactly(n, full, radix, err.filterEscapeCharRequiresExactDigits(radix, reqDigits)))
-    }
+    }*/
 
-    private lazy val digitsParsed = parsley.registers.Reg.make[Int]
+    //private lazy val digitsParsed = parsley.registers.Reg.make[Int]
     private def oneOfExactly(n: Int, ns: List[Int], radix: Int): Parsley[BigInt] = {
-        val reqDigits@(m :: ms) = (n :: ns).sorted // make this a precondition of the description?
+        new Parsley(new token.EscapeOneOfExactly(radix, (n :: ns).sorted, err.filterEscapeCharRequiresExactDigits(radix, (n :: ns).sorted)))
+        /*val reqDigits@(m :: ms) = (n :: ns).sorted // make this a precondition of the description?
         def go(digits: Int, m: Int, ns: List[Int]): Parsley[BigInt] = ns match {
             case Nil => exactly(digits, m, radix, reqDigits) <* digitsParsed.put(digits)
             case n :: ns  =>
                 val theseDigits = exactly(digits, m, radix, reqDigits)
                 val restDigits = (
-                        (attempt(go(n-m, n, ns).map(Some(_)) <* digitsParsed.modify(_ + digits)))
-                    <|> (digitsParsed.put(digits) #> None)
+                        attempt(go(n-m, n, ns).map(Some(_)) <* digitsParsed.modify(_ + digits))
+                      | digitsParsed.put(digits) #> None
                 )
                 (theseDigits, restDigits, digitsParsed.get).zipped[BigInt] {
                     case (x, None, _) => x
                     case (x, Some(y), exp) => (x * BigInt(radix).pow(exp - digits) + y) // digits is removed here, because it's been added before the get
                 }
         }
-        go(m, m, ms)
+        go(m, m, ms)*/
     }
 
     private def fromDesc(radix: Int, desc: NumericEscape, integer: =>Parsley[BigInt]): Parsley[Int] = desc match {

--- a/parsley/shared/src/main/scala/parsley/token/text/Escape.scala
+++ b/parsley/shared/src/main/scala/parsley/token/text/Escape.scala
@@ -3,10 +3,8 @@
  */
 package parsley.token.text
 
-import parsley.Parsley, Parsley.{/*attempt,*/ empty}
-import parsley.character.{/*bit, */char/*, digit, hexDigit, octDigit*/}
-//import parsley.combinator.ensure
-//import parsley.implicits.zipped.Zipped3
+import parsley.Parsley, Parsley.empty
+import parsley.character.char
 import parsley.token.descriptions.text.{EscapeDesc, NumberOfDigits, NumericEscape}
 import parsley.token.errors.{ErrorConfig, NotConfigured}
 import parsley.token.numeric

--- a/parsley/shared/src/main/scala/parsley/token/text/Escape.scala
+++ b/parsley/shared/src/main/scala/parsley/token/text/Escape.scala
@@ -33,28 +33,8 @@ private [token] class Escape(desc: EscapeDesc, err: ErrorConfig, generic: numeri
     }
 
     private def atMost(n: Int, radix: Int): Parsley[BigInt] = new Parsley(new token.EscapeAtMost(n, radix))
-    /*private def exactly(n: Int, full: Int, radix: Int, reqDigits: Seq[Int]): Parsley[BigInt] = {
-        new Parsley(new token.EscapeExactly(n, full, radix, err.filterEscapeCharRequiresExactDigits(radix, reqDigits)))
-    }*/
-
-    //private lazy val digitsParsed = parsley.registers.Reg.make[Int]
     private def oneOfExactly(n: Int, ns: List[Int], radix: Int): Parsley[BigInt] = {
         new Parsley(new token.EscapeOneOfExactly(radix, (n :: ns).sorted, err.filterEscapeCharRequiresExactDigits(radix, (n :: ns).sorted)))
-        /*val reqDigits@(m :: ms) = (n :: ns).sorted // make this a precondition of the description?
-        def go(digits: Int, m: Int, ns: List[Int]): Parsley[BigInt] = ns match {
-            case Nil => exactly(digits, m, radix, reqDigits) <* digitsParsed.put(digits)
-            case n :: ns  =>
-                val theseDigits = exactly(digits, m, radix, reqDigits)
-                val restDigits = (
-                        attempt(go(n-m, n, ns).map(Some(_)) <* digitsParsed.modify(_ + digits))
-                      | digitsParsed.put(digits) #> None
-                )
-                (theseDigits, restDigits, digitsParsed.get).zipped[BigInt] {
-                    case (x, None, _) => x
-                    case (x, Some(y), exp) => (x * BigInt(radix).pow(exp - digits) + y) // digits is removed here, because it's been added before the get
-                }
-        }
-        go(m, m, ms)*/
     }
 
     private def fromDesc(radix: Int, desc: NumericEscape, integer: =>Parsley[BigInt]): Parsley[Int] = desc match {

--- a/parsley/shared/src/main/scala/parsley/token/text/Escape.scala
+++ b/parsley/shared/src/main/scala/parsley/token/text/Escape.scala
@@ -32,28 +32,19 @@ private [token] class Escape(desc: EscapeDesc, err: ErrorConfig, generic: numeri
         }
     }
 
-    // this is a really neat trick :)
-    //private lazy val atMostReg = parsley.registers.Reg.make[Int]
-    private def atMost(n: Int, radix: Int): Parsley[BigInt] = new Parsley(new token.EscapeAtMost(n, radix))
-    /*private def atMost(n: Int, radix: Int, digit: Parsley[Char]): Parsley[BigInt] = atMost(n, radix){
-        atMostReg.put(n) *> ensure(atMostReg.gets(_ > 0),
-                                   digit <* atMostReg.modify(_ - 1)).foldLeft1[BigInt](0)((n, d) => n * radix + d.asDigit)
-    }*/
 
+    private def atMost(n: Int, radix: Int): Parsley[BigInt] = new Parsley(new token.EscapeAtMost(n, radix))
     private def exactly(n: Int, full: Int, radix: Int, reqDigits: Seq[Int]): Parsley[BigInt] = {
         new Parsley(new token.EscapeExactly(n, full, radix, err.filterEscapeCharRequiresExactDigits(radix, reqDigits)))
     }
-    /*private def exactly(n: Int, full: Int, radix: Int/*, digit: Parsley[Char]*/, reqDigits: Seq[Int]): Parsley[BigInt] = {
-        atMost(n, radix/*, digit*/) <* err.filterEscapeCharRequiresExactDigits(radix, reqDigits).filter(atMostReg.gets(full - _))(_ == full)
-    }*/
 
     private lazy val digitsParsed = parsley.registers.Reg.make[Int]
-    private def oneOfExactly(n: Int, ns: List[Int], radix: Int/*, digit: Parsley[Char]*/): Parsley[BigInt] = {
+    private def oneOfExactly(n: Int, ns: List[Int], radix: Int): Parsley[BigInt] = {
         val reqDigits@(m :: ms) = (n :: ns).sorted // make this a precondition of the description?
         def go(digits: Int, m: Int, ns: List[Int]): Parsley[BigInt] = ns match {
-            case Nil => exactly(digits, m, radix/*, digit*/, reqDigits) <* digitsParsed.put(digits)
+            case Nil => exactly(digits, m, radix, reqDigits) <* digitsParsed.put(digits)
             case n :: ns  =>
-                val theseDigits = exactly(digits, m, radix/*, digit*/, reqDigits)
+                val theseDigits = exactly(digits, m, radix, reqDigits)
                 val restDigits = (
                         (attempt(go(n-m, n, ns).map(Some(_)) <* digitsParsed.modify(_ + digits)))
                     <|> (digitsParsed.put(digits) #> None)
@@ -66,19 +57,19 @@ private [token] class Escape(desc: EscapeDesc, err: ErrorConfig, generic: numeri
         go(m, m, ms)
     }
 
-    private def fromDesc(radix: Int, desc: NumericEscape, integer: =>Parsley[BigInt]/*, digit: Parsley[Char]*/): Parsley[Int] = desc match {
+    private def fromDesc(radix: Int, desc: NumericEscape, integer: =>Parsley[BigInt]): Parsley[Int] = desc match {
         case NumericEscape.Illegal => empty
         case NumericEscape.Supported(prefix, numberOfDigits, maxValue) => numberOfDigits match {
             case NumberOfDigits.Unbounded         => boundedChar(integer, maxValue, prefix, radix)
-            case NumberOfDigits.AtMost(n)         => boundedChar(atMost(n, radix/*, digit*/), maxValue, prefix, radix)
-            case NumberOfDigits.Exactly(n, ns@_*) => boundedChar(oneOfExactly(n, ns.toList, radix/*, digit*/), maxValue, prefix, radix)
+            case NumberOfDigits.AtMost(n)         => boundedChar(atMost(n, radix), maxValue, prefix, radix)
+            case NumberOfDigits.Exactly(n, ns@_*) => boundedChar(oneOfExactly(n, ns.toList, radix), maxValue, prefix, radix)
         }
     }
 
-    private val decimalEscape = fromDesc(radix = 10, desc.decimalEscape, generic.zeroAllowedDecimal(NotConfigured)/*, digit*/)
-    private val hexadecimalEscape = fromDesc(radix = 16, desc.hexadecimalEscape, generic.zeroAllowedHexadecimal(NotConfigured)/*, hexDigit*/)
-    private val octalEscape = fromDesc(radix = 8, desc.octalEscape, generic.zeroAllowedOctal(NotConfigured)/*, octDigit*/)
-    private val binaryEscape = fromDesc(radix = 2, desc.binaryEscape, generic.zeroAllowedBinary(NotConfigured)/*, bit*/)
+    private val decimalEscape = fromDesc(radix = 10, desc.decimalEscape, generic.zeroAllowedDecimal(NotConfigured))
+    private val hexadecimalEscape = fromDesc(radix = 16, desc.hexadecimalEscape, generic.zeroAllowedHexadecimal(NotConfigured))
+    private val octalEscape = fromDesc(radix = 8, desc.octalEscape, generic.zeroAllowedOctal(NotConfigured))
+    private val binaryEscape = fromDesc(radix = 2, desc.binaryEscape, generic.zeroAllowedBinary(NotConfigured))
     private val numericEscape = decimalEscape <|> hexadecimalEscape <|> octalEscape <|> binaryEscape
     val escapeCode = err.labelEscapeEnd(escMapped <|> numericEscape)
     val escapeBegin = err.labelEscapeSequence(char(desc.escBegin))

--- a/parsley/shared/src/test/scala/parsley/token/descriptions/DescGen.scala
+++ b/parsley/shared/src/test/scala/parsley/token/descriptions/DescGen.scala
@@ -28,9 +28,11 @@ object DescGen {
     )
 
     val nameDescGen = for {
+        identifierStart <- identifierLetterGen
         identifierLetter <- identifierLetterGen
+        operatorStart <- operatorLetterGen
         operatorLetter <- operatorLetterGen
-    } yield NameDesc.plain.copy(identifierLetter = identifierLetter, operatorLetter = operatorLetter)
+    } yield NameDesc(identifierStart, identifierLetter, operatorStart, operatorLetter)
 
     // SYMBOL
     val keywordGen = Gen.oneOf("if", "foo", "while", "key", "a", "bar7")

--- a/parsley/shared/src/test/scala/parsley/token/descriptions/DescGen.scala
+++ b/parsley/shared/src/test/scala/parsley/token/descriptions/DescGen.scala
@@ -53,11 +53,32 @@ object DescGen {
     private val singleGen = Gen.mapOf(Gen.zip(Gen.alphaChar, codepointGen))
     private val multiGen = Gen.mapOf(Gen.zip(Gen.nonEmptyListOf(Gen.alphaChar).map(_.mkString), codepointGen))
 
-    //TODO: Expand with more configuration fields as more of the escape is optimised
+
+    def numericEscapeOf(prefix: Option[Char])(numDigits: NumberOfDigits): NumericEscape = {
+        NumericEscape.Supported(prefix, numDigits, java.lang.Character.MAX_CODE_POINT)
+    }
+
+    private val digitsRange = Gen.choose(1, 16)
+    private def numericEscapeGen(prefix: Option[Char]): Gen[NumericEscape] = Gen.oneOf(
+        Gen.const(NumericEscape.Illegal),
+        Gen.const(NumberOfDigits.Unbounded).map(numericEscapeOf(prefix)),
+        digitsRange.map(NumberOfDigits.AtMost(_)).map(numericEscapeOf(prefix)),
+        Gen.containerOfN[Set, Int](4, digitsRange).suchThat(_.nonEmpty).map { set =>
+            val x::xs = set.toList
+            numericEscapeOf(prefix)(NumberOfDigits.Exactly(x, xs: _*))
+        }
+    )
+
     val escDescGen = for {
         literals <- literalGen
         singles <- singleGen
         multis <- multiGen
         if !singles.keys.exists(c => multis.contains(s"$c"))
-    } yield EscapeDesc.plain.copy(literals = literals, singleMap = singles, multiMap = multis)
+        decimalEscape <- numericEscapeGen(None)
+        hexadecimalEscape <- numericEscapeGen(Some('x'))
+        octalEscape <- numericEscapeGen(Some('o'))
+        binaryEscape <- numericEscapeGen(Some('b'))
+        emptyEscape <- Gen.oneOf(None, Some('&'))
+        gapsSupported <- Arbitrary.arbitrary[Boolean]
+    } yield EscapeDesc('\\', literals, singles, multis, decimalEscape, hexadecimalEscape, octalEscape, binaryEscape, emptyEscape, gapsSupported)
 }

--- a/parsley/shared/src/test/scala/parsley/token/descriptions/DescShrink.scala
+++ b/parsley/shared/src/test/scala/parsley/token/descriptions/DescShrink.scala
@@ -5,6 +5,7 @@ import org.scalacheck.Shrink
 import parsley.token.descriptions.text._
 
 object DescShrink {
+    // TODO: shrinking logic for new esc desc stuff
     implicit val escDescShrink: Shrink[EscapeDesc] = Shrink {
         case desc@EscapeDesc(_, literals, singles, multis, _, _, _, _, _, _) =>
             val shrinkLiterals = for (ls <- Shrink.shrink(literals)) yield desc.copy(literals = ls)

--- a/parsley/shared/src/test/scala/parsley/token/text/EscapeSemanticPreservationSpec.scala
+++ b/parsley/shared/src/test/scala/parsley/token/text/EscapeSemanticPreservationSpec.scala
@@ -20,7 +20,13 @@ class EscapeSemanticPreservationSpec extends AnyPropSpec with ScalaCheckProperty
     def makeOptEscape(escDesc: EscapeDesc) = new Escape(escDesc, errConfig, generic)
     def makeUnoptEscape(escDesc: EscapeDesc) = new OriginalEscape(escDesc, errConfig, generic)
 
-    val escInputGen = Gen.alphaNumStr.map(s => s"\\$s")
+    val escInputGen = Gen.frequency(
+        4 -> Gen.alphaNumStr,
+        1 -> Gen.numStr,
+        1 -> Gen.hexStr.map(s => s"x$s"),
+        1 -> Gen.stringOf(Gen.choose('0', '7')).map(s => s"b$s"),
+        1 -> Gen.stringOf(Gen.oneOf('0', '1')).map(s => s"b$s"),
+    ).map(s => s"\\$s")
 
     property("reading escape characters should not vary based on optimisations") {
         forAll(escDescGen -> "escDesc", escInputGen -> "input") { (escDesc, input) =>

--- a/parsley/shared/src/test/scala/parsley/token/text/EscapeTests.scala
+++ b/parsley/shared/src/test/scala/parsley/token/text/EscapeTests.scala
@@ -93,5 +93,6 @@ class EscapeTests extends ParsleyTest {
         "\\b10000000" -> Some(128),
         "\\b10000001" -> None,
         "\\b01111111" -> Some(127),
+        "\\b011111110" -> None,
     )
 }

--- a/parsley/shared/src/test/scala/parsley/token/text/OriginalEscape.scala
+++ b/parsley/shared/src/test/scala/parsley/token/text/OriginalEscape.scala
@@ -44,7 +44,9 @@ private [token] class OriginalEscape(desc: EscapeDesc, err: ErrorConfig, generic
     }
 
     private def exactly(n: Int, full: Int, radix: Int, digit: Parsley[Char], reqDigits: Seq[Int]): Parsley[BigInt] = {
-        atMost(n, radix, digit) <* err.filterEscapeCharRequiresExactDigits(radix, reqDigits).filter(atMostReg.gets(full - _))(_ == full)
+        err.filterEscapeCharRequiresExactDigits(radix, reqDigits).injectSnd.collect(atMost(n, radix, digit) <~> atMostReg.gets(full - _)) {
+            case (num, n) if n == full => num
+        }
     }
 
     private lazy val digitsParsed = parsley.registers.Reg.make[Int]

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.8.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-val sbtTypelevelVersion = "0.4.19"
+val sbtTypelevelVersion = "0.4.20"
 
 libraryDependencySchemes ++= Seq(
   "org.scala-native" % "sbt-scala-native" % VersionScheme.Always,
@@ -10,8 +10,8 @@ addSbtPlugin("org.typelevel" % "sbt-typelevel-settings" % sbtTypelevelVersion)
 addSbtPlugin("org.typelevel" % "sbt-typelevel-ci-release" % sbtTypelevelVersion)
 
 // CI Stuff
-addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.2.0")
-addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.2.0")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "1.3.1")
+addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.3.1")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.12.0")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.9")
 


### PR DESCRIPTION
The character mappings have been optimised, but not the numeric escapes: `atMost`, `exactly`, or `oneOfExactly`. This PR optimises these, which should decrease the size of text lexing a bunch