### PR TITLE
Explicit types

### DIFF
--- a/parsley/shared/src/main/scala/parsley/internal/machine/instructions/IntrinsicInstrs.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/instructions/IntrinsicInstrs.scala
@@ -368,7 +368,7 @@ private [internal] object StringTok {
     private [StringTok] class Set extends Adjust {
         private [this] var at = 1
         // Round up to the nearest multiple of 4 /+1/
-        private [StringTok] def tab = { at = ((at + 3) & -4) | 1; this } // scalastyle:ignore magic.number
+        private [StringTok] def tab: Set = { at = ((at + 3) & -4) | 1; this } // scalastyle:ignore magic.number
         private [StringTok] def next() = at += 1
         private [StringTok] def toAdjuster = {
             val x = at // capture it now, so it doesn't need to hold the object later
@@ -378,7 +378,7 @@ private [internal] object StringTok {
     // No information about alignment: a line or a tab hasn't been read
     private [StringTok] class Offset extends Adjust {
         private [this] var by = 0
-        private [StringTok] def tab = new OffsetAlignOffset(by)
+        private [StringTok] def tab: OffsetAlignOffset = new OffsetAlignOffset(by)
         private [StringTok] def next() = by += 1
         private [StringTok] def toAdjuster = {
             val x = by // capture it now, so it doesn't need to hold the object later
@@ -389,7 +389,7 @@ private [internal] object StringTok {
     private [StringTok] class OffsetAlignOffset(firstBy: Int) extends Adjust {
         private [this] var thenBy = 0
         // Round up to nearest multiple of /4/ (offset from aligned, not real value)
-        private [StringTok] def tab = { thenBy = (thenBy | 3) + 1; this }
+        private [StringTok] def tab: OffsetAlignOffset = { thenBy = (thenBy | 3) + 1; this }
         private [StringTok] def next() = thenBy += 1
         // Round up to the nearest multiple of 4 /+1/
         private [StringTok] def toAdjuster = {

--- a/parsley/shared/src/main/scala/parsley/token/errors/ConfigImplTyped.scala
+++ b/parsley/shared/src/main/scala/parsley/token/errors/ConfigImplTyped.scala
@@ -60,19 +60,19 @@ abstract class SpecialisedMessage[A] extends SpecialisedFilterConfig[A] { self =
     }
 
     // $COVERAGE-OFF$
-    private [parsley] final override def injectLeft[B] = new SpecialisedMessage[Either[A, B]] {
+    private [parsley] final override def injectLeft[B]: FilterConfig[Either[A,B]] = new SpecialisedMessage[Either[A, B]] {
         def message(xy: Either[A, B]) = {
             val Left(x) = xy: @unchecked
             self.message(x)
         }
     }
-    private [parsley] final override def injectRight[B] = new SpecialisedMessage[Either[B, A]] {
+    private [parsley] final override def injectRight[B]: FilterConfig[Either[B,A]] = new SpecialisedMessage[Either[B, A]] {
         def message(xy: Either[B, A]) = {
             val Right(y) = xy: @unchecked
             self.message(y)
         }
     }
-    private [parsley] final override def injectSnd[B] = new SpecialisedMessage[(B, A)] {
+    private [parsley] final override def injectSnd[B]: FilterConfig[(B, A)] = new SpecialisedMessage[(B, A)] {
         def message(xy: (B, A)) = self.message(xy._2)
     }
     // $COVERAGE-ON$
@@ -98,19 +98,19 @@ abstract class Unexpected[A] extends VanillaFilterConfig[A] { self =>
     }
 
     // $COVERAGE-OFF$
-    private [parsley] final override def injectLeft[B] = new Unexpected[Either[A, B]] {
+    private [parsley] final override def injectLeft[B]: FilterConfig[Either[A,B]] = new Unexpected[Either[A, B]] {
         def unexpected(xy: Either[A, B]) = {
             val Left(x) = xy: @unchecked
             self.unexpected(x)
         }
     }
-    private [parsley] final override def injectRight[B] = new Unexpected[Either[B, A]] {
+    private [parsley] final override def injectRight[B]: FilterConfig[Either[B,A]] = new Unexpected[Either[B, A]] {
         def unexpected(xy: Either[B, A]) = {
             val Right(y) = xy: @unchecked
             self.unexpected(y)
         }
     }
-    private [parsley] final override def injectSnd[B] = new Unexpected[(B, A)] {
+    private [parsley] final override def injectSnd[B]: FilterConfig[(B, A)] = new Unexpected[(B, A)] {
         def unexpected(xy: (B, A)) = self.unexpected(xy._2)
     }
     // $COVERAGE-ON$
@@ -136,19 +136,19 @@ abstract class Because[A] extends VanillaFilterConfig[A] { self =>
     }
 
     // $COVERAGE-OFF$
-    private [parsley] final override def injectLeft[B] = new Because[Either[A, B]] {
+    private [parsley] final override def injectLeft[B]: FilterConfig[Either[A,B]] = new Because[Either[A, B]] {
         def reason(xy: Either[A, B]) = {
             val Left(x) = xy: @unchecked
             self.reason(x)
         }
     }
-    private [parsley] final override def injectRight[B] = new Because[Either[B, A]] {
+    private [parsley] final override def injectRight[B]: FilterConfig[Either[B,A]] = new Because[Either[B, A]] {
         def reason(xy: Either[B, A]) = {
             val Right(y) = xy: @unchecked
             self.reason(y)
         }
     }
-    private [parsley] final override def injectSnd[B] = new Because[(B, A)] {
+    private [parsley] final override def injectSnd[B]: FilterConfig[(B, A)] = new Because[(B, A)] {
         def reason(xy: (B, A)) = self.reason(xy._2)
     }
     // $COVERAGE-ON$
@@ -179,7 +179,7 @@ abstract class UnexpectedBecause[A] extends VanillaFilterConfig[A] { self =>
     }
 
     // $COVERAGE-OFF$
-    private [parsley] final override def injectLeft[B] = new UnexpectedBecause[Either[A, B]] {
+    private [parsley] final override def injectLeft[B]: FilterConfig[Either[A,B]] = new UnexpectedBecause[Either[A, B]] {
         def unexpected(xy: Either[A, B]) = {
             val Left(x) = xy: @unchecked
             self.unexpected(x)
@@ -189,7 +189,7 @@ abstract class UnexpectedBecause[A] extends VanillaFilterConfig[A] { self =>
             self.reason(x)
         }
     }
-    private [parsley] final override def injectRight[B] = new UnexpectedBecause[Either[B, A]] {
+    private [parsley] final override def injectRight[B]: FilterConfig[Either[B,A]] = new UnexpectedBecause[Either[B, A]] {
         def unexpected(xy: Either[B, A]) = {
             val Right(y) = xy: @unchecked
             self.unexpected(y)
@@ -199,7 +199,7 @@ abstract class UnexpectedBecause[A] extends VanillaFilterConfig[A] { self =>
             self.reason(y)
         }
     }
-    private [parsley] final override def injectSnd[B] = new UnexpectedBecause[(B, A)] {
+    private [parsley] final override def injectSnd[B]: FilterConfig[(B, A)] = new UnexpectedBecause[(B, A)] {
         def unexpected(xy: (B, A)) = self.unexpected(xy._2)
         def reason(xy: (B, A)) = self.reason(xy._2)
     }
@@ -218,8 +218,8 @@ final class BasicFilter[A] extends SpecialisedFilterConfig[A] with VanillaFilter
     }
 
     // $COVERAGE-OFF$
-    private [parsley] final override def injectLeft[B] = new BasicFilter[Either[A, B]]
-    private [parsley] final override def injectRight[B] = new BasicFilter[Either[B, A]]
-    private [parsley] final override def injectSnd[B] = new BasicFilter[(B, A)]
+    private [parsley] final override def injectLeft[B]: FilterConfig[Either[A,B]] = new BasicFilter[Either[A, B]]
+    private [parsley] final override def injectRight[B]: FilterConfig[Either[B,A]] = new BasicFilter[Either[B, A]]
+    private [parsley] final override def injectSnd[B]: FilterConfig[(B, A)] = new BasicFilter[(B, A)]
     // $COVERAGE-ON$
 }

--- a/parsley/shared/src/main/scala/parsley/token/errors/ConfigImplUntyped.scala
+++ b/parsley/shared/src/main/scala/parsley/token/errors/ConfigImplUntyped.scala
@@ -57,13 +57,13 @@ private [errors] final class Label private[errors] (val labels: Seq[String]) ext
     private [parsley] final override def apply[A](p: Parsley[A]) = p.labels(labels: _*)
     private [parsley] final override def asExpectDescs: Iterable[ExpectDesc] = labels.map(new ExpectDesc(_))
     private [parsley] final override def asExpectDescs(@unused otherwise: String) = asExpectDescs
-    private [parsley] final override def asExpectItems(@unused raw: String) = asExpectDescs
+    private [parsley] final override def asExpectItems(@unused raw: String): Iterable[ExpectItem] = asExpectDescs
     private [parsley] final override def orElse(config: LabelWithExplainConfig) = config match {
         case r: Reason => new LabelAndReason(labels, r.reason)
         case lr: LabelAndReason => new LabelAndReason(labels, lr.reason)
         case _ => this
     }
-    private [parsley] final override def orElse(config: LabelConfig) = this
+    private [parsley] final override def orElse(config: LabelConfig): LabelConfig = this
 }
 /** This object has a factory for configurations producing labels: if the empty string is provided, this equivalent to [[Hidden `Hidden`]].
   * @since 4.1.0
@@ -80,19 +80,19 @@ object Label {
   */
 object Hidden extends LabelConfig {
     private [parsley] final override def apply[A](p: Parsley[A]) = p.hide
-    private [parsley] final override def asExpectDescs = None
+    private [parsley] final override def asExpectDescs: Iterable[ExpectDesc] = None
     private [parsley] final override def asExpectDescs(@unused otherwise: String) = asExpectDescs
-    private [parsley] final override def asExpectItems(@unused raw: String) = asExpectDescs
-    private [parsley] final override def orElse(config: LabelWithExplainConfig) = this
-    private [parsley] final override def orElse(config: LabelConfig) = this
+    private [parsley] final override def asExpectItems(@unused raw: String): Iterable[ExpectItem] = asExpectDescs
+    private [parsley] final override def orElse(config: LabelWithExplainConfig): LabelWithExplainConfig = this
+    private [parsley] final override def orElse(config: LabelConfig): LabelConfig = this
 }
 
 private [errors] final class Reason private[errors]  (val reason: String) extends ExplainConfig {
     require(reason.nonEmpty, "reasons cannot be empty strings")
     private [parsley] final override def apply[A](p: Parsley[A]) = p.explain(reason)
-    private [parsley] final override def asExpectDescs = None
+    private [parsley] final override def asExpectDescs: Iterable[ExpectDesc]  = None
     private [parsley] final override def asExpectDescs(otherwise: String) = Some(new ExpectDesc(otherwise))
-    private [parsley] final override def asExpectItems(raw: String) = Some(new ExpectRaw(raw))
+    private [parsley] final override def asExpectItems(raw: String): Iterable[ExpectItem] = Some(new ExpectRaw(raw))
     private [parsley] final override def orElse(config: LabelWithExplainConfig) = config match {
         case l: Label => new LabelAndReason(l.labels, reason)
         case lr: LabelAndReason => new LabelAndReason(lr.labels, reason)
@@ -111,10 +111,10 @@ private [errors] final class LabelAndReason private[errors] (val labels: Seq[Str
     require(reason.nonEmpty, "reason cannot be empty strings, use `Label` instead")
     require(labels.forall(_.nonEmpty), "labels cannot be empty strings")
     private [parsley] final override def apply[A](p: Parsley[A]) = p.labels(labels: _*).explain(reason)
-    private [parsley] final override def asExpectDescs = labels.map(new ExpectDesc(_))
+    private [parsley] final override def asExpectDescs: Iterable[ExpectDesc]  = labels.map(new ExpectDesc(_))
     private [parsley] final override def asExpectDescs(@unused otherwise: String) = asExpectDescs
-    private [parsley] final override def asExpectItems(@unused raw: String) = asExpectDescs
-    private [parsley] final override def orElse(config: LabelWithExplainConfig) = this
+    private [parsley] final override def asExpectItems(@unused raw: String): Iterable[ExpectItem]  = asExpectDescs
+    private [parsley] final override def orElse(config: LabelWithExplainConfig): LabelWithExplainConfig = this
 }
 /** This object has a factory for configurations producing labels and reasons: if the empty label is provided, this equivalent to [[Hidden `Hidden`]] with no
   * reason; if the empty reason is provided this is equivalent to [[Label$ `Label`]].
@@ -135,9 +135,9 @@ object LabelAndReason {
   */
 object NotConfigured extends LabelConfig with ExplainConfig with LabelWithExplainConfig {
     private [parsley] final override def apply[A](p: Parsley[A]) = p
-    private [parsley] final override def asExpectDescs = None
+    private [parsley] final override def asExpectDescs: Iterable[ExpectDesc]  = None
     private [parsley] final override def asExpectDescs(otherwise: String) = Some(new ExpectDesc(otherwise))
-    private [parsley] final override def asExpectItems(raw: String) = Some(new ExpectRaw(raw))
+    private [parsley] final override def asExpectItems(raw: String): Iterable[ExpectItem]  = Some(new ExpectRaw(raw))
     private [parsley] final override def orElse(config: LabelWithExplainConfig) = config
     private [parsley] final override def orElse(config: LabelConfig) = config
 }

--- a/parsley/shared/src/main/scala/parsley/token/numeric/UnsignedReal.scala
+++ b/parsley/shared/src/main/scala/parsley/token/numeric/UnsignedReal.scala
@@ -13,7 +13,7 @@ import parsley.implicits.character.charLift
 import parsley.lift.lift2
 import parsley.registers.Reg
 import parsley.token.descriptions.numeric.{BreakCharDesc, ExponentDesc, NumericDesc}
-import parsley.token.errors.{ErrorConfig, LabelConfig}
+import parsley.token.errors.{ErrorConfig, LabelConfig, LabelWithExplainConfig}
 
 private [token] final class UnsignedReal(desc: NumericDesc, natural: UnsignedInteger, err: ErrorConfig, generic: Generic) extends Real(err) {
     override lazy val _decimal: Parsley[BigDecimal] = attempt(ofRadix(10, digit, err.labelRealDecimalEnd))
@@ -106,7 +106,7 @@ private [token] final class UnsignedReal(desc: NumericDesc, natural: UnsignedInt
         val (requiredExponent, exponent, base) = expDesc match {
             case ExponentDesc.Supported(compulsory, exp, base, sign) =>
                 val expErr = new ErrorConfig {
-                    override def labelIntegerSignedDecimal(bits: Int) = err.labelRealExponentEnd.orElse(endLabel)
+                    override def labelIntegerSignedDecimal(bits: Int): LabelWithExplainConfig = err.labelRealExponentEnd.orElse(endLabel)
                     override def labelIntegerDecimalEnd = err.labelRealExponentEnd.orElse(endLabel)
                 }
                 val integer = new SignedInteger(desc.copy(positiveSign = sign), natural, expErr)


### PR DESCRIPTION
I was looking at how inferred types change under `-Xsource:3` and picked this sample project.

This PR is just documentation of the types, and it probably doesn't matter because everything is qualified private.

Indeed, I've never seen so much qualified private before.

Under `-Xsource:3`, you'd probably just silence the migration warning.