### PR TITLE
Added "wordy" `as` and `from` combinators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        scala: [2.13.11]
+        scala: [2.13]
         java: [temurin@11]
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -118,7 +118,7 @@ lazy val parsley = crossProject(JSPlatform, JVMPlatform, NativePlatform)
 def testCoverageJob(cacheSteps: List[WorkflowStep]) = WorkflowJob(
     id = "coverage",
     name = "Run Test Coverage and Upload",
-    scalas = List(Scala213),
+    scalas = List(CrossVersion.binaryScalaVersion(Scala213)),
     cond = Some(s"github.ref == 'refs/heads/$mainBranch' || (github.event_name == 'pull_request' && github.base_ref == '$mainBranch')"),
     steps =
         WorkflowStep.Checkout ::

--- a/build.sbt
+++ b/build.sbt
@@ -118,7 +118,7 @@ lazy val parsley = crossProject(JSPlatform, JVMPlatform, NativePlatform)
 def testCoverageJob(cacheSteps: List[WorkflowStep]) = WorkflowJob(
     id = "coverage",
     name = "Run Test Coverage and Upload",
-    scalas = List(CrossVersion.binaryScalaVersion(Scala213)),
+    scalas = List(CrossVersion.binaryScalaVersion(Scala213)), // TODO: this can be dropped when https://github.com/typelevel/sbt-typelevel/pull/565 is merged
     cond = Some(s"github.ref == 'refs/heads/$mainBranch' || (github.event_name == 'pull_request' && github.base_ref == '$mainBranch')"),
     steps =
         WorkflowStep.Checkout ::

--- a/parsley/shared/src/main/scala/parsley/Parsley.scala
+++ b/parsley/shared/src/main/scala/parsley/Parsley.scala
@@ -165,9 +165,29 @@ final class Parsley[+A] private [parsley] (private [parsley] val internal: front
       *
       * @param x the new result of this parser.
       * @return a new parser that behaves the same as this parser, but always succeeds with `x` as the result.
+      * @note just an alias for `as`.
       * @group map
       */
-    def #>[B](x: B): Parsley[B] = this *> pure(x)
+    def #>[B](x: B): Parsley[B] = this.as(x)
+    /** This combinator replaces the result of this parser, ignoring the old result.
+      *
+      * Similar to `map`, except the old result of this parser is not required to
+      * compute the new result. This is useful when the result is a constant value (or function!).
+      * Functionally the same as `this *> pure(x)` or `this.map(_ => x)`.
+      *
+      * ''In Haskell, this combinator is known as `($>)`''.
+      *
+      * @example {{{
+      * scala> import parsley.character.string
+      * scala> (string("true").as(true)).parse("true")
+      * val res0 = Success(true)
+      * }}}
+      *
+      * @param x the new result of this parser.
+      * @return a new parser that behaves the same as this parser, but always succeeds with `x` as the result.
+      * @group map
+      */
+    def as[B](x: B): Parsley[B] = this *> pure(x)
     /** Replaces the result of this parser with `()`.
       *
       * This combinator is useful when the result of this parser is not required, and the

--- a/parsley/shared/src/main/scala/parsley/genericbridges.scala
+++ b/parsley/shared/src/main/scala/parsley/genericbridges.scala
@@ -23,7 +23,7 @@ import lift._
 object genericbridges {
     // $COVERAGE-OFF$
     // scalastyle:off parameter.number ensure.single.space.after.token
-    /** Generic bridge trait enabling the `<#` syntax on this type:
+    /** Generic bridge trait enabling the `<#`/`from` combinator on this type:
       * this is useful when the constructor is not applied immediately,
       * like when using `precedence`. It does not track any metadata.
       *
@@ -38,8 +38,15 @@ object genericbridges {
           * returns `con`.
           *
           * @param op the parser that should be parsed before returning `con`.
+          * @note equivalent to `from`.
           */
-        final def <#(op: Parsley[_]): Parsley[A] = op #> con
+        final def <#(op: Parsley[_]): Parsley[A] = this.from(op)
+        /** The combinator on this implementing type that performs the parser and
+          * returns `con`.
+          *
+          * @param op the parser that should be parsed before returning `con`.
+          */
+        final def from(op: Parsley[_]): Parsley[A] = op.as(con)
     }
 
     /** Generic bridge trait for singleton objects that simply return themselves


### PR DESCRIPTION
Fixes #187. Adds the `as` combinator to alias `#>`, and additionally adds the symmetric `from` combinator to alias `<#` on the generic bridges.