### PR TITLE
Partial Amending

### DIFF
--- a/parsley/shared/src/main/scala/parsley/errors/combinator.scala
+++ b/parsley/shared/src/main/scala/parsley/errors/combinator.scala
@@ -170,10 +170,8 @@ object combinator {
       */
     def amendThenDislodge[A](p: Parsley[A]): Parsley[A] = dislodge(amend(p))
 
-    // These aren't going to be exposed and should be removed in 5.0.0 as well!
-    @deprecated("this combinator is evil, because it renders the error at the wrong place unless it is amended!", "4.2.0")
+    // TODO: test, document, and expose :)
     private [parsley] def partialAmend[A](p: Parsley[A]): Parsley[A] = new Parsley(new frontend.ErrorAmend(p.internal, partial = true))
-    @deprecated("this combinator is evil, because it renders the error at the wrong place unless it is amended!", "4.2.0")
     private [parsley] def partialAmendThenDislodge[A](p: Parsley[A]): Parsley[A] = dislodge(partialAmend(p))
 
     /** This combinator marks any errors within the given parser as being ''lexical errors''.

--- a/parsley/shared/src/main/scala/parsley/internal/machine/Context.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/Context.scala
@@ -96,7 +96,7 @@ private [parsley] final class Context(private [machine] var instrs: Array[Instr]
 
     private def addErrorToHints(err: DefuncError): Unit = {
         assume(!(!err.isExpectedEmpty) || err.isTrivialError, "not having an empty expected implies you are a trivial error")
-        if (/*err.isTrivialError && */ !err.isExpectedEmpty && err.offset == offset) { // scalastyle:ignore disallow.space.after.token
+        if (/*err.isTrivialError && */ !err.isExpectedEmpty && err.presentationOffset == offset) { // scalastyle:ignore disallow.space.after.token
             // If our new hints have taken place further in the input stream, then they must invalidate the old ones
             invalidateHints()
             hints = hints.addError(err)
@@ -192,9 +192,9 @@ private [parsley] final class Context(private [machine] var instrs: Array[Instr]
 
     private [machine] def pushError(err: DefuncError): Unit = this.errs = new ErrorStack(this.useHints(err), this.errs)
     private [machine] def useHints(err: DefuncError): DefuncError = {
-        if (hintsValidOffset == err.offset) err.withHints(hints)
+        if (hintsValidOffset == err.presentationOffset) err.withHints(hints)
         else {
-            hintsValidOffset = err.offset
+            hintsValidOffset = err.presentationOffset
             hints = EmptyHints
             err
         }

--- a/parsley/shared/src/main/scala/parsley/internal/machine/errors/DefuncBuilders.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/errors/DefuncBuilders.scala
@@ -18,7 +18,7 @@ import TrivialErrorBuilder.{BuilderUnexpectItem, NoItem, Other, Raw}
   * @param offset the offset that the error being built occured at
   * @param outOfRange whether or not this error occured at the end of the input or not
   */
-private [errors] final class TrivialErrorBuilder(offset: Int, outOfRange: Boolean, lexicalError: Boolean) {
+private [errors] final class TrivialErrorBuilder(presentationOffset: Int, outOfRange: Boolean, lexicalError: Boolean) {
     private var line: Int = _
     private var col: Int = _
     private val expecteds = mutable.Set.empty[ExpectItem]
@@ -83,7 +83,7 @@ private [errors] final class TrivialErrorBuilder(offset: Int, outOfRange: Boolea
       * @return the final error message
       */
     def mkError(implicit itemBuilder: ErrorItemBuilder): TrivialError = {
-        new TrivialError(offset, line, col, unexpected.toErrorItem(offset), expecteds.toSet, reasons.toSet, lexicalError)
+        new TrivialError(presentationOffset, line, col, unexpected.toErrorItem(presentationOffset), expecteds.toSet, reasons.toSet, lexicalError)
     }
     /** Performs some given action only when this builder is currently accepting new expected items
       *
@@ -146,7 +146,7 @@ private [errors] object TrivialErrorBuilder {
   *
   * @param offset the offset that the error being built occured at
   */
-private [errors] final class FancyErrorBuilder(offset: Int, lexicalError: Boolean) {
+private [errors] final class FancyErrorBuilder(presentationOffset: Int, lexicalError: Boolean) {
     private var line: Int = _
     private var col: Int = _
     private var caretWidth: Int = 0
@@ -184,7 +184,7 @@ private [errors] final class FancyErrorBuilder(offset: Int, lexicalError: Boolea
     def ++=(msgs: Seq[String]): Unit = this.msgs ++= msgs
     /** Builds the final error. */
     def mkError: FancyError = {
-        new FancyError(offset, line, col, msgs.toList.distinct, caretWidth, lexicalError)
+        new FancyError(presentationOffset, line, col, msgs.toList.distinct, caretWidth, lexicalError)
     }
 }
 

--- a/parsley/shared/src/main/scala/parsley/internal/machine/errors/DefuncError.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/errors/DefuncError.scala
@@ -289,8 +289,8 @@ private [errors] sealed abstract class BaseError extends TrivialDefuncError {
     }
 }
 
-private [machine] final class ClassicExpectedError(val presentationOffset: Int, val line: Int, val col: Int, val expected: Option[ExpectItem], val unexpectedWidth: Int)
-    extends BaseError {
+private [machine] final class ClassicExpectedError(val presentationOffset: Int, val line: Int, val col: Int,
+                                                   val expected: Option[ExpectItem], val unexpectedWidth: Int) extends BaseError {
     override final val flags = if (expected.isEmpty) (DefuncError.ExpectedEmptyMask | DefuncError.TrivialErrorMask) else DefuncError.TrivialErrorMask
     override def expectedIterable: Iterable[ExpectItem] = expected
 }
@@ -344,7 +344,8 @@ private [parsley] final class EmptyErrorWithReason(val presentationOffset: Int, 
         builder += reason
     }
 }
-private [machine] final class MultiExpectedError(val presentationOffset: Int, val line: Int, val col: Int, val expected: Set[ExpectItem], val unexpectedWidth: Int)
+private [machine] final class MultiExpectedError(val presentationOffset: Int, val line: Int, val col: Int,
+                                                 val expected: Set[ExpectItem], val unexpectedWidth: Int)
     extends BaseError {
     override final val flags = if (expected.isEmpty) DefuncError.ExpectedEmptyMask | DefuncError.TrivialErrorMask else DefuncError.TrivialErrorMask
     override def expectedIterable: Iterable[ExpectItem] = expected
@@ -421,8 +422,8 @@ private [errors] final class WithLabel private [errors] (val err: TrivialDefuncE
     }
 }
 
-private [errors] final class TrivialAmended private [errors]
-    (val presentationOffset: Int, val underlyingOffset: Int, val line: Int, val col: Int, val err: TrivialDefuncError) extends TrivialTransitive {
+private [errors] final class TrivialAmended private [errors](val presentationOffset: Int, val underlyingOffset: Int, val line: Int, val col: Int,
+                                                             val err: TrivialDefuncError) extends TrivialTransitive {
     assume(!err.entrenched, "an amendment will only occur on unentrenched errors")
     override final val flags = err.flags
     override def makeTrivial(builder: TrivialErrorBuilder): Unit = {
@@ -432,8 +433,8 @@ private [errors] final class TrivialAmended private [errors]
     }
 }
 
-private [errors] final class FancyAmended private [errors]
-    (val presentationOffset: Int, val underlyingOffset: Int, val line: Int, val col: Int, val err: FancyDefuncError) extends FancyDefuncError {
+private [errors] final class FancyAmended private [errors](val presentationOffset: Int, val underlyingOffset: Int, val line: Int, val col: Int,
+                                                           val err: FancyDefuncError) extends FancyDefuncError {
     assume(!err.entrenched, "an amendment will only occur on unentrenched errors")
     override final val flags = err.flags
     override def makeFancy(builder: FancyErrorBuilder): Unit = {

--- a/parsley/shared/src/main/scala/parsley/internal/machine/errors/DefuncError.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/errors/DefuncError.scala
@@ -35,6 +35,8 @@ private [parsley] sealed abstract class DefuncError {
     private [machine] final def flexibleCaret: Boolean = (flags & DefuncError.FlexibleCaretMask) != 0
     /** The offset at which this error appears to occur */
     private [machine] val presentationOffset: Int
+    /** The offset at which this error supposedly originated */
+    private [machine] def underlyingOffset: Int = presentationOffset
     /** This function forces the lazy defunctionalised structure into a final `ParseError` value. */
     private [machine] def asParseError(implicit itemBuilder: ErrorItemBuilder): ParseError
 
@@ -170,7 +172,7 @@ private [errors] sealed abstract class TrivialDefuncError extends DefuncError {
     }
 
     private [machine] final override def merge(err: DefuncError): DefuncError = {
-        val cmp = Integer.compareUnsigned(this.presentationOffset, err.presentationOffset)
+        val cmp = Integer.compareUnsigned(this.underlyingOffset, err.underlyingOffset)
         if (cmp > 0) this
         else if (cmp < 0) err
         else err match {
@@ -221,7 +223,7 @@ private [errors] sealed abstract class FancyDefuncError extends DefuncError {
     private [errors] def makeFancy(builder: FancyErrorBuilder): Unit
 
     private [machine] final override def merge(err: DefuncError): DefuncError = {
-        val cmp = Integer.compareUnsigned(this.presentationOffset, err.presentationOffset)
+        val cmp = Integer.compareUnsigned(this.underlyingOffset, err.underlyingOffset)
         if (cmp > 0) this
         else if (cmp < 0) err
         else err match {

--- a/parsley/shared/src/main/scala/parsley/internal/machine/errors/DefuncError.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/errors/DefuncError.scala
@@ -33,8 +33,8 @@ private [parsley] sealed abstract class DefuncError {
     private [machine] final def lexicalError: Boolean = (flags & DefuncError.LexicalErrorMask) != 0
     /** Is the caret on this error flexible (only relevant for fancy errors) **/
     private [machine] final def flexibleCaret: Boolean = (flags & DefuncError.FlexibleCaretMask) != 0
-    /** The offset at which this error occured */
-    private [machine] val offset: Int
+    /** The offset at which this error appears to occur */
+    private [machine] val presentationOffset: Int
     /** This function forces the lazy defunctionalised structure into a final `ParseError` value. */
     private [machine] def asParseError(implicit itemBuilder: ErrorItemBuilder): ParseError
 
@@ -69,7 +69,7 @@ private [parsley] sealed abstract class DefuncError {
       * @note reasons are kept in-order
       */
     private [parsley] def withReason(reason: String, offset: Int): DefuncError
-    private [parsley] def withReason(reason: String): DefuncError = withReason(reason, offset)
+    private [parsley] def withReason(reason: String): DefuncError = withReason(reason, presentationOffset)
     /** This operation replaces the expected labels in this error message
       * by the given label. This can only happen when the offset of
       * this error message matches the given offset: this should be the
@@ -132,7 +132,7 @@ object DefuncError {
 /** Represents partially evaluated trivial errors */
 private [errors] sealed abstract class TrivialDefuncError extends DefuncError {
     private [machine] final override def asParseError(implicit itemBuilder: ErrorItemBuilder): TrivialError = {
-        val errorBuilder = new TrivialErrorBuilder(offset, !itemBuilder.inRange(offset), lexicalError)
+        val errorBuilder = new TrivialErrorBuilder(presentationOffset, !itemBuilder.inRange(presentationOffset), lexicalError)
         makeTrivial(errorBuilder)
         errorBuilder.mkError
     }
@@ -170,7 +170,7 @@ private [errors] sealed abstract class TrivialDefuncError extends DefuncError {
     }
 
     private [machine] final override def merge(err: DefuncError): DefuncError = {
-        val cmp = Integer.compareUnsigned(this.offset, err.offset)
+        val cmp = Integer.compareUnsigned(this.presentationOffset, err.presentationOffset)
         if (cmp > 0) this
         else if (cmp < 0) err
         else err match {
@@ -184,11 +184,11 @@ private [errors] sealed abstract class TrivialDefuncError extends DefuncError {
         else this
     }
     private [parsley] final override def withReason(reason: String, offset: Int): TrivialDefuncError = {
-        if (this.offset == offset) new WithReason(this, reason)
+        if (this.presentationOffset == offset) new WithReason(this, reason)
         else this
     }
     private [machine] final override def label(label: String, offset: Int): TrivialDefuncError = {
-        if (this.offset == offset) new WithLabel(this, label)
+        if (this.presentationOffset == offset) new WithLabel(this, label)
         else this
     }
     private [machine] final override def amend(offset: Int, line: Int, col: Int): TrivialDefuncError = {
@@ -206,7 +206,7 @@ private [errors] sealed abstract class TrivialDefuncError extends DefuncError {
         case self => new TrivialDislodged(by, self)
     }
     private [machine] final override def markAsLexical(offset: Int): TrivialDefuncError = {
-        if (Integer.compareUnsigned(this.offset, offset) > 0) new TrivialLexical(this)
+        if (Integer.compareUnsigned(this.presentationOffset, offset) > 0) new TrivialLexical(this)
         else this
     }
 }
@@ -214,14 +214,14 @@ private [errors] sealed abstract class TrivialDefuncError extends DefuncError {
 /** Represents partially evaluated fancy errors */
 private [errors] sealed abstract class FancyDefuncError extends DefuncError {
     private [machine] final override def asParseError(implicit itemBuilder: ErrorItemBuilder): FancyError = {
-        val builder = new FancyErrorBuilder(offset, lexicalError)
+        val builder = new FancyErrorBuilder(presentationOffset, lexicalError)
         makeFancy(builder)
         builder.mkError
     }
     private [errors] def makeFancy(builder: FancyErrorBuilder): Unit
 
     private [machine] final override def merge(err: DefuncError): DefuncError = {
-        val cmp = Integer.compareUnsigned(this.offset, err.offset)
+        val cmp = Integer.compareUnsigned(this.presentationOffset, err.presentationOffset)
         if (cmp > 0) this
         else if (cmp < 0) err
         else err match {
@@ -249,7 +249,7 @@ private [errors] sealed abstract class FancyDefuncError extends DefuncError {
         case self => new FancyDislodged(by, self)
     }
     private [machine] final override def markAsLexical(offset: Int): FancyDefuncError = {
-        if (Integer.compareUnsigned(this.offset, offset) > 0) new FancyLexical(this)
+        if (Integer.compareUnsigned(this.presentationOffset, offset) > 0) new FancyLexical(this)
         else this
     }
 }
@@ -288,12 +288,12 @@ private [errors] sealed abstract class BaseError extends TrivialDefuncError {
     }
 }
 
-private [machine] final class ClassicExpectedError(val offset: Int, val line: Int, val col: Int, val expected: Option[ExpectItem], val unexpectedWidth: Int)
+private [machine] final class ClassicExpectedError(val presentationOffset: Int, val line: Int, val col: Int, val expected: Option[ExpectItem], val unexpectedWidth: Int)
     extends BaseError {
     override final val flags = if (expected.isEmpty) (DefuncError.ExpectedEmptyMask | DefuncError.TrivialErrorMask) else DefuncError.TrivialErrorMask
     override def expectedIterable: Iterable[ExpectItem] = expected
 }
-private [machine] final class ClassicExpectedErrorWithReason(val offset: Int, val line: Int, val col: Int,
+private [machine] final class ClassicExpectedErrorWithReason(val presentationOffset: Int, val line: Int, val col: Int,
                                                              val expected: Option[ExpectItem], val reason: String, val unexpectedWidth: Int) extends BaseError {
     override final val flags = if (expected.isEmpty) (DefuncError.ExpectedEmptyMask | DefuncError.TrivialErrorMask) else DefuncError.TrivialErrorMask
     override def expectedIterable: Iterable[ExpectItem] = expected
@@ -302,7 +302,7 @@ private [machine] final class ClassicExpectedErrorWithReason(val offset: Int, va
         builder += reason
     }
 }
-private [parsley] final class ClassicUnexpectedError(val offset: Int, val line: Int, val col: Int, val expected: Option[ExpectItem],
+private [parsley] final class ClassicUnexpectedError(val presentationOffset: Int, val line: Int, val col: Int, val expected: Option[ExpectItem],
                                                      val unexpected: UnexpectDesc) extends BaseError {
     override final val flags = if (expected.isEmpty) (DefuncError.ExpectedEmptyMask | DefuncError.TrivialErrorMask) else DefuncError.TrivialErrorMask
     override def expectedIterable: Iterable[ExpectItem] = expected
@@ -314,7 +314,7 @@ private [parsley] final class ClassicUnexpectedError(val offset: Int, val line: 
     }
 }
 
-private [parsley] final class ClassicFancyError(val offset: Int, val line: Int, val col: Int, caretWidth: CaretWidth, val msgs: String*)
+private [parsley] final class ClassicFancyError(val presentationOffset: Int, val line: Int, val col: Int, caretWidth: CaretWidth, val msgs: String*)
     extends FancyDefuncError {
     override final val flags =
         if (caretWidth.isFlexible) DefuncError.ExpectedEmptyMask | DefuncError.FlexibleCaretMask else DefuncError.ExpectedEmptyMask
@@ -324,7 +324,7 @@ private [parsley] final class ClassicFancyError(val offset: Int, val line: Int, 
         builder.updateCaretWidth(caretWidth)
     }
 }
-private [parsley] final class EmptyError(val offset: Int, val line: Int, val col: Int, val unexpectedWidth: Int) extends BaseError {
+private [parsley] final class EmptyError(val presentationOffset: Int, val line: Int, val col: Int, val unexpectedWidth: Int) extends BaseError {
     override final val flags = DefuncError.ExpectedEmptyMask | DefuncError.TrivialErrorMask
     override def expectedIterable: Iterable[ExpectItem] = None
     override def makeTrivial(builder: TrivialErrorBuilder): Unit = {
@@ -332,7 +332,7 @@ private [parsley] final class EmptyError(val offset: Int, val line: Int, val col
         builder.updateEmptyUnexpected(unexpectedWidth)
     }
 }
-private [parsley] final class EmptyErrorWithReason(val offset: Int, val line: Int, val col: Int, val reason: String, val unexpectedWidth: Int)
+private [parsley] final class EmptyErrorWithReason(val presentationOffset: Int, val line: Int, val col: Int, val reason: String, val unexpectedWidth: Int)
     extends BaseError {
     override final val flags = DefuncError.ExpectedEmptyMask | DefuncError.TrivialErrorMask
     override def expectedIterable: Iterable[ExpectItem] = None
@@ -342,7 +342,7 @@ private [parsley] final class EmptyErrorWithReason(val offset: Int, val line: In
         builder += reason
     }
 }
-private [machine] final class MultiExpectedError(val offset: Int, val line: Int, val col: Int, val expected: Set[ExpectItem], val unexpectedWidth: Int)
+private [machine] final class MultiExpectedError(val presentationOffset: Int, val line: Int, val col: Int, val expected: Set[ExpectItem], val unexpectedWidth: Int)
     extends BaseError {
     override final val flags = if (expected.isEmpty) DefuncError.ExpectedEmptyMask | DefuncError.TrivialErrorMask else DefuncError.TrivialErrorMask
     override def expectedIterable: Iterable[ExpectItem] = expected
@@ -350,8 +350,8 @@ private [machine] final class MultiExpectedError(val offset: Int, val line: Int,
 
 private [errors] final class TrivialMergedErrors private [errors] (val err1: TrivialDefuncError, val err2: TrivialDefuncError) extends TrivialDefuncError {
     override final val flags = err1.flags & err2.flags
-    assume(err1.offset == err2.offset, "two errors only merge when they have matching offsets")
-    val offset = err1.offset //Math.max(err1.offset, err2.offset)
+    assume(err1.presentationOffset == err2.presentationOffset, "two errors only merge when they have matching offsets")
+    val presentationOffset = err1.presentationOffset //Math.max(err1.offset, err2.offset)
     override def makeTrivial(builder: TrivialErrorBuilder): Unit = {
         err1.makeTrivial(builder)
         err2.makeTrivial(builder)
@@ -360,8 +360,8 @@ private [errors] final class TrivialMergedErrors private [errors] (val err1: Tri
 
 private [errors] final class FancyMergedErrors private [errors] (val err1: FancyDefuncError, val err2: FancyDefuncError) extends FancyDefuncError {
     override final val flags = err1.flags & err2.flags
-    assume(err1.offset == err2.offset, "two errors only merge when they have matching offsets")
-    override val offset = err1.offset //Math.max(err1.offset, err2.offset)
+    assume(err1.presentationOffset == err2.presentationOffset, "two errors only merge when they have matching offsets")
+    override val presentationOffset = err1.presentationOffset //Math.max(err1.offset, err2.offset)
     override def makeFancy(builder: FancyErrorBuilder): Unit = {
         err1.makeFancy(builder)
         err2.makeFancy(builder)
@@ -370,8 +370,8 @@ private [errors] final class FancyMergedErrors private [errors] (val err1: Fancy
 
 private [errors] final class FancyAdjustCaret private [errors] (val err: FancyDefuncError, val caretAdjuster: TrivialDefuncError) extends FancyDefuncError {
     override final val flags = err.flags
-    assume(err.offset == caretAdjuster.offset, "two errors only merge when they have matching offsets")
-    override val offset = err.offset
+    assume(err.presentationOffset == caretAdjuster.presentationOffset, "two errors only merge when they have matching offsets")
+    override val presentationOffset = err.presentationOffset
     override def makeFancy(builder: FancyErrorBuilder): Unit = {
         err.makeFancy(builder)
         caretAdjuster.adjustCaret(builder)
@@ -381,7 +381,7 @@ private [errors] final class FancyAdjustCaret private [errors] (val err: FancyDe
 private [errors] final class WithHints private [errors] (val err: TrivialDefuncError, val hints: DefuncHints) extends TrivialTransitive {
     assume(!hints.isEmpty, "WithHints will always have non-empty hints")
     override final val flags = err.flags & ~DefuncError.ExpectedEmptyMask //err.isExpectedEmpty && hints.isEmpty
-    override val offset = err.offset
+    override val presentationOffset = err.presentationOffset
     override def makeTrivial(builder: TrivialErrorBuilder): Unit = {
         err.makeTrivial(builder)
         builder.whenAcceptingExpected {
@@ -392,7 +392,7 @@ private [errors] final class WithHints private [errors] (val err: TrivialDefuncE
 
 private [errors] final class WithReason private [errors] (val err: TrivialDefuncError, val reason: String) extends TrivialTransitive {
     override final val flags = err.flags
-    val offset = err.offset
+    val presentationOffset = err.presentationOffset
     override def makeTrivial(builder: TrivialErrorBuilder): Unit = {
         err.makeTrivial(builder)
         builder += reason
@@ -404,7 +404,7 @@ private [errors] final class WithLabel private [errors] (val err: TrivialDefuncE
         if (label.isEmpty) err.flags |  DefuncError.ExpectedEmptyMask
         else               err.flags & ~DefuncError.ExpectedEmptyMask
     }
-    val offset = err.offset
+    val presentationOffset = err.presentationOffset
     override def makeTrivial(builder: TrivialErrorBuilder): Unit = {
         builder.ignoreExpected {
             err.makeTrivial(builder)
@@ -413,7 +413,7 @@ private [errors] final class WithLabel private [errors] (val err: TrivialDefuncE
     }
 }
 
-private [errors] final class TrivialAmended private [errors] (val offset: Int, val line: Int, val col: Int, val err: TrivialDefuncError)
+private [errors] final class TrivialAmended private [errors] (val presentationOffset: Int, val line: Int, val col: Int, val err: TrivialDefuncError)
     extends TrivialTransitive {
     assume(!err.entrenched, "an amendment will only occur on unentrenched errors")
     override final val flags = err.flags
@@ -424,7 +424,7 @@ private [errors] final class TrivialAmended private [errors] (val offset: Int, v
     }
 }
 
-private [errors] final class FancyAmended private [errors] (val offset: Int, val line: Int, val col: Int, val err: FancyDefuncError) extends FancyDefuncError {
+private [errors] final class FancyAmended private [errors] (val presentationOffset: Int, val line: Int, val col: Int, val err: FancyDefuncError) extends FancyDefuncError {
     assume(!err.entrenched, "an amendment will only occur on unentrenched errors")
     override final val flags = err.flags
     override def makeFancy(builder: FancyErrorBuilder): Unit = {
@@ -437,7 +437,7 @@ private [errors] final class TrivialEntrenched private [errors] (val by: Int, va
     assume((DefuncError.EntrenchedMask & 1) == 1, "the entrenchment is the least significant bits of the flag")
     override final val flags = err.flags + by//| DefuncError.EntrenchedMask
     assert((flags & ~DefuncError.EntrenchedMask) == (err.flags & ~DefuncError.EntrenchedMask), "entrench should not affect any other flags")
-    override val offset = err.offset
+    override val presentationOffset = err.presentationOffset
     override def makeTrivial(builder: TrivialErrorBuilder): Unit = err.makeTrivial(builder)
 }
 
@@ -446,7 +446,7 @@ private [errors] final class TrivialDislodged private [errors] (val by: Int, val
     assume((DefuncError.EntrenchedMask & 1) == 1, "the entrenchment is the least significant bits of the flag")
     override final val flags = if (err.entrenchedBy > by) err.flags - by else err.flags & ~DefuncError.EntrenchedMask
     assert((flags & ~DefuncError.EntrenchedMask) == (err.flags & ~DefuncError.EntrenchedMask), "dislodge should not affect any other flags")
-    override val offset = err.offset
+    override val presentationOffset = err.presentationOffset
     override def makeTrivial(builder: TrivialErrorBuilder): Unit = err.makeTrivial(builder)
 }
 
@@ -454,7 +454,7 @@ private [errors] final class FancyEntrenched private [errors] (val by: Int, val 
     assume((DefuncError.EntrenchedMask & 1) == 1, "the entrenchment is the least significant bits of the flag")
     override final val flags = err.flags + by//| DefuncError.EntrenchedMask
     assert((flags & ~DefuncError.EntrenchedMask) == (err.flags & ~DefuncError.EntrenchedMask), "entrench should not affect any other flags")
-    override val offset = err.offset
+    override val presentationOffset = err.presentationOffset
     override def makeFancy(builder: FancyErrorBuilder): Unit = err.makeFancy(builder)
 }
 
@@ -463,18 +463,18 @@ private [errors] final class FancyDislodged private [errors] (val by: Int, val e
     assume((DefuncError.EntrenchedMask & 1) == 1, "the entrenchment is the least significant bits of the flag")
     override final val flags = if (err.entrenchedBy > by) err.flags - by else err.flags & ~DefuncError.EntrenchedMask
     assert((flags & ~DefuncError.EntrenchedMask) == (err.flags & ~DefuncError.EntrenchedMask), "dislodge should not affect any other flags")
-    override val offset = err.offset
+    override val presentationOffset = err.presentationOffset
     override def makeFancy(builder: FancyErrorBuilder): Unit = err.makeFancy(builder)
 }
 
 private [errors] final class TrivialLexical private [errors] (val err: TrivialDefuncError) extends TrivialTransitive {
     override final val flags = err.flags | DefuncError.LexicalErrorMask
-    override val offset = err.offset
+    override val presentationOffset = err.presentationOffset
     override def makeTrivial(builder: TrivialErrorBuilder): Unit = err.makeTrivial(builder)
 }
 
 private [errors] final class FancyLexical private [errors] (val err: FancyDefuncError) extends FancyDefuncError {
     override final val flags = err.flags | DefuncError.LexicalErrorMask
-    override val offset = err.offset
+    override val presentationOffset = err.presentationOffset
     override def makeFancy(builder: FancyErrorBuilder): Unit = err.makeFancy(builder)
 }

--- a/parsley/shared/src/main/scala/parsley/internal/machine/instructions/ErrorInstrs.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/instructions/ErrorInstrs.scala
@@ -89,7 +89,7 @@ private [internal] class ApplyReasonAndFail(reason: String) extends Instr {
 private [internal] class AmendAndFail private (partial: Boolean) extends Instr {
     override def apply(ctx: Context): Unit = {
         ensureHandlerInstruction(ctx)
-        ctx.errs.error = ctx.errs.error.amend(if (partial) ctx.offset else ctx.states.offset, ctx.states.line, ctx.states.col)
+        ctx.errs.error = ctx.errs.error.amend(partial, ctx.states.offset, ctx.states.line, ctx.states.col)
         ctx.states = ctx.states.tail
         ctx.fail()
     }

--- a/parsley/shared/src/test/scala/parsley/internal/machine/errors/DefuncErrorTests.scala
+++ b/parsley/shared/src/test/scala/parsley/internal/machine/errors/DefuncErrorTests.scala
@@ -205,14 +205,14 @@ class DefuncErrorTests extends ParsleyTest {
     }
 
     "Amended" should "Change the error position information" in {
-        val err =  new EmptyError(0, 0, 0, 0).amend(10, 10, 10)
+        val err =  new EmptyError(0, 0, 0, 0).amend(false, 10, 10, 10)
         val errOut = err.asParseError
         errOut.col shouldBe 10
         errOut.line shouldBe 10
         errOut.offset shouldBe 10
     }
     it should "work for fancy errors too" in {
-        val err = new ClassicFancyError(0, 0, 0, new RigidCaret(1), "").amend(10, 10, 10)
+        val err = new ClassicFancyError(0, 0, 0, new RigidCaret(1), "").amend(partial = false, 10, 10, 10)
         val errOut = err.asParseError
         errOut.col shouldBe 10
         errOut.line shouldBe 10
@@ -220,7 +220,7 @@ class DefuncErrorTests extends ParsleyTest {
     }
 
     "Entrenched" should "guard against amendment" in {
-        val err = new EmptyError(0, 0, 0, 0).entrench.amend(10, 10, 10)
+        val err = new EmptyError(0, 0, 0, 0).entrench.amend(partial = false, 10, 10, 10)
         val errOut = err.asParseError
         err.entrenched shouldBe true
         errOut.col shouldBe 0
@@ -228,7 +228,7 @@ class DefuncErrorTests extends ParsleyTest {
         errOut.offset shouldBe 0
     }
     it should "work for fancy errors too" in {
-        val err = new ClassicFancyError(0, 0, 0, new RigidCaret(1), "").entrench.amend(10, 10, 10)
+        val err = new ClassicFancyError(0, 0, 0, new RigidCaret(1), "").entrench.amend(partial = false, 10, 10, 10)
         val errOut = err.asParseError
         err.entrenched shouldBe true
         errOut.col shouldBe 0
@@ -240,7 +240,7 @@ class DefuncErrorTests extends ParsleyTest {
         val err = new EmptyError(0, 0, 0, 0).entrench
         require(err.entrenched)
         err.dislodge(Int.MaxValue).entrenched shouldBe false
-        val err2 = err.dislodge(Int.MaxValue).amend(10, 10, 10).asParseError
+        val err2 = err.dislodge(Int.MaxValue).amend(partial = false, 10, 10, 10).asParseError
         err2.col shouldBe 10
         err2.line shouldBe 10
         err2.offset shouldBe 10
@@ -249,7 +249,7 @@ class DefuncErrorTests extends ParsleyTest {
         val err = new ClassicFancyError(0, 0, 0, new RigidCaret(1), "").entrench
         require(err.entrenched)
         err.dislodge(Int.MaxValue).entrenched shouldBe false
-        val err2 = err.dislodge(Int.MaxValue).amend(10, 10, 10).asParseError
+        val err2 = err.dislodge(Int.MaxValue).amend(partial = false, 10, 10, 10).asParseError
         err2.col shouldBe 10
         err2.line shouldBe 10
         err2.offset shouldBe 10


### PR DESCRIPTION
Implemented partial amending as described in #152, but not yet with the caret stretching behaviour: the combinators are not exposed until another minor release.