### PR TITLE
Fixed caret not appearing for EOF

### DIFF
--- a/parsley/shared/src/main/scala/parsley/internal/errors/ParseError.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/errors/ParseError.scala
@@ -33,7 +33,7 @@ private [internal] case class TrivialError(offset: Int, line: Int, col: Int,
             builder.expected(builder.combineExpectedItems(expecteds.map(_.formatExpect))),
             builder.combineMessages(reasons.map(builder.reason(_)).toSeq),
             // this was changed to +1 to allow EoF caret, does this need more nuance?
-            builder.lineInfo(line, beforeLines, afterLines, caret, math.min(caretSize, line.length-caret+1)))
+            builder.lineInfo(line, beforeLines, afterLines, caret, math.min(caretSize, line.length - caret + 1)))
     }
 }
 private [internal] case class FancyError(offset: Int, line: Int, col: Int, msgs: List[String], caretWidth: Int, lexicalError: Boolean) extends ParseError {

--- a/parsley/shared/src/main/scala/parsley/internal/errors/ParseError.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/errors/ParseError.scala
@@ -32,7 +32,8 @@ private [internal] case class TrivialError(offset: Int, line: Int, col: Int,
             builder.unexpected(unexpectedTok.toOption.map(_._1)),
             builder.expected(builder.combineExpectedItems(expecteds.map(_.formatExpect))),
             builder.combineMessages(reasons.map(builder.reason(_)).toSeq),
-            builder.lineInfo(line, beforeLines, afterLines, caret, math.min(caretSize, line.length-caret)))
+            // this was changed to +1 to allow EoF caret, does this need more nuance?
+            builder.lineInfo(line, beforeLines, afterLines, caret, math.min(caretSize, line.length-caret+1)))
     }
 }
 private [internal] case class FancyError(offset: Int, line: Int, col: Int, msgs: List[String], caretWidth: Int, lexicalError: Boolean) extends ParseError {


### PR DESCRIPTION
Due to capping of the caret at the end of the input line, carets focused on the EOF itself were not rendered. This increases that limit by 1, which allows carets to stretch one position over the end of the input line to EOF.