### PR TITLE
New Reference Expansion

### DIFF
--- a/parsley/jvm-native/src/main/scala/parsley/PlatformSpecific.scala
+++ b/parsley/jvm-native/src/main/scala/parsley/PlatformSpecific.scala
@@ -48,7 +48,7 @@ trait PlatformSpecific {
             } yield {
                 src.close()
                 val internal = p.internal
-                new Context(internal.instrs, input, internal.numRegs, Some(file.getName)).run()
+                new Context(internal.instrs, input, internal.numRefs, Some(file.getName)).run()
             }
         }
     }

--- a/parsley/shared/src/main/scala/parsley/Parsley.scala
+++ b/parsley/shared/src/main/scala/parsley/Parsley.scala
@@ -130,7 +130,7 @@ final class Parsley[+A] private [parsley] (private [parsley] val internal: front
       * @group run
       */
     def parse[Err: ErrorBuilder](input: String): Result[Err, A] = {
-        try new Context(internal.instrs, input, internal.numRegs, None).run()
+        try new Context(internal.instrs, input, internal.numRefs, None).run()
         catch {
             // $COVERAGE-OFF$
             case UserException(err) => throw err // scalastyle:ignore throw

--- a/parsley/shared/src/main/scala/parsley/exceptions/CorruptedReferenceException.scala
+++ b/parsley/shared/src/main/scala/parsley/exceptions/CorruptedReferenceException.scala
@@ -7,5 +7,5 @@ package parsley.exceptions
 
 // $COVERAGE-OFF$
 private [parsley] class CorruptedReferenceException
-    extends ParsleyException("A reference has been used across two different parsers in separate calls to parse, causing it to be misallocated")
+    extends ParsleyException("A reference has been used across two different parsers in separate calls to parse, causing it to clash with another reference")
 // $COVERAGE-ON$

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/SequenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/SequenceEmbedding.scala
@@ -95,7 +95,6 @@ private [deepembedding] final class >>=[A, B](val p: StrictParsley[A], private [
         suspend(p.codeGen[M, R](producesResults = true)) |> {
             instrs += instructions.DynCall[A] { (x, refsSz) =>
                 val q = f(x)
-                q.demandCalleeSave(state.numRegs)
                 q.setMinReferenceAllocation(refsSz)
                 if (implicitly[ContOps[M]].isStackSafe) q.overflows()
                 q.instrs

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/SequenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/SequenceEmbedding.scala
@@ -93,9 +93,10 @@ private [deepembedding] final class >>=[A, B](val p: StrictParsley[A], private [
     }
     override def codeGen[M[_, +_]: ContOps, R](producesResults: Boolean)(implicit instrs: InstrBuffer, state: CodeGenState): M[R, Unit] = {
         suspend(p.codeGen[M, R](producesResults = true)) |> {
-            instrs += instructions.DynCall[A] { x =>
+            instrs += instructions.DynCall[A] { (x, refsSz) =>
                 val q = f(x)
                 q.demandCalleeSave(state.numRegs)
+                q.setMinReferenceAllocation(refsSz)
                 if (implicitly[ContOps[M]].isStackSafe) q.overflows()
                 q.instrs
             }

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/StrictParsley.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/StrictParsley.scala
@@ -37,8 +37,8 @@ private [deepembedding] trait StrictParsley[+A] {
       *   1. any sharable, fail-only, handler instructions are then generated at the end of the instruction stream
       *   1. jump-labels in the code are removed, and tail-call optimisation is applied
       *
-      * @param numRegsUsedByParent the number of registers in use by the parent (should one exist), required by callee-save
-      * @param usedRefs the registers used by this parser (these may require allocation)
+      * @param minRef the number of references determined to currently exist according to the context (or -1 if this is root)
+      * @param usedRefs the references used by this parser (these may require allocation)
       * @param recs a stream of pairs of rec nodes and the generators for their strict parsers
       *             (this is just because more `Cont` operations are performed later)
       * @param state the code generator state
@@ -48,7 +48,8 @@ private [deepembedding] trait StrictParsley[+A] {
                                                                             (implicit state: CodeGenState): Array[Instr] = {
         implicit val instrs: InstrBuffer = newInstrBuffer
         perform {
-            generateCalleeSave[M, Array[Instr]](minRef, this.codeGen(producesResults = true), usedRefs) |> {
+            allocateAndExpandRefs(minRef, usedRefs)
+            this.codeGen[M, Array[Instr]](producesResults = true) |> {
                 // When `minRef` is -1 this is top level, otherwise it is a flatMap
                 instrs += (if (minRef >= 0) instructions.Return else instructions.Halt)
                 val letRets = finaliseLets(bodyMap)
@@ -97,24 +98,16 @@ private [deepembedding] object StrictParsley {
     /** Make a fresh instruction buffer */
     private def newInstrBuffer: InstrBuffer = new ResizableArray()
 
-    /** If required, generates callee-save around a main body of instructions.
+    /** Allocates references, and, if required, generates an instruction to expand array size.
       *
       * This is needed when using `flatMap`, as it is unaware of the register
-      * context of its parent, other than the number used. The expectation is
-      * that such a parser will save all the registers used by its parents that
-      * it itself does not explicitly use and restore them when it is completed
-      * (if the parent has not allocated a register it may be assumed that
-      * it is local to the `flatMap`: this is a documented limitation of the
-      * system).
+      * context of its parents.
       *
-      * @param numRegsUsedByParent the size of the current register array as dictated by the parent
-      * @param bodyGen a computation that generates instructions into the instruction buffer
-      * @param reqRegs the number of registered used by the parser in question
-      * @param allocatedRegs the slots used by the registered allocated local to the parser
+      * @param minRef the number of references in existance, according to the context
+      * @param usedRefs the referenced used in this parser that may need allocation
       * @param instrs the instruction buffer
-      * @param state the code generation state, for label generation
       */
-    private def generateCalleeSave[M[_, +_], R](minRef: Int, bodyGen: =>M[R, Unit], usedRefs: Set[Ref[_]])(implicit instrs: InstrBuffer): M[R, Unit] = {
+    private def allocateAndExpandRefs(minRef: Int, usedRefs: Set[Ref[_]])(implicit instrs: InstrBuffer): Unit = {
         var nextSlot = math.max(minRef, 0)
         for (r <- usedRefs if !r.allocated) {
             r.allocate(nextSlot)
@@ -129,7 +122,6 @@ private [deepembedding] object StrictParsley {
         if (minRef >= 0 && (minRef < totalSlotsRequired)) {
             instrs += new instructions.ExpandRefs(totalSlotsRequired)
         }
-        bodyGen
     }
 
     /** Generates each of the shared, non-recursive, parsers that have been ''used'' by
@@ -243,9 +235,9 @@ private [deepembedding] trait MZero extends StrictParsley[Nothing]
 /** This is the escapulated state required for code generation,
   * which is threaded through the entire backend.
   *
-  * @param numRegs the number of registers required by the parser being generated
+  * @param numRefs the number of references required by the parser being generated
   */
-private [deepembedding] class CodeGenState(val numRegs: Int) {
+private [deepembedding] class CodeGenState(val numRefs: Int) {
     /** The next jump-label identifier. */
     private var current = 0
     /** The shared-parsers that have been referenced at some point in the generation so far. */

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/LazyParsley.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/LazyParsley.scala
@@ -37,7 +37,7 @@ private [parsley] abstract class LazyParsley[+A] private [deepembedding] {
     // $COVERAGE-ON$
 
     // The instructions used to execute this parser along with the number of registers it uses
-    final private [parsley] lazy val (instrs: Array[Instr], numRegs: Int) = computeInstrs
+    final private [parsley] lazy val (instrs: Array[Instr], numRefs: Int) = computeInstrs
 
     /** This parser is the result of a `flatMap` operation, and as such may need to expand
       * the refs set. If so, it needs to know what the minimum free slot is according to
@@ -115,11 +115,11 @@ private [parsley] abstract class LazyParsley[+A] private [deepembedding] {
                 val usedRefs: Set[Ref[_]] = letFinderState.usedRefs
                 implicit val letMap: LetMap = LetMap(letFinderState.lets, letFinderState.recs)
                 for { sp <- this.optimised } yield {
-                    implicit val state: backend.CodeGenState = new backend.CodeGenState(letFinderState.numRegs)
+                    implicit val state: backend.CodeGenState = new backend.CodeGenState(letFinderState.numRefs)
                     sp.generateInstructions(minRef, usedRefs, letMap.bodies)
                 }
             }
-        }, letFinderState.numRegs)
+        }, letFinderState.numRefs)
     }
 
     // Pass 1
@@ -243,7 +243,7 @@ private [deepembedding] class LetFinderState {
     /** Returns all the registers used by the parser */
     private [frontend] def usedRefs: Set[Ref[_]] = _usedRefs.toSet
     /** Returns the number of registers used by the parser */
-    private [frontend] def numRegs: Int = _usedRefs.size
+    private [frontend] def numRefs: Int = _usedRefs.size
 }
 
 /** Represents a map of let-bound lazy parsers to their strict equivalents. */

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/LazyParsley.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/LazyParsley.scala
@@ -39,13 +39,6 @@ private [parsley] abstract class LazyParsley[+A] private [deepembedding] {
     // The instructions used to execute this parser along with the number of registers it uses
     final private [parsley] lazy val (instrs: Array[Instr], numRegs: Int) = computeInstrs
 
-    /** This parser is the result of a `flatMap` operation, and as such must perform
-      * callee-save on `numRegs` registers (which belong to its parent)
-      *
-      * @param numRegs the number of registers the parent uses (these must be saved)
-      */
-    private [deepembedding] def demandCalleeSave(numRegs: Int): Unit = numRegsUsedByParent = numRegs
-
     /** This parser is the result of a `flatMap` operation, and as such may need to expand
       * the refs set. If so, it needs to know what the minimum free slot is according to
       * the context.
@@ -90,7 +83,6 @@ private [parsley] abstract class LazyParsley[+A] private [deepembedding] {
     final private var cps = false
     final private [deepembedding] def isCps: Boolean = cps
     /** how many registers are used by the ''parent'' of this combinator (this combinator is part of a `flatMap` when this is not -1) */
-    /*@deprecated("this is no longer needed", "5.0.0-M10")*/ final private var numRegsUsedByParent = -1
     final private var minRef = -1
 
     /** Computes the instructions associated with this parser as well as the number of
@@ -124,7 +116,7 @@ private [parsley] abstract class LazyParsley[+A] private [deepembedding] {
                 implicit val letMap: LetMap = LetMap(letFinderState.lets, letFinderState.recs)
                 for { sp <- this.optimised } yield {
                     implicit val state: backend.CodeGenState = new backend.CodeGenState(letFinderState.numRegs)
-                    sp.generateInstructions(numRegsUsedByParent, minRef, usedRefs, letMap.bodies)
+                    sp.generateInstructions(minRef, usedRefs, letMap.bodies)
                 }
             }
         }, letFinderState.numRegs)

--- a/parsley/shared/src/main/scala/parsley/internal/diagnostics.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/diagnostics.scala
@@ -5,7 +5,7 @@
  */
 package parsley.internal.diagnostics
 
-import parsley.exceptions.{BadLazinessException, CorruptedReferenceException, ParsleyException}
+import parsley.exceptions.{BadLazinessException, ParsleyException}
 
 private [parsley] object UserException {
     def unapply(e: Throwable): Option[Throwable] = e match {
@@ -22,22 +22,6 @@ private [parsley] object UserException {
     def pruneParsley(e: Array[StackTraceElement]): Array[StackTraceElement] = {
         val (userBits, parsleyTrace) = e.span(!_.getClassName.startsWith("parsley.internal"))
         userBits ++ parsleyTrace.dropWhile(_.getClassName.startsWith("parsley.internal"))
-    }
-}
-
-private [parsley] object RegisterOutOfBoundsException {
-    def unapply(e: Throwable): Option[Throwable] = e match {
-        case e: ArrayIndexOutOfBoundsException => e.getStackTrace.headOption.collect {
-            // this exception was thrown plainly during the execution of an instruction
-            // only register arrays are accessed raw like this: therefore it must be an
-            // out of bounds register.
-            case ste if ste.getMethodName == "apply"
-                     && ste.getClassName.startsWith("parsley.internal.machine.instructions") =>
-                val err = new CorruptedReferenceException
-                err.addSuppressed(e)
-                err
-        }
-        case _ => None
     }
 }
 

--- a/parsley/shared/src/main/scala/parsley/internal/machine/Context.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/Context.scala
@@ -14,7 +14,6 @@ import parsley.Success
 import parsley.XAssert._
 import parsley.errors.ErrorBuilder
 
-import parsley.internal.diagnostics.RegisterOutOfBoundsException
 import parsley.internal.errors.{CaretWidth, ExpectItem, LineBuilder, UnexpectDesc}
 import parsley.internal.machine.errors.{ClassicFancyError, DefuncError, DefuncHints, EmptyHints,
                                         ErrorItemBuilder, ExpectedError, ExpectedErrorWithReason, UnexpectedError}
@@ -125,15 +124,7 @@ private [parsley] final class Context(private [machine] var instrs: Array[Instr]
     }
     // $COVERAGE-ON$
 
-    private [parsley] def run[Err: ErrorBuilder, A](): Result[Err, A] = {
-        try go[Err, A]()
-        catch {
-            // additional diagnostic checks
-            // $COVERAGE-OFF$
-            case RegisterOutOfBoundsException(err) => throw err // scalastyle:ignore throw
-            // $COVERAGE-ON$
-        }
-    }
+    private [parsley] def run[Err: ErrorBuilder, A](): Result[Err, A] = go[Err, A]()
     @tailrec private def go[Err: ErrorBuilder, A](): Result[Err, A] = {
         //println(pretty)
         if (running) { // this is the likeliest branch, so should be executed with fewest comparisons

--- a/parsley/shared/src/main/scala/parsley/internal/machine/instructions/CoreInstrs.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/instructions/CoreInstrs.scala
@@ -72,17 +72,17 @@ private [internal] object Apply extends Instr {
 }
 
 // Monadic
-private [internal] final class DynCall(f: Any => Array[Instr]) extends Instr {
+private [internal] final class DynCall(f: (Any, Int) => Array[Instr]) extends Instr {
     override def apply(ctx: Context): Unit = {
         ensureRegularInstruction(ctx)
-        ctx.call(f(ctx.stack.upop()))
+        ctx.call(f(ctx.stack.upop(), ctx.regs.size))
     }
     // $COVERAGE-OFF$
     override def toString: String = "DynCall(?)"
     // $COVERAGE-ON$
 }
 private [internal] object DynCall {
-    def apply[A](f: A => Array[Instr]): DynCall = new DynCall(f.asInstanceOf[Any => Array[Instr]])
+    def apply[A](f: (A, Int) => Array[Instr]): DynCall = new DynCall(f.asInstanceOf[(Any, Int) => Array[Instr]])
 }
 
 // Control Flow

--- a/parsley/shared/src/main/scala/parsley/internal/machine/instructions/PrimitiveInstrs.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/instructions/PrimitiveInstrs.scala
@@ -5,7 +5,7 @@
  */
 package parsley.internal.machine.instructions
 
-import parsley.state.Ref
+//import parsley.state.Ref
 import parsley.token.errors.LabelConfig
 
 import parsley.internal.errors.ExpectDesc
@@ -161,7 +161,7 @@ private [internal] object Span extends Instr {
 // same mapping for a let-bound parser)
 // TODO: unit test to demonstrate the above issue!
 // This instruction holds mutable state, but it is safe to do so, because it's always the first instruction of a DynCall.
-private [parsley] final class CalleeSave(var label: Int, localRefs: Set[Ref[_]], reqSize: Int, slots: List[(Int, Int)], saveArray: Array[AnyRef])
+/*private [parsley] final class CalleeSave(var label: Int, localRefs: Set[Ref[_]], reqSize: Int, slots: List[(Int, Int)], saveArray: Array[AnyRef])
     extends InstrWithLabel {
     private def this(label: Int, localRefs: Set[Ref[_]], reqSize: Int, slots: List[Int]) =
         this(label, localRefs, reqSize, slots.zipWithIndex, new Array[AnyRef](slots.length))
@@ -222,4 +222,13 @@ private [parsley] final class CalleeSave(var label: Int, localRefs: Set[Ref[_]],
     // $COVERAGE-OFF$
     override def toString: String = s"CalleeSave($label, newSz = $reqSize, slotsToSave = $slots)"
     // $COVERAGE-ON$
+}*/
+
+private [parsley] final class ExpandRefs(newSz: Int) extends Instr {
+    override def apply(ctx: Context): Unit = {
+        if (newSz > ctx.regs.size) {
+            ctx.regs = java.util.Arrays.copyOf(ctx.regs, newSz)
+        }
+        ctx.inc()
+    }
 }

--- a/parsley/shared/src/main/scala/parsley/state.scala
+++ b/parsley/shared/src/main/scala/parsley/state.scala
@@ -285,10 +285,6 @@ object state {
             assert(!allocated)
             this._v = v
         }
-        private [parsley] def deallocate(): Unit = {
-            assert((new Throwable).getStackTrace.exists(_.getClassName == "parsley.internal.machine.instructions.CalleeSave"))
-            _v = -1
-        }
         //override def toString: String = s"Reg(${if (allocated) addr else "unallocated"})"
     }
 

--- a/parsley/shared/src/main/scala/parsley/state.scala
+++ b/parsley/shared/src/main/scala/parsley/state.scala
@@ -295,13 +295,12 @@ object state {
         /** This function creates a new (global) reference of a given type.
           *
           * The reference created by this function is not allocated to any specific parser until it has been
-          * used by a parser. It should not be used with multiple different parsers.
+          * used by a parser. It should not be used with multiple different parsers: while this ''may'' work,
+          * there is a chance that two such references collide in allocation, which is undefined behaviour.
           *
           * @tparam A the type to be contained in this reference during runtime
           * @return a new reference which can contain the given type.
-          * @note references created in this manner ''must'' be initialised in the top-level parser and not
-          *       inside a `flatMap`, as this may make them corrupt other references. They should be used with
-          *       caution. It is recommended to use `makeRef` and `fillRef` where possible.
+          * @note They should be used with caution. It is recommended to use `makeRef` and `fillRef` where possible.
           * @since 2.2.0
           */
         def make[A]: Ref[A] = new Ref

--- a/parsley/shared/src/test/scala/parsley/CoreTests.scala
+++ b/parsley/shared/src/test/scala/parsley/CoreTests.scala
@@ -230,7 +230,7 @@ class CoreTests extends ParsleyTest {
         val p = "hello :)".makeRef(r2 => q *> q *> r2.get)
         p.parse("aa") shouldBe Success("hello :)")
     }
-    they should "be preserved by callee-save in flatMap" ignore {
+    they should "be preserved by callee-save in flatMap" in {
         val p = "hello world".makeRef(r2 => {
             6.makeRef(r1 => {
                 unit.flatMap(_ => 4.makeRef(_ => r2.set("hi"))) *>
@@ -239,7 +239,7 @@ class CoreTests extends ParsleyTest {
         })
         p.parse("") shouldBe Success((6, "hi"))
     }
-    they should "be preserved by callee-save in flatMap even when it fails" ignore {
+    they should "be preserved by callee-save in flatMap even when it fails" in {
         val p = "hello world".makeRef(r2 => {
             6.makeRef(r1 => {
                 combinator.optional(unit.flatMap(_ => r2.set("hi") *> 4.makeRef(_ => Parsley.empty))) *>
@@ -392,7 +392,7 @@ class CoreTests extends ParsleyTest {
         q.parse("aaaabbb") shouldBe a [Success[_]]
     }
 
-    "flatMap" should "consistently generate a callee-save instruction if needed" ignore {
+    "flatMap" should "consistently generate a callee-save instruction if needed" in {
         import parsley.state._
         val r = Ref.make[Int]
         val p = unit.flatMap { _ =>

--- a/parsley/shared/src/test/scala/parsley/CoreTests.scala
+++ b/parsley/shared/src/test/scala/parsley/CoreTests.scala
@@ -230,7 +230,7 @@ class CoreTests extends ParsleyTest {
         val p = "hello :)".makeRef(r2 => q *> q *> r2.get)
         p.parse("aa") shouldBe Success("hello :)")
     }
-    they should "be preserved by callee-save in flatMap" in {
+    they should "be preserved by callee-save in flatMap" ignore {
         val p = "hello world".makeRef(r2 => {
             6.makeRef(r1 => {
                 unit.flatMap(_ => 4.makeRef(_ => r2.set("hi"))) *>
@@ -239,7 +239,7 @@ class CoreTests extends ParsleyTest {
         })
         p.parse("") shouldBe Success((6, "hi"))
     }
-    they should "be preserved by callee-save in flatMap even when it fails" in {
+    they should "be preserved by callee-save in flatMap even when it fails" ignore {
         val p = "hello world".makeRef(r2 => {
             6.makeRef(r1 => {
                 combinator.optional(unit.flatMap(_ => r2.set("hi") *> 4.makeRef(_ => Parsley.empty))) *>

--- a/parsley/shared/src/test/scala/parsley/CoreTests.scala
+++ b/parsley/shared/src/test/scala/parsley/CoreTests.scala
@@ -400,19 +400,6 @@ class CoreTests extends ParsleyTest {
         }
         (unit.flatMap(_ => r.set(0)) *> p *> p).parse("") shouldBe Success(2)
     }
-    /*it should "correct nest callee-saving" in {
-        import parsley.state._
-        // outer sets up a saved reference within middle, that doesn't use it
-        // it uses its own. Inner sibling is under a flatMap, so not visible for
-        // middle, uses the global. After its done and changed global state,
-        // the second call to middle needs to calleeSave that, which is not
-        // what would happen...
-        lazy val inner = ???
-        lazy val middle = ???
-        lazy val outer = 0.makeReg { r =>
-
-        }
-    }*/
 
     "span" should "return all the input parsed by a parser, exactly as it was" in {
         import parsley.character.whitespaces


### PR DESCRIPTION
`CalleeSave` is a problematic instruction that has possible race-conditions, as well as being badly behaved for recursively bound `flatMap`s. This system was designed to allow for references to reuse slots in the array when necessary. However, it is much safer to think of all the references in the universe being independent; the problem, of course, is that not all of these references are visible at the top-level, so there is likely not enough space to accommodate them.

This PR reworks things so that the `Context` feeds back information to a soon-to-be-generated `flatMap` body about the currently largest residency found for references. The `flatMap` will always allocate its references above this, and emit a new instruction that *just* resizes the refs array. 

It is possible that global references find themselves occupying the same slot as another if it was used across two parsers, and this is more explicitly checked now up-front in the allocator. Whereas before only if a reference was out of range would it crash, now it will crash immediately as soon as a clash for the references of a parser appear: this avoids the undefined behaviour where two references would write over each other.

In all, a better system. Fixes #241 