### PR TITLE
fix: Spelling error in api guide docs

### DIFF
--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,23 @@
+# This is workflow for spell checking using PySpelling lib (https://pypi.org/project/pyspelling/)
+name: Spellcheck
+# Controls when the action will run.
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Spellcheck
+      - uses: actions/checkout@v2
+      - uses: igsekor/pyspelling-any@v0.0.2
+        name: Spellcheck

--- a/docs/api-guide/errors/ErrorBuilder.md
+++ b/docs/api-guide/errors/ErrorBuilder.md
@@ -132,7 +132,7 @@ user to pick how each component should be represented without
 exposing unnecessary information into the rest of the system.
 
 After these types are specified, the methods of the typeclass
-can be implemented. These put together the primtive-most components
+can be implemented. These put together the primitive-most components
 and compose them into the larger whole. The documentation of the
 typeclass details the role of these well enough, however. For example's sake, however, these
 are the two shapes of call that will be made for the different types of error messages:


### PR DESCRIPTION
There was a spelling mistake in the api guide docs for errors - 'primtive' instead of 'primitive'. This can lead to confusion for users reading the docs.