### PR TITLE
Improved Unicode handling in token extractors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,7 @@ inThisBuild(List(
     ProblemFilters.exclude[DirectMissingMethodProblem]("parsley.token.errors.*.asExpectDesc"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("parsley.token.errors.*.label"),
     ProblemFilters.exclude[IncompatibleMethTypeProblem]("parsley.token.errors.*.this"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("parsley.errors.helpers#WhitespaceOrUnprintable.unapply"),
     // Expression refactor
     ProblemFilters.exclude[ReversedMissingMethodProblem]("parsley.expr.Fixity.chain"),
     ProblemFilters.exclude[ReversedMissingMethodProblem]("parsley.expr.Ops.chain"),

--- a/parsley/shared/src/main/scala/parsley/errors/helpers.scala
+++ b/parsley/shared/src/main/scala/parsley/errors/helpers.scala
@@ -6,9 +6,6 @@ package parsley.errors
 import scala.annotation.tailrec
 import scala.collection.immutable.WrappedString
 
-// Turn coverage off, because the tests have their own error builder
-// We might want to test this on its own though
-// $COVERAGE-OFF$
 private [parsley] object helpers {
     def renderRawString(s: String): String = s match {
         case WhitespaceOrUnprintable(name) => name
@@ -66,4 +63,3 @@ private [parsley] object helpers {
         }
     }
 }
-// $COVERAGE-ON$

--- a/parsley/shared/src/main/scala/parsley/errors/helpers.scala
+++ b/parsley/shared/src/main/scala/parsley/errors/helpers.scala
@@ -7,6 +7,8 @@ import scala.annotation.tailrec
 import scala.collection.immutable.WrappedString
 
 private [parsley] object helpers {
+    // These don't really need to be tested right now
+    // $COVERAGE-OFF$
     def renderRawString(s: String): String = s match {
         case WhitespaceOrUnprintable(name) => name
         // this will handle utf-16 surrogate pairs properly
@@ -21,6 +23,7 @@ private [parsley] object helpers {
         case any@(alt::alts) if any.exists(_.contains(",")) => Some(s"${alts.reverse.mkString("; ")}; or $alt")
         case alt::alts => Some(s"${alts.reverse.mkString(", ")}, or $alt")
     }
+    // $COVERAGE-ON$
 
     object WhitespaceOrUnprintable {
         // These are all inlined, so aren't "tested"
@@ -55,7 +58,8 @@ private [parsley] object helpers {
         }
     }
 
-    def takeCodePoints(s: WrappedString, n: Int): String = takeCodePoints(s.iterator, n, new StringBuilder)
+    // TODO: optimise this to avoid copy?
+    def takeCodePoints(s: WrappedString, n: Int): String = takeCodePoints(s: Iterable[Char], n)//takeCodePoints(s.iterator, n, new StringBuilder)
     def takeCodePoints(s: Iterable[Char], n: Int): String = takeCodePoints(s.iterator, n, new StringBuilder)
 
     @tailrec private def takeCodePoints(it: Iterator[Char], n: Int, sb: StringBuilder): String = {

--- a/parsley/shared/src/main/scala/parsley/errors/helpers.scala
+++ b/parsley/shared/src/main/scala/parsley/errors/helpers.scala
@@ -23,10 +23,13 @@ private [parsley] object helpers {
     }
 
     object WhitespaceOrUnprintable {
+        // These are all inlined, so aren't "tested"
+        // $COVERAGE-OFF$
         private final val Newline  = 0x000a
         private final val Carriage = 0x000d
         private final val Tab      = 0x0009
         private final val Space    = 0x0020
+        // $COVERAGE-ON$
 
         def unapply(cs: Iterable[Char]): Option[String] = unapply(cs.take(2).mkString)
         def unapply(s: String): Option[String] = unapply(s.codePointAt(0))
@@ -44,8 +47,8 @@ private [parsley] object helpers {
                    | Character.UNASSIGNED
                    | Character.CONTROL =>
                     Character.toChars(cp) match {
-                        case Array(h, l) => Some(f"non-printable codepoint (\\u${h.toInt}%04X\\u${l.toInt}%04X, or 0x$cp%08X)")
-                        case Array(c)    => Some(f"non-printable character (\\u${c.toInt}%04X)")
+                        case Array(h, l) => Some(f"non-printable codepoint (\\u${h.toInt}%04x\\u${l.toInt}%04x, or 0x$cp%06x)")
+                        case Array(c)    => Some(f"non-printable character (\\u${c.toInt}%04x)")
                     }
                 case _ => None
             }

--- a/parsley/shared/src/main/scala/parsley/errors/helpers.scala
+++ b/parsley/shared/src/main/scala/parsley/errors/helpers.scala
@@ -5,7 +5,7 @@ package parsley.errors
 
 import scala.annotation.tailrec
 import scala.collection.immutable.WrappedString
-import scala.util.matching.Regex
+//import scala.util.matching.Regex
 
 // Turn coverage off, because the tests have their own error builder
 // We might want to test this on its own though
@@ -26,12 +26,15 @@ private [parsley] object helpers {
         case alt::alts => Some(s"${alts.reverse.mkString(", ")}, or $alt")
     }
 
-    private val Unprintable: Regex = "(\\p{C})".r
+    //private val Unprintable: Regex = "(\\p{C})".r
 
     object WhitespaceOrUnprintable {
-        def unapply(cs: Iterable[Char]): Option[String] = unapply(cs.head)
-        def unapply(s: String): Option[String] = unapply(s.charAt(0))
-        def unapply(c: Char): Option[String] = c match {
+        def unapply(cs: Iterable[Char]): Option[String] = unapply(cs.take(2).mkString) /*{
+            if (cs.head.isHighSurrogate && cs.size > 1) unapply(Character.toCodePoint(cs.head, cs.tail.head))
+            else unapply(cs.head.toInt)
+        }*/
+        def unapply(s: String): Option[String] = unapply(s.codePointAt(0))
+        /*def unapply(c: Char): Option[String] = c match {
             case '\n' => Some("newline")
             case '\t' => Some("tab")
             case c if c.isSpaceChar => Some("space")
@@ -39,6 +42,26 @@ private [parsley] object helpers {
             case c if c.isHighSurrogate => None
             case Unprintable(up) => Some(f"unprintable character (\\u${up.toInt}%04X)")
             case _ => None
+        }*/
+        def unapply(cp: Int): Option[String] = {
+            if (Character.isWhitespace(cp)) cp match {
+                case 0x000a => Some("newline")
+                case 0x000d => Some("carriage return")
+                case 0x0009 => Some("tab")
+                case 0x0020 => Some("space")
+                case _      => Some("whitespace character")
+            } else Character.getType(cp) match {
+                case Character.FORMAT
+                   | Character.SURROGATE
+                   | Character.PRIVATE_USE
+                   | Character.UNASSIGNED
+                   | Character.CONTROL =>
+                    Character.toChars(cp) match {
+                        case Array(h, l) => Some(f"non-printable codepoint (\\u${h.toInt}%04X\\u${l.toInt}%04X, or 0x$cp%08X) ")
+                        case Array(c)    => Some(f"non-printable character (\\u${c.toInt}%04X)")
+                    }
+                case _ => None
+            }
         }
     }
 

--- a/parsley/shared/src/main/scala/parsley/errors/helpers.scala
+++ b/parsley/shared/src/main/scala/parsley/errors/helpers.scala
@@ -5,7 +5,6 @@ package parsley.errors
 
 import scala.annotation.tailrec
 import scala.collection.immutable.WrappedString
-//import scala.util.matching.Regex
 
 // Turn coverage off, because the tests have their own error builder
 // We might want to test this on its own though
@@ -26,23 +25,9 @@ private [parsley] object helpers {
         case alt::alts => Some(s"${alts.reverse.mkString(", ")}, or $alt")
     }
 
-    //private val Unprintable: Regex = "(\\p{C})".r
-
     object WhitespaceOrUnprintable {
-        def unapply(cs: Iterable[Char]): Option[String] = unapply(cs.take(2).mkString) /*{
-            if (cs.head.isHighSurrogate && cs.size > 1) unapply(Character.toCodePoint(cs.head, cs.tail.head))
-            else unapply(cs.head.toInt)
-        }*/
+        def unapply(cs: Iterable[Char]): Option[String] = unapply(cs.take(2).mkString)
         def unapply(s: String): Option[String] = unapply(s.codePointAt(0))
-        /*def unapply(c: Char): Option[String] = c match {
-            case '\n' => Some("newline")
-            case '\t' => Some("tab")
-            case c if c.isSpaceChar => Some("space")
-            case c if c.isWhitespace => Some("whitespace character")
-            case c if c.isHighSurrogate => None
-            case Unprintable(up) => Some(f"unprintable character (\\u${up.toInt}%04X)")
-            case _ => None
-        }*/
         def unapply(cp: Int): Option[String] = {
             if (Character.isWhitespace(cp)) cp match {
                 case 0x000a => Some("newline")

--- a/parsley/shared/src/main/scala/parsley/errors/helpers.scala
+++ b/parsley/shared/src/main/scala/parsley/errors/helpers.scala
@@ -26,15 +26,20 @@ private [parsley] object helpers {
     }
 
     object WhitespaceOrUnprintable {
+        private final val Newline  = 0x000a
+        private final val Carriage = 0x000d
+        private final val Tab      = 0x0009
+        private final val Space    = 0x0020
+
         def unapply(cs: Iterable[Char]): Option[String] = unapply(cs.take(2).mkString)
         def unapply(s: String): Option[String] = unapply(s.codePointAt(0))
         def unapply(cp: Int): Option[String] = {
             if (Character.isWhitespace(cp)) cp match {
-                case 0x000a => Some("newline")
-                case 0x000d => Some("carriage return")
-                case 0x0009 => Some("tab")
-                case 0x0020 => Some("space")
-                case _      => Some("whitespace character")
+                case Newline  => Some("newline")
+                case Carriage => Some("carriage return")
+                case Tab      => Some("tab")
+                case Space    => Some("space")
+                case _        => Some("whitespace character")
             } else Character.getType(cp) match {
                 case Character.FORMAT
                    | Character.SURROGATE
@@ -42,7 +47,7 @@ private [parsley] object helpers {
                    | Character.UNASSIGNED
                    | Character.CONTROL =>
                     Character.toChars(cp) match {
-                        case Array(h, l) => Some(f"non-printable codepoint (\\u${h.toInt}%04X\\u${l.toInt}%04X, or 0x$cp%08X) ")
+                        case Array(h, l) => Some(f"non-printable codepoint (\\u${h.toInt}%04X\\u${l.toInt}%04X, or 0x$cp%08X)")
                         case Array(c)    => Some(f"non-printable character (\\u${c.toInt}%04X)")
                     }
                 case _ => None

--- a/parsley/shared/src/main/scala/parsley/errors/tokenextractors/LexToken.scala
+++ b/parsley/shared/src/main/scala/parsley/errors/tokenextractors/LexToken.scala
@@ -67,7 +67,8 @@ trait LexToken { this: ErrorBuilder[_] =>
       * the residual input, this function will select ''one'' of them to report back.
       *
       * The default behaviour is to take the longest matched token (i.e. the one with
-      * the largest paired position).
+      * the largest paired position). In case of a tie, the first token is chosen:
+      * this means that more specific tokens should be put sooner in the `tokens` list.
       *
       * @param matchedToks the list of tokens successfully parsed, along with the position
       *                    at the end of that parse (careful: this position starts back at

--- a/parsley/shared/src/main/scala/parsley/errors/tokenextractors/LexToken.scala
+++ b/parsley/shared/src/main/scala/parsley/errors/tokenextractors/LexToken.scala
@@ -14,9 +14,6 @@ import parsley.combinator.{choice, eof, option, sequence, someUntil}
 import parsley.errors.{ErrorBuilder, Token, TokenSpan}
 import parsley.position
 
-// Turn coverage off, because the tests have their own error builder
-// TODO: We might want to test this on its own though
-// $COVERAGE-OFF$
 /** This extractor mixin provides an implementation for
   * [[parsley.errors.ErrorBuilder.unexpectedToken `ErrorBuilder.unexpectedToken`]] when mixed into
   * an error builder: it will try and parse the residual input to identify a valid lexical token
@@ -126,4 +123,3 @@ object LexToken {
         case (p, n) => p #> n
     }
 }
-// $COVERAGE-ON$

--- a/parsley/shared/src/main/scala/parsley/errors/tokenextractors/MatchParserDemand.scala
+++ b/parsley/shared/src/main/scala/parsley/errors/tokenextractors/MatchParserDemand.scala
@@ -8,9 +8,6 @@ import scala.collection.immutable.WrappedString
 import parsley.XCompat.unused
 import parsley.errors.{helpers, ErrorBuilder, Token, TokenSpan}
 
-// Turn coverage off, because the tests have their own error builder
-// We might want to test this on its own though
-// $COVERAGE-OFF$
 /** This extractor mixin provides an implementation for
   * [[parsley.errors.ErrorBuilder.unexpectedToken `ErrorBuilder.unexpectedToken`]] when mixed into
   * an error builder: it will make a token as wide as the amount of input the parser tried to
@@ -45,4 +42,3 @@ object MatchParserDemand {
         case _ => helpers.takeCodePoints(cs, upto)
     }
 }
-// $COVERAGE-ON$

--- a/parsley/shared/src/main/scala/parsley/errors/tokenextractors/MatchParserDemand.scala
+++ b/parsley/shared/src/main/scala/parsley/errors/tokenextractors/MatchParserDemand.scala
@@ -39,6 +39,6 @@ object MatchParserDemand {
     // this is redundant.
     private def substring(cs: Iterable[Char], upto: Int): String = cs match {
         case cs: WrappedString => helpers.takeCodePoints(cs, upto)
-        case _ => helpers.takeCodePoints(cs, upto)
+        case _ => helpers.takeCodePoints(cs, upto) // this will be relevant when Cosmin's work is merged
     }
 }

--- a/parsley/shared/src/main/scala/parsley/errors/tokenextractors/MatchParserDemand.scala
+++ b/parsley/shared/src/main/scala/parsley/errors/tokenextractors/MatchParserDemand.scala
@@ -39,6 +39,6 @@ object MatchParserDemand {
     // this is redundant.
     private def substring(cs: Iterable[Char], upto: Int): String = cs match {
         case cs: WrappedString => helpers.takeCodePoints(cs, upto)
-        case _ => helpers.takeCodePoints(cs, upto) // this will be relevant when Cosmin's work is merged
+        case _ => helpers.takeCodePoints(cs, upto)
     }
 }

--- a/parsley/shared/src/main/scala/parsley/errors/tokenextractors/SingleChar.scala
+++ b/parsley/shared/src/main/scala/parsley/errors/tokenextractors/SingleChar.scala
@@ -31,10 +31,13 @@ object SingleChar {
     /** The implementation of `unexpectedToken` as done by `SingleChar`, with redundant arguments removed.
       * @since 4.0.0
       */
-    def unexpectedToken(cs: Iterable[Char]): Token = cs.head match {
-        case helpers.WhitespaceOrUnprintable(name) => Token.Named(name, TokenSpan.Width(1))
-        case c if c.isHighSurrogate => Token.Raw(cs.take(2).mkString)
-        case c => Token.Raw(s"$c")
+    def unexpectedToken(cs: Iterable[Char]): Token = {
+        val s = cs.take(2).mkString
+        s.codePointAt(0) match {
+            case helpers.WhitespaceOrUnprintable(name) => Token.Named(name, TokenSpan.Width(1))
+            case cp if Character.isSupplementaryCodePoint(cp) => Token.Raw(s)
+            case cp => Token.Raw(s"${cp.toChar}")
+        }
     }
 }
 // $COVERAGE-ON$

--- a/parsley/shared/src/main/scala/parsley/errors/tokenextractors/SingleChar.scala
+++ b/parsley/shared/src/main/scala/parsley/errors/tokenextractors/SingleChar.scala
@@ -6,9 +6,6 @@ package parsley.errors.tokenextractors
 import parsley.XCompat.unused
 import parsley.errors.{helpers, ErrorBuilder, Token, TokenSpan}
 
-// Turn coverage off, because the tests have their own error builder
-// We might want to test this on its own though
-// $COVERAGE-OFF$
 /** This extractor mixin provides an implementation for
   * [[parsley.errors.ErrorBuilder.unexpectedToken `ErrorBuilder.unexpectedToken`]] when mixed into
   * an error builder: it will unconditionally report the first character in the remaining input
@@ -40,4 +37,3 @@ object SingleChar {
         }
     }
 }
-// $COVERAGE-ON$

--- a/parsley/shared/src/main/scala/parsley/errors/tokenextractors/TillNextWhitespace.scala
+++ b/parsley/shared/src/main/scala/parsley/errors/tokenextractors/TillNextWhitespace.scala
@@ -61,6 +61,7 @@ object TillNextWhitespace {
     }
 
     // TODO: we should take to minimum of parser demand and next whitespace, this would potentially be much much cheaper
+    // Assumption: there are no non-BMP whitespace characters
     private def extractTillNextWhitespace(cs: Iterable[Char]): String = cs match {
         case cs: WrappedString =>
             // These do not require allocation on the string
@@ -69,6 +70,6 @@ object TillNextWhitespace {
                 if (idx != -1) idx else cs.length
             }
             cs.slice(0, idx).toString
-        case cs => cs.takeWhile(!_.isWhitespace).mkString
+        case cs => cs.takeWhile(!_.isWhitespace).mkString // this will be relevant when Cosmin's work is merged
     }
 }

--- a/parsley/shared/src/main/scala/parsley/errors/tokenextractors/TillNextWhitespace.scala
+++ b/parsley/shared/src/main/scala/parsley/errors/tokenextractors/TillNextWhitespace.scala
@@ -70,6 +70,6 @@ object TillNextWhitespace {
                 if (idx != -1) idx else cs.length
             }
             cs.slice(0, idx).toString
-        case cs => cs.takeWhile(!_.isWhitespace).mkString // this will be relevant when Cosmin's work is merged
+        case cs => cs.takeWhile(!_.isWhitespace).mkString
     }
 }

--- a/parsley/shared/src/main/scala/parsley/errors/tokenextractors/TillNextWhitespace.scala
+++ b/parsley/shared/src/main/scala/parsley/errors/tokenextractors/TillNextWhitespace.scala
@@ -8,9 +8,6 @@ import scala.collection.immutable.WrappedString
 import parsley.XCompat.unused
 import parsley.errors.{helpers, ErrorBuilder, Token, TokenSpan}
 
-// Turn coverage off, because the tests have their own error builder
-// We might want to test this on its own though
-// $COVERAGE-OFF$
 /** This extractor mixin provides an implementation for
   * [[parsley.errors.ErrorBuilder.unexpectedToken `ErrorBuilder.unexpectedToken`]] when mixed into
   * an error builder: it will construct a token that extends to the next available whitespace
@@ -75,4 +72,3 @@ object TillNextWhitespace {
         case cs => cs.takeWhile(!_.isWhitespace).mkString
     }
 }
-// $COVERAGE-ON$

--- a/parsley/shared/src/test/scala/parsley/ParsleyTest.scala
+++ b/parsley/shared/src/test/scala/parsley/ParsleyTest.scala
@@ -57,8 +57,8 @@ abstract class TestErrorBuilder extends ErrorBuilder[TestError] {
     type LineInfo = Unit
     override def lineInfo(line: String, linesBefore: Seq[String], linesAfter: Seq[String], errorPointsAt: Int, errorWidth: Int): Unit = ()
 
-    override val numLinesBefore: Int = 0
-    override val numLinesAfter: Int = 0
+    override val numLinesBefore: Int = 2
+    override val numLinesAfter: Int = 2
 
     type Item = TestErrorItem
     type Raw = parsley.Raw

--- a/parsley/shared/src/test/scala/parsley/ParsleyTest.scala
+++ b/parsley/shared/src/test/scala/parsley/ParsleyTest.scala
@@ -24,7 +24,7 @@ case class Raw(item: String) extends TestErrorItem
 case class Named(item: String) extends TestErrorItem
 case object EndOfInput extends TestErrorItem
 
-class TestErrorBuilder extends ErrorBuilder[TestError] with tokenextractors.MatchParserDemand {
+abstract class TestErrorBuilder extends ErrorBuilder[TestError] {
     override def format(pos: Position, source: Source, lines: ErrorInfoLines): TestError = TestError(pos, lines)
 
     type Position = (Int, Int)
@@ -57,8 +57,8 @@ class TestErrorBuilder extends ErrorBuilder[TestError] with tokenextractors.Matc
     type LineInfo = Unit
     override def lineInfo(line: String, linesBefore: Seq[String], linesAfter: Seq[String], errorPointsAt: Int, errorWidth: Int): Unit = ()
 
-    override val numLinesBefore: Int = 2
-    override val numLinesAfter: Int = 2
+    override val numLinesBefore: Int = 0
+    override val numLinesAfter: Int = 0
 
     type Item = TestErrorItem
     type Raw = parsley.Raw
@@ -85,7 +85,7 @@ abstract class ParsleyTest extends AnyFlatSpec with Matchers with Assertions wit
         }
     }
 
-    implicit val eb: ErrorBuilder[TestError] = new TestErrorBuilder
+    implicit val eb: ErrorBuilder[TestError] = new TestErrorBuilder with tokenextractors.MatchParserDemand
 
     implicit class FullParse[A](val p: Parsley[A]) {
         def parseAll[Err: ErrorBuilder](input: String): Result[Err, A] = (p <* eof).parse(input)

--- a/parsley/shared/src/test/scala/parsley/errors/TokenExtractorTests.scala
+++ b/parsley/shared/src/test/scala/parsley/errors/TokenExtractorTests.scala
@@ -1,0 +1,43 @@
+package parsley.errors
+
+import parsley.{ParsleyTest, TestErrorBuilder}
+import parsley.errors._
+import parsley.errors.tokenextractors._
+
+class TokenExtractorTests extends ParsleyTest {
+    val singleChar = new TestErrorBuilder with SingleChar
+    val matchParserDemand = new TestErrorBuilder with MatchParserDemand
+    val tillNextWhitespaceTrimmed = new TestErrorBuilder with TillNextWhitespace {
+        def trimToParserDemand: Boolean = true
+    }
+    val tillNextWhitespaceRaw = new TestErrorBuilder with TillNextWhitespace {
+        def trimToParserDemand: Boolean = false
+    }
+    // TODO: lexToken
+
+    "SingleChar" should "return a single printable ascii character" in {
+        singleChar.unexpectedToken("abc", 1, false) shouldBe Token.Raw("a")
+        singleChar.unexpectedToken("1", 1, false) shouldBe Token.Raw("1")
+        singleChar.unexpectedToken(";", 2, true) shouldBe Token.Raw(";")
+    }
+    it should "handle supplementary unicode characters" in {
+        singleChar.unexpectedToken("🙂", 1, true) shouldBe Token.Raw("🙂")
+        singleChar.unexpectedToken("🙂🙂🙂", 1, false) shouldBe Token.Raw("🙂")
+    }
+    it should "deal with whitespace characters by naming them" in {
+        singleChar.unexpectedToken(" ", 1, true) shouldBe Token.Named("space", TokenSpan.Width(1))
+        singleChar.unexpectedToken("\n", 1, true) shouldBe Token.Named("newline", TokenSpan.Width(1))
+        singleChar.unexpectedToken("\t", 1, true) shouldBe Token.Named("tab", TokenSpan.Width(1))
+        singleChar.unexpectedToken("\r", 1, true) shouldBe Token.Named("carriage return", TokenSpan.Width(1))
+        singleChar.unexpectedToken("\f", 1, true) shouldBe Token.Named("whitespace character", TokenSpan.Width(1))
+    }
+    it should "refuse to print control characters" in {
+        singleChar.unexpectedToken("\u0000", 1, true) shouldBe Token.Named("non-printable character (\\u0000)", TokenSpan.Width(1))
+        singleChar.unexpectedToken("\u0001", 1, true) shouldBe Token.Named("non-printable character (\\u0001)", TokenSpan.Width(1))
+        singleChar.unexpectedToken("\ud83d", 1, true) shouldBe Token.Named("non-printable character (\\ud83d)", TokenSpan.Width(1))
+    }
+    it should "refuse to print non-printable supplementary characters" in {
+        singleChar.unexpectedToken(Character.toChars(0x0f0000), 1, true) shouldBe Token.Named("non-printable codepoint (\\udb80\\udc00, or 0x0f0000)", TokenSpan.Width(1))
+        singleChar.unexpectedToken(Character.toChars(0x10ffff), 1, true) shouldBe Token.Named("non-printable codepoint (\\udbff\\udfff, or 0x10ffff)", TokenSpan.Width(1))
+    }
+}

--- a/parsley/shared/src/test/scala/parsley/errors/TokenExtractorTests.scala
+++ b/parsley/shared/src/test/scala/parsley/errors/TokenExtractorTests.scala
@@ -1,3 +1,6 @@
+/* SPDX-FileCopyrightText: © 2023 Parsley Contributors <https://github.com/j-mie6/Parsley/graphs/contributors>
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 package parsley.errors
 
 import parsley.{ParsleyTest, TestErrorBuilder}

--- a/parsley/shared/src/test/scala/parsley/errors/TokenExtractorTests.scala
+++ b/parsley/shared/src/test/scala/parsley/errors/TokenExtractorTests.scala
@@ -64,12 +64,57 @@ class TokenExtractorTests extends ParsleyTest {
         matchParserDemand.unexpectedToken(Character.toChars(0x10ffff), 1, true) shouldBe Token.Named("non-printable codepoint (\\udbff\\udfff, or 0x10ffff)", TokenSpan.Width(1))
     }
 
-
     val tillNextWhitespaceTrimmed = new TestErrorBuilder with TillNextWhitespace {
         def trimToParserDemand: Boolean = true
     }
     val tillNextWhitespaceRaw = new TestErrorBuilder with TillNextWhitespace {
         def trimToParserDemand: Boolean = false
+    }
+    "TillNextWhitespace" should "return a single printable ascii character" in {
+        tillNextWhitespaceTrimmed.unexpectedToken("abc", 1, false) shouldBe Token.Raw("a")
+        tillNextWhitespaceTrimmed.unexpectedToken("abc ", 2, false) shouldBe Token.Raw("ab")
+        tillNextWhitespaceTrimmed.unexpectedToken("a  bc", 2, false) shouldBe Token.Raw("a")
+        tillNextWhitespaceTrimmed.unexpectedToken("1\n23", 4, false) shouldBe Token.Raw("1")
+        tillNextWhitespaceTrimmed.unexpectedToken("; ", 2, true) shouldBe Token.Raw(";")
+        tillNextWhitespaceTrimmed.unexpectedToken(";. ,", 3, true) shouldBe Token.Raw(";.")
+        tillNextWhitespaceRaw.unexpectedToken("abc", 1, false) shouldBe Token.Raw("abc")
+        tillNextWhitespaceRaw.unexpectedToken("abc ", 2, false) shouldBe Token.Raw("abc")
+        tillNextWhitespaceRaw.unexpectedToken("a  bc", 2, false) shouldBe Token.Raw("a")
+        tillNextWhitespaceRaw.unexpectedToken("1\n23", 4, false) shouldBe Token.Raw("1")
+        tillNextWhitespaceRaw.unexpectedToken("; ", 2, true) shouldBe Token.Raw(";")
+        tillNextWhitespaceRaw.unexpectedToken(";. ,", 3, true) shouldBe Token.Raw(";.")
+    }
+    it should "handle supplementary unicode characters" in {
+        tillNextWhitespaceTrimmed.unexpectedToken("😀", 2, true) shouldBe Token.Raw("😀")
+        tillNextWhitespaceTrimmed.unexpectedToken("😀😀😀 😀", 2, false) shouldBe Token.Raw("😀😀")
+        tillNextWhitespaceRaw.unexpectedToken("😀 😀", 2, true) shouldBe Token.Raw("😀")
+        tillNextWhitespaceRaw.unexpectedToken("😀😀 😀", 1, false) shouldBe Token.Raw("😀😀")
+    }
+    it should "deal with whitespace characters by naming them" in {
+        tillNextWhitespaceTrimmed.unexpectedToken(" aa", 2, true) shouldBe Token.Named("space", TokenSpan.Width(1))
+        tillNextWhitespaceTrimmed.unexpectedToken("\naa", 2, true) shouldBe Token.Named("newline", TokenSpan.Width(1))
+        tillNextWhitespaceTrimmed.unexpectedToken("\taa", 2, true) shouldBe Token.Named("tab", TokenSpan.Width(1))
+        tillNextWhitespaceTrimmed.unexpectedToken("\raa", 3, true) shouldBe Token.Named("carriage return", TokenSpan.Width(1))
+        tillNextWhitespaceTrimmed.unexpectedToken("\faa", 1, true) shouldBe Token.Named("whitespace character", TokenSpan.Width(1))
+        tillNextWhitespaceRaw.unexpectedToken(" aa", 2, true) shouldBe Token.Named("space", TokenSpan.Width(1))
+        tillNextWhitespaceRaw.unexpectedToken("\naa", 2, true) shouldBe Token.Named("newline", TokenSpan.Width(1))
+        tillNextWhitespaceRaw.unexpectedToken("\taa", 2, true) shouldBe Token.Named("tab", TokenSpan.Width(1))
+        tillNextWhitespaceRaw.unexpectedToken("\raa", 3, true) shouldBe Token.Named("carriage return", TokenSpan.Width(1))
+        tillNextWhitespaceRaw.unexpectedToken("\faa", 1, true) shouldBe Token.Named("whitespace character", TokenSpan.Width(1))
+    }
+    it should "refuse to print control characters" in {
+        tillNextWhitespaceTrimmed.unexpectedToken("\u0000aaa", 3, true) shouldBe Token.Named("non-printable character (\\u0000)", TokenSpan.Width(1))
+        tillNextWhitespaceTrimmed.unexpectedToken("\u0001aaa", 3, true) shouldBe Token.Named("non-printable character (\\u0001)", TokenSpan.Width(1))
+        tillNextWhitespaceTrimmed.unexpectedToken("\ud83daaa", 2, true) shouldBe Token.Named("non-printable character (\\ud83d)", TokenSpan.Width(1))
+        tillNextWhitespaceRaw.unexpectedToken("\u0000aaa", 3, true) shouldBe Token.Named("non-printable character (\\u0000)", TokenSpan.Width(1))
+        tillNextWhitespaceRaw.unexpectedToken("\u0001aaa", 3, true) shouldBe Token.Named("non-printable character (\\u0001)", TokenSpan.Width(1))
+        tillNextWhitespaceRaw.unexpectedToken("\ud83daaa", 2, true) shouldBe Token.Named("non-printable character (\\ud83d)", TokenSpan.Width(1))
+    }
+    it should "refuse to print non-printable supplementary characters" in {
+        tillNextWhitespaceTrimmed.unexpectedToken(Character.toChars(0x0f0000), 1, true) shouldBe Token.Named("non-printable codepoint (\\udb80\\udc00, or 0x0f0000)", TokenSpan.Width(1))
+        tillNextWhitespaceTrimmed.unexpectedToken(Character.toChars(0x10ffff), 1, true) shouldBe Token.Named("non-printable codepoint (\\udbff\\udfff, or 0x10ffff)", TokenSpan.Width(1))
+        tillNextWhitespaceRaw.unexpectedToken(Character.toChars(0x0f0000), 1, true) shouldBe Token.Named("non-printable codepoint (\\udb80\\udc00, or 0x0f0000)", TokenSpan.Width(1))
+        tillNextWhitespaceRaw.unexpectedToken(Character.toChars(0x10ffff), 1, true) shouldBe Token.Named("non-printable codepoint (\\udbff\\udfff, or 0x10ffff)", TokenSpan.Width(1))
     }
     // TODO: lexToken
 }

--- a/parsley/shared/src/test/scala/parsley/errors/TokenExtractorTests.scala
+++ b/parsley/shared/src/test/scala/parsley/errors/TokenExtractorTests.scala
@@ -24,8 +24,8 @@ class TokenExtractorTests extends ParsleyTest {
         singleChar.unexpectedToken(";", 2, true) shouldBe Token.Raw(";")
     }
     it should "handle supplementary unicode characters" in {
-        singleChar.unexpectedToken("🙂", 1, true) shouldBe Token.Raw("🙂")
-        singleChar.unexpectedToken("🙂🙂🙂", 1, false) shouldBe Token.Raw("🙂")
+        singleChar.unexpectedToken("😀", 1, true) shouldBe Token.Raw("😀")
+        singleChar.unexpectedToken("😀😀😀", 1, false) shouldBe Token.Raw("😀")
     }
     it should "deal with whitespace characters by naming them" in {
         singleChar.unexpectedToken(" ", 1, true) shouldBe Token.Named("space", TokenSpan.Width(1))


### PR DESCRIPTION
Slightly improved the rendering of unprintable characters, and unicode handling within the existing token extractors.

Now, `SingleChar` will always account for a code-point (no per character handling!) and the categories are more explicit with no more regex (which apparently is a little buggy on the JVM for this kind of thing!)