### PR TITLE
Handle Looping Combinators with Tagging

### DIFF
--- a/parsley-debug/shared/src/main/scala/parsley/debug/DebugTree.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/debug/DebugTree.scala
@@ -47,6 +47,9 @@ private [debug] abstract class DebugTree extends Iterable[DebugTree] {
       */
     def nodeChildren: List[DebugTree]
 
+    /** Does this node need to bubble up its success state to its parent? */
+    def doesNeedBubbling: Boolean
+
 // $COVERAGE-OFF$
     /** Provides a depth-first view of the tree as an iterator. */
     override def iterator: Iterator[DebugTree] = Iterator(this) ++ nodeChildren.iterator.flatMap(_.iterator)

--- a/parsley-debug/shared/src/main/scala/parsley/debug/DebugTree.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/debug/DebugTree.scala
@@ -47,8 +47,8 @@ private [debug] abstract class DebugTree extends Iterable[DebugTree] {
       */
     def nodeChildren: List[DebugTree]
 
-    /** Does this node need to bubble up its success state to its parent? */
-    def doesNeedBubbling: Boolean
+    /** Is this parser iterative? */
+    def isIterative: Boolean
 
 // $COVERAGE-OFF$
     /** Provides a depth-first view of the tree as an iterator. */

--- a/parsley-debug/shared/src/main/scala/parsley/debug/internal/DebugContext.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/debug/internal/DebugContext.scala
@@ -115,6 +115,7 @@ private [parsley] class DebugContext(private val toStringRules: PartialFunction[
         newTree.name = Renamer.nameOf(userAssignedName, parser)
         newTree.internal = Renamer.internalName(parser)
         newTree.needsBubbling = needsBubbling
+        newTree.iterative = parser.isIterative
 
         // Send the debug tree here if ExitBreak
         parser match {

--- a/parsley-debug/shared/src/main/scala/parsley/debug/internal/DebugContext.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/debug/internal/DebugContext.scala
@@ -76,10 +76,11 @@ private [parsley] class DebugContext(private val toStringRules: PartialFunction[
     }*/
 
     // Push a new parser onto the parser callstack.
-    def push(fullInput: String, parser: LazyParsley[_], userAssignedName: Option[String]): Unit = {
+    def push(fullInput: String, parser: LazyParsley[_], needsBubbling: Boolean, userAssignedName: Option[String]): Unit = {
         val newTree = new TransientDebugTree(fullInput = fullInput)
         newTree.name = Renamer.nameOf(userAssignedName, parser)
         newTree.internal = Renamer.internalName(parser)
+        newTree.needsBubbling = needsBubbling
 
         //val uid = nextUid()
         //builderStack.head.children(s"${newTree.name}-#$uid") = newTree

--- a/parsley-debug/shared/src/main/scala/parsley/debug/internal/DebugContext.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/debug/internal/DebugContext.scala
@@ -101,7 +101,7 @@ private [parsley] class DebugContext(private val toStringRules: PartialFunction[
     }
 
     // Push a new parser onto the parser callstack.
-    def push(fullInput: String, parser: LazyParsley[_], needsBubbling: Boolean, userAssignedName: Option[String]): Unit = {
+    def push(fullInput: String, parser: LazyParsley[_], isIterative: Boolean, userAssignedName: Option[String]): Unit = {
         // Send the debug tree here if EntryBreak
         parser match {
             case break: RemoteBreak[_] => break.break match {
@@ -114,8 +114,7 @@ private [parsley] class DebugContext(private val toStringRules: PartialFunction[
         val newTree = new TransientDebugTree(fullInput = fullInput)
         newTree.name = Renamer.nameOf(userAssignedName, parser)
         newTree.internal = Renamer.internalName(parser)
-        newTree.needsBubbling = needsBubbling
-        newTree.iterative = parser.isIterative
+        newTree.iterative = isIterative
 
         // Send the debug tree here if ExitBreak
         parser match {

--- a/parsley-debug/shared/src/main/scala/parsley/debug/internal/DivergenceContext.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/debug/internal/DivergenceContext.scala
@@ -17,7 +17,7 @@ import parsley.internal.deepembedding.frontend.LazyParsley
 private [parsley] final class DivergenceContext {
     case class CtxSnap(pc: Int, instrs: Array[_], off: Int, regs: List[AnyRef])
     case class HandlerSnap(pc: Int, instrs: Array[_])
-    private case class Snapshot(name: String, internalName: String, needsBubbling: Boolean, ctxSnap: CtxSnap, handlerSnap: Option[HandlerSnap], children: mutable.ListBuffer[Snapshot]) {
+    private case class Snapshot(name: String, internalName: String, isIterative: Boolean, ctxSnap: CtxSnap, handlerSnap: Option[HandlerSnap], children: mutable.ListBuffer[Snapshot]) {
         // this is true when the ctxSnaps match
         def matchesParent(that: Snapshot): Boolean = this.ctxSnap == that.ctxSnap
 
@@ -32,12 +32,12 @@ private [parsley] final class DivergenceContext {
     // For a recursive structure, I think the pruning actually would work, and can be done
     private val snaps = mutable.Stack.empty[Snapshot]
 
-    def takeSnapshot(parser: LazyParsley[_], needsBubbling: Boolean, userAssignedName: Option[String], ctxSnap: CtxSnap, handlerSnap: Option[HandlerSnap]): Unit = {
+    def takeSnapshot(parser: LazyParsley[_], isIterative: Boolean, userAssignedName: Option[String], ctxSnap: CtxSnap, handlerSnap: Option[HandlerSnap]): Unit = {
         val name = Renamer.nameOf(userAssignedName, parser)
         val internalName = Renamer.internalName(parser)
         // at this point we may have some old snapshots on the stack
         // we also have a current snapshot and optional handler snapshot ready to go
-        val self = Snapshot(name, internalName, needsBubbling, ctxSnap, handlerSnap, mutable.ListBuffer.empty)
+        val self = Snapshot(name, internalName, isIterative, ctxSnap, handlerSnap, mutable.ListBuffer.empty)
 
         // first step is to check for divergence
         // we must have a parent snapshot for it to possible that we have diverged

--- a/parsley-debug/shared/src/main/scala/parsley/debug/internal/DivergenceContext.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/debug/internal/DivergenceContext.scala
@@ -17,7 +17,7 @@ import parsley.internal.deepembedding.frontend.LazyParsley
 private [parsley] final class DivergenceContext {
     case class CtxSnap(pc: Int, instrs: Array[_], off: Int, regs: List[AnyRef])
     case class HandlerSnap(pc: Int, instrs: Array[_])
-    private case class Snapshot(name: String, internalName: String, isIterative: Boolean, ctxSnap: CtxSnap, handlerSnap: Option[HandlerSnap], children: mutable.ListBuffer[Snapshot]) {
+    private case class Snapshot(name: String, internalName: String, ctxSnap: CtxSnap, handlerSnap: Option[HandlerSnap], children: mutable.ListBuffer[Snapshot]) {
         // this is true when the ctxSnaps match
         def matchesParent(that: Snapshot): Boolean = this.ctxSnap == that.ctxSnap
 
@@ -32,12 +32,12 @@ private [parsley] final class DivergenceContext {
     // For a recursive structure, I think the pruning actually would work, and can be done
     private val snaps = mutable.Stack.empty[Snapshot]
 
-    def takeSnapshot(parser: LazyParsley[_], isIterative: Boolean, userAssignedName: Option[String], ctxSnap: CtxSnap, handlerSnap: Option[HandlerSnap]): Unit = {
+    def takeSnapshot(parser: LazyParsley[_], userAssignedName: Option[String], ctxSnap: CtxSnap, handlerSnap: Option[HandlerSnap]): Unit = {
         val name = Renamer.nameOf(userAssignedName, parser)
         val internalName = Renamer.internalName(parser)
         // at this point we may have some old snapshots on the stack
         // we also have a current snapshot and optional handler snapshot ready to go
-        val self = Snapshot(name, internalName, isIterative, ctxSnap, handlerSnap, mutable.ListBuffer.empty)
+        val self = Snapshot(name, internalName, ctxSnap, handlerSnap, mutable.ListBuffer.empty)
 
         // first step is to check for divergence
         // we must have a parent snapshot for it to possible that we have diverged

--- a/parsley-debug/shared/src/main/scala/parsley/debug/internal/DivergenceContext.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/debug/internal/DivergenceContext.scala
@@ -17,7 +17,7 @@ import parsley.internal.deepembedding.frontend.LazyParsley
 private [parsley] final class DivergenceContext {
     case class CtxSnap(pc: Int, instrs: Array[_], off: Int, regs: List[AnyRef])
     case class HandlerSnap(pc: Int, instrs: Array[_])
-    private case class Snapshot(name: String, internalName: String, ctxSnap: CtxSnap, handlerSnap: Option[HandlerSnap], children: mutable.ListBuffer[Snapshot]) {
+    private case class Snapshot(name: String, internalName: String, needsBubbling: Boolean, ctxSnap: CtxSnap, handlerSnap: Option[HandlerSnap], children: mutable.ListBuffer[Snapshot]) {
         // this is true when the ctxSnaps match
         def matchesParent(that: Snapshot): Boolean = this.ctxSnap == that.ctxSnap
 
@@ -32,12 +32,12 @@ private [parsley] final class DivergenceContext {
     // For a recursive structure, I think the pruning actually would work, and can be done
     private val snaps = mutable.Stack.empty[Snapshot]
 
-    def takeSnapshot(parser: LazyParsley[_], userAssignedName: Option[String], ctxSnap: CtxSnap, handlerSnap: Option[HandlerSnap]): Unit = {
+    def takeSnapshot(parser: LazyParsley[_], needsBubbling: Boolean, userAssignedName: Option[String], ctxSnap: CtxSnap, handlerSnap: Option[HandlerSnap]): Unit = {
         val name = Renamer.nameOf(userAssignedName, parser)
         val internalName = Renamer.internalName(parser)
         // at this point we may have some old snapshots on the stack
         // we also have a current snapshot and optional handler snapshot ready to go
-        val self = Snapshot(name, internalName, ctxSnap, handlerSnap, mutable.ListBuffer.empty)
+        val self = Snapshot(name, internalName, needsBubbling, ctxSnap, handlerSnap, mutable.ListBuffer.empty)
 
         // first step is to check for divergence
         // we must have a parent snapshot for it to possible that we have diverged

--- a/parsley-debug/shared/src/main/scala/parsley/debug/internal/TransientDebugTree.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/debug/internal/TransientDebugTree.scala
@@ -21,7 +21,8 @@ import parsley.debug.{DebugTree, ParseAttempt}
   */
 private [parsley] class TransientDebugTree(var name: String = "", var internal: String = "", val fullInput: String,
                                            var parse: Option[ParseAttempt] = None, var cNumber: Option[Long] = None,
-                                           val children: mutable.ListBuffer[TransientDebugTree] = mutable.ListBuffer.empty) extends DebugTree {
+                                           val children: mutable.ListBuffer[TransientDebugTree] = mutable.ListBuffer.empty,
+                                           var needsBubbling: Boolean = false) extends DebugTree {
     // These are user-facing, and will depend heavily on what the parser looks like.
     // $COVERAGE-OFF$
     override def parserName: String = name
@@ -34,6 +35,8 @@ private [parsley] class TransientDebugTree(var name: String = "", var internal: 
     override def parseResults: Option[ParseAttempt] = parse
 
     override def nodeChildren: List[DebugTree] = children.toList
+
+    override def doesNeedBubbling: Boolean = needsBubbling
 
     // Factors out inputs or results for parsers with children.
     private type Augment  = (Long, (Int, Int))

--- a/parsley-debug/shared/src/main/scala/parsley/debug/internal/TransientDebugTree.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/debug/internal/TransientDebugTree.scala
@@ -22,7 +22,7 @@ import parsley.debug.{DebugTree, ParseAttempt}
 private [parsley] class TransientDebugTree(var name: String = "", var internal: String = "", val fullInput: String,
                                            var parse: Option[ParseAttempt] = None, var cNumber: Option[Long] = None,
                                            val children: mutable.ListBuffer[TransientDebugTree] = mutable.ListBuffer.empty,
-                                           var needsBubbling: Boolean = false, var iterative: Boolean = false) extends DebugTree {
+                                           var iterative: Boolean = false) extends DebugTree {
     // These are user-facing, and will depend heavily on what the parser looks like.
     // $COVERAGE-OFF$
     override def parserName: String = name
@@ -37,13 +37,11 @@ private [parsley] class TransientDebugTree(var name: String = "", var internal: 
     override def nodeChildren: List[DebugTree] = children.toList
 
     /**
-      * 
-      *
-      * @return If the parser needs bubbling then we do not see it because it is transparent. 
+      * If the parser needs bubbling then we do not see it because it is transparent. 
       * If it does not need bubbling then it is either an iterative, opaque parser or a non-iterative, opaque parser.
       * To cover both cases, we also chekc if it is iterative.
       */
-    override def isIterative: Boolean = !needsBubbling && iterative
+    override def isIterative: Boolean = iterative
 
     // Factors out inputs or results for parsers with children.
     private type Augment  = (Long, (Int, Int))

--- a/parsley-debug/shared/src/main/scala/parsley/debug/internal/TransientDebugTree.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/debug/internal/TransientDebugTree.scala
@@ -36,11 +36,12 @@ private [parsley] class TransientDebugTree(var name: String = "", var internal: 
 
     override def nodeChildren: List[DebugTree] = children.toList
 
-    /**
-      * If the parser needs bubbling then we do not see it because it is transparent. 
-      * If it does not need bubbling then it is either an iterative, opaque parser or a non-iterative, opaque parser.
-      * To cover both cases, we also chekc if it is iterative.
-      */
+    
+    // If the parser needs bubbling then we do not see it because it is transparent. 
+    // If it does not need bubbling then it is either an iterative, opaque parser 
+    // or a non-iterative, opaque parser.
+    // To cover both cases, we also check if it is iterative.
+      
     override def isIterative: Boolean = iterative
 
     // Factors out inputs or results for parsers with children.

--- a/parsley-debug/shared/src/main/scala/parsley/debug/internal/TransientDebugTree.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/debug/internal/TransientDebugTree.scala
@@ -22,7 +22,7 @@ import parsley.debug.{DebugTree, ParseAttempt}
 private [parsley] class TransientDebugTree(var name: String = "", var internal: String = "", val fullInput: String,
                                            var parse: Option[ParseAttempt] = None, var cNumber: Option[Long] = None,
                                            val children: mutable.ListBuffer[TransientDebugTree] = mutable.ListBuffer.empty,
-                                           var needsBubbling: Boolean = false) extends DebugTree {
+                                           var needsBubbling: Boolean = false, var iterative: Boolean = false) extends DebugTree {
     // These are user-facing, and will depend heavily on what the parser looks like.
     // $COVERAGE-OFF$
     override def parserName: String = name
@@ -36,7 +36,14 @@ private [parsley] class TransientDebugTree(var name: String = "", var internal: 
 
     override def nodeChildren: List[DebugTree] = children.toList
 
-    override def doesNeedBubbling: Boolean = needsBubbling
+    /**
+      * 
+      *
+      * @return If the parser needs bubbling then we do not see it because it is transparent. 
+      * If it does not need bubbling then it is either an iterative, opaque parser or a non-iterative, opaque parser.
+      * To cover both cases, we also chekc if it is iterative.
+      */
+    override def isIterative: Boolean = !needsBubbling && iterative
 
     // Factors out inputs or results for parsers with children.
     private type Augment  = (Long, (Int, Int))

--- a/parsley-debug/shared/src/main/scala/parsley/internal/deepembedding/backend/debug/Tags.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/internal/deepembedding/backend/debug/Tags.scala
@@ -27,7 +27,7 @@ private [parsley] final class Debugging(dbgCtx: DebugContext) extends TagFactory
 
 private [parsley] final class CheckDivergence(dtx: DivergenceContext) extends TagFactory {
     def create[A](origin: LazyParsley[A], p: StrictParsley[A], isIterative: Boolean, userAssignedName: Option[String]): StrictParsley[A] = {
-        new DivergenceChecker(origin, p, isIterative, userAssignedName)(dtx)
+        new DivergenceChecker(origin, p, userAssignedName)(dtx)
     }
 }
 
@@ -47,11 +47,11 @@ private [backend] final class Debugged[A](origin: LazyParsley[A], val p: StrictP
     override protected def pretty(p: String): String = s"debugged($p)"
 }
 
-private [backend] final class DivergenceChecker[A](origin: LazyParsley[A], val p: StrictParsley[A], isIterative: Boolean, userAssignedName: Option[String])(dtx: DivergenceContext)
+private [backend] final class DivergenceChecker[A](origin: LazyParsley[A], val p: StrictParsley[A], userAssignedName: Option[String])(dtx: DivergenceContext)
     extends Unary[A, A] {
     override protected [backend] def codeGen[M[_, +_]: ContOps, R](producesResults: Boolean)(implicit instrs: InstrBuffer, state: CodeGenState): M[R, Unit] = {
         val handler = state.freshLabel()
-        instrs += new TakeSnapshot(handler, origin, isIterative, userAssignedName)(dtx)
+        instrs += new TakeSnapshot(handler, origin, userAssignedName)(dtx)
         suspend[M, R, Unit](p.codeGen[M, R](producesResults)) |> {
             instrs += new Label(handler)
             instrs += new DropSnapshot(dtx)

--- a/parsley-debug/shared/src/main/scala/parsley/internal/deepembedding/backend/debug/Tags.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/internal/deepembedding/backend/debug/Tags.scala
@@ -16,27 +16,27 @@ import parsley.internal.machine.instructions.{Label, Pop}
 import parsley.internal.machine.instructions.debug.{AddAttemptAndLeave, DropSnapshot, EnterParser, TakeSnapshot}
 
 private [deepembedding] sealed abstract class TagFactory {
-    def create[A](origin: LazyParsley[A], p: StrictParsley[A], userAssignedName: Option[String]): StrictParsley[A]
+    def create[A](origin: LazyParsley[A], p: StrictParsley[A], needsBubbling: Boolean, userAssignedName: Option[String]): StrictParsley[A]
 }
 
 private [parsley] final class Debugging(dbgCtx: DebugContext) extends TagFactory {
-    def create[A](origin: LazyParsley[A], p: StrictParsley[A], userAssignedName: Option[String]): StrictParsley[A] = {
-        new Debugged(origin, p, userAssignedName)(dbgCtx)
+    def create[A](origin: LazyParsley[A], p: StrictParsley[A], needsBubbling: Boolean, userAssignedName: Option[String]): StrictParsley[A] = {
+        new Debugged(origin, p, needsBubbling, userAssignedName)(dbgCtx)
     }
 }
 
 private [parsley] final class CheckDivergence(dtx: DivergenceContext) extends TagFactory {
-    def create[A](origin: LazyParsley[A], p: StrictParsley[A], userAssignedName: Option[String]): StrictParsley[A] = {
-        new DivergenceChecker(origin, p, userAssignedName)(dtx)
+    def create[A](origin: LazyParsley[A], p: StrictParsley[A], needsBubbling: Boolean, userAssignedName: Option[String]): StrictParsley[A] = {
+        new DivergenceChecker(origin, p, needsBubbling, userAssignedName)(dtx)
     }
 }
 
 // backend implementations
-private [backend] final class Debugged[A](origin: LazyParsley[A], val p: StrictParsley[A], userAssignedName: Option[String])(dbgCtx: DebugContext)
+private [backend] final class Debugged[A](origin: LazyParsley[A], val p: StrictParsley[A], needsBubbling: Boolean, userAssignedName: Option[String])(dbgCtx: DebugContext)
     extends Unary[A, A] {
     override protected [backend] def codeGen[M[_, +_]: ContOps, R](producesResults: Boolean)(implicit instrs: InstrBuffer, state: CodeGenState): M[R, Unit] = {
         val handler = state.freshLabel()
-        instrs += new EnterParser(handler, origin, userAssignedName)(dbgCtx)
+        instrs += new EnterParser(handler, origin, needsBubbling, userAssignedName)(dbgCtx)
         suspend[M, R, Unit](p.codeGen[M, R](producesResults = true)) |> {
             instrs += new Label(handler)
             instrs += new AddAttemptAndLeave(dbgCtx)
@@ -47,11 +47,11 @@ private [backend] final class Debugged[A](origin: LazyParsley[A], val p: StrictP
     override protected def pretty(p: String): String = s"debugged($p)"
 }
 
-private [backend] final class DivergenceChecker[A](origin: LazyParsley[A], val p: StrictParsley[A], userAssignedName: Option[String])(dtx: DivergenceContext)
+private [backend] final class DivergenceChecker[A](origin: LazyParsley[A], val p: StrictParsley[A], needsBubbling: Boolean, userAssignedName: Option[String])(dtx: DivergenceContext)
     extends Unary[A, A] {
     override protected [backend] def codeGen[M[_, +_]: ContOps, R](producesResults: Boolean)(implicit instrs: InstrBuffer, state: CodeGenState): M[R, Unit] = {
         val handler = state.freshLabel()
-        instrs += new TakeSnapshot(handler, origin, userAssignedName)(dtx)
+        instrs += new TakeSnapshot(handler, origin, needsBubbling, userAssignedName)(dtx)
         suspend[M, R, Unit](p.codeGen[M, R](producesResults)) |> {
             instrs += new Label(handler)
             instrs += new DropSnapshot(dtx)

--- a/parsley-debug/shared/src/main/scala/parsley/internal/deepembedding/frontend/debug/TaggedWith.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/internal/deepembedding/frontend/debug/TaggedWith.scala
@@ -127,13 +127,11 @@ private [parsley] object TaggedWith {
 
         // This is the main logic for the visitor: everything else is just plumbing
         private def handlePossiblySeen[A](self: LazyParsley[A], context: ParserTracker)(subResult: =>DL[A]): DL[A] = {
-            // We have seen this parser before, fetch parser from the tracker's context
             if (context.hasSeen(self)) {
                 result(TaggingResult(context.get(self), self.isIterative)) 
             } else {
                 val prom = context.put(self)
                 subResult.map { case TaggingResult(subParser, subIsIterative) =>
-                    // If either the child or we are iterative then we are iterative here
                     val isIterative = self.isIterative || subIsIterative
                     // If we are opaque then attach TaggedWith now, otherwise bubble upwards
                     val retParser = {

--- a/parsley-debug/shared/src/main/scala/parsley/internal/deepembedding/frontend/debug/TaggedWith.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/internal/deepembedding/frontend/debug/TaggedWith.scala
@@ -92,8 +92,8 @@ private [parsley] object TaggedWith {
         def apply[A](x: =>A) = new Deferred(x)
     }
 
-     /**
-      * This class is used to store the result of a parser visit, and whether or not the parser needs to bubble up
+    /** This class is used to store the result of a parser visit, and whether
+      *  or not the parser needs to bubble up
       *
       * @param parser The parser that was visited
       * @param isIterative Whether or not the parser is transparent and hence needs to bubble up
@@ -104,11 +104,11 @@ private [parsley] object TaggedWith {
     // Keeping this around for easy access to LPM.
     @unused private [this] final class ContWrap[M[_, +_], R] {
         type LPM[+A] = M[R, LazyParsley[A]]
-        /** 
-         * ParserResult containing the related LazyParsley combinator and a Boolean for if the
-         * combinator need to be bubble up to an opaque parser
-         **/
-        type DLPM[+A] = M[R, ParserResult[A]] 
+         
+        // Containing the related LazyParsley combinator and a Boolean for if the
+        // combinator need to be bubble up to an opaque parser
+         
+        type DLPM[+A] = M[R, (ParserResult[A])] 
     }
 
     private def visitWithM[M[_, +_]: ContOps, A](parser: LazyParsley[A], tracker: ParserTracker, visitor: DebugInjectingVisitorM[M, LazyParsley[A]]) = {

--- a/parsley-debug/shared/src/main/scala/parsley/internal/deepembedding/frontend/debug/TaggedWith.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/internal/deepembedding/frontend/debug/TaggedWith.scala
@@ -135,7 +135,7 @@ private [parsley] object TaggedWith {
                 val prom = context.put(self)
                 subResult.map { subResult_ =>
                     /* If either the child or we are iterative then we are iterative here */
-                    val isIterativeHere = self.isIterative || subResult_.isIterative
+                    val isIterative = self.isIterative || subResult_.isIterative
                     /* If we are opaque then attach TaggedWith now, otherwise bubble upwards */
                     val retParser = {
                         if (self.isOpaque) 
@@ -146,10 +146,10 @@ private [parsley] object TaggedWith {
                     }
 
                     /* If we are still iterative but transparent then we bubble up */
-                    val bubbleNeeded = isIterativeHere && !self.isOpaque
+                    val bubbleNeeded = isIterative && !self.isOpaque
                     
                     prom.set(retParser)
-                    ParserResult(retParser, bubbleNeeded)
+                    ParserResult(retParser, isIterative)
                 }
             }
         }

--- a/parsley-debug/shared/src/main/scala/parsley/internal/deepembedding/frontend/debug/TaggedWith.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/internal/deepembedding/frontend/debug/TaggedWith.scala
@@ -144,12 +144,10 @@ private [parsley] object TaggedWith {
                             subParser /* The parser is transparent, so no tagging */
                         }
                     }
-
-                    /* If we are still iterative but transparent then we bubble up */
-                    val bubbleNeeded = isIterative && !self.isOpaque
                     
                     prom.set(retParser)
-                    ParserResult(retParser, bubbleNeeded)
+                    /* If we are still iterative but transparent then we bubble up */
+                    ParserResult(retParser, isIterative && !self.isOpaque)
                 }
             }
         }

--- a/parsley-debug/shared/src/main/scala/parsley/internal/deepembedding/frontend/debug/TaggedWith.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/internal/deepembedding/frontend/debug/TaggedWith.scala
@@ -123,8 +123,7 @@ private [parsley] object TaggedWith {
         extends GenericLazyParsleyIVisitor[ParserTracker, ContWrap[M, R]#DLPM] {
         private type DL[+A] = ContWrap[M, R]#DLPM[A]
 
-        private def visit[A](p: LazyParsley[A], context: ParserTracker) = 
-            suspend[M, R, ParserResult[A]](p.visit(this, context))
+        private def visit[A](p: LazyParsley[A], context: ParserTracker) = suspend[M, R, ParserResult[A]](p.visit(this, context))
 
         // This is the main logic for the visitor: everything else is just plumbing
         private def handlePossiblySeen[A](self: LazyParsley[A], context: ParserTracker)(subResult: =>DL[A]): DL[A] = {

--- a/parsley-debug/shared/src/main/scala/parsley/internal/deepembedding/frontend/debug/TaggedWith.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/internal/deepembedding/frontend/debug/TaggedWith.scala
@@ -133,15 +133,15 @@ private [parsley] object TaggedWith {
                 result(ParserResult(context.get(self), self.isIterative)) 
             } else {
                 val prom = context.put(self)
-                subResult.map { subResult_ =>
+                subResult.map { case ParserResult(subParser, subIsIterative) =>
                     /* If either the child or we are iterative then we are iterative here */
-                    val isIterative = self.isIterative || subResult_.isIterative
+                    val isIterative = self.isIterative || subIsIterative
                     /* If we are opaque then attach TaggedWith now, otherwise bubble upwards */
                     val retParser = {
                         if (self.isOpaque) 
-                            Deferred(new TaggedWith(strategy)(self, subResult_.parser.get, subResult_.isIterative, None)) 
+                            Deferred(new TaggedWith(strategy)(self, subParser.get, isIterative, None)) 
                         else { 
-                            subResult_.parser /* The parser is transparent, so no tagging */
+                            subParser /* The parser is transparent, so no tagging */
                         }
                     }
 
@@ -149,7 +149,7 @@ private [parsley] object TaggedWith {
                     val bubbleNeeded = isIterative && !self.isOpaque
                     
                     prom.set(retParser)
-                    ParserResult(retParser, isIterative)
+                    ParserResult(retParser, bubbleNeeded)
                 }
             }
         }

--- a/parsley-debug/shared/src/main/scala/parsley/internal/deepembedding/frontend/debug/TaggedWith.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/internal/deepembedding/frontend/debug/TaggedWith.scala
@@ -107,7 +107,7 @@ private [parsley] object TaggedWith {
         /** 
          * ParserResult containing the related LazyParsley combinator and a Boolean for if the
          * combinator need to be bubble up to an opaque parser
-         *  */
+         **/
         type DLPM[+A] = M[R, ParserResult[A]] 
     }
 
@@ -127,25 +127,25 @@ private [parsley] object TaggedWith {
 
         // This is the main logic for the visitor: everything else is just plumbing
         private def handlePossiblySeen[A](self: LazyParsley[A], context: ParserTracker)(subResult: =>DL[A]): DL[A] = {
-            /* We have seen this parser before, fetch parser from the tracker's context */
+            // We have seen this parser before, fetch parser from the tracker's context
             if (context.hasSeen(self)) {
                 result(ParserResult(context.get(self), self.isIterative)) 
             } else {
                 val prom = context.put(self)
                 subResult.map { case ParserResult(subParser, subIsIterative) =>
-                    /* If either the child or we are iterative then we are iterative here */
+                    // If either the child or we are iterative then we are iterative here
                     val isIterative = self.isIterative || subIsIterative
-                    /* If we are opaque then attach TaggedWith now, otherwise bubble upwards */
+                    // If we are opaque then attach TaggedWith now, otherwise bubble upwards
                     val retParser = {
                         if (self.isOpaque) 
                             Deferred(new TaggedWith(strategy)(self, subParser.get, isIterative, None)) 
                         else { 
-                            subParser /* The parser is transparent, so no tagging */
+                            subParser // The parser is transparent, so no tagging
                         }
                     }
                     
                     prom.set(retParser)
-                    /* If we are still iterative but transparent then we bubble up */
+                    // If we are still iterative but transparent then we bubble up
                     ParserResult(retParser, isIterative && !self.isOpaque)
                 }
             }

--- a/parsley-debug/shared/src/main/scala/parsley/internal/machine/instructions/debug/DebugInstrs.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/internal/machine/instructions/debug/DebugInstrs.scala
@@ -16,14 +16,14 @@ import parsley.internal.machine.XAssert._
 import parsley.internal.machine.stacks.Stack.StackExt
 
 // Enter into the scope of a parser in the current context.
-private [internal] class EnterParser(var label: Int, origin: LazyParsley[_], needsBubbling: Boolean, userAssignedName: Option[String])(dbgCtx: DebugContext) extends InstrWithLabel {
+private [internal] class EnterParser(var label: Int, origin: LazyParsley[_], isIterative: Boolean, userAssignedName: Option[String])(dbgCtx: DebugContext) extends InstrWithLabel {
     override def apply(ctx: Context): Unit = {
         ensureRegularInstruction(ctx)
         // Uncomment to debug entries and exits.
         // println(s"Entering ${origin.prettyName} (@ ${ctx.pc} -> Exit @ $label)")
 
         // I think we can get away with executing this unconditionally.
-        dbgCtx.push(ctx.input, origin, needsBubbling, userAssignedName)
+        dbgCtx.push(ctx.input, origin, isIterative, userAssignedName)
         // Using my own state tracker instead.
         dbgCtx.pushPos(ctx.offset, ctx.line, ctx.col)
         ctx.pushHandler(label) // Mark the AddAttempt instruction as an exit handler.
@@ -76,13 +76,13 @@ private [internal] class AddAttemptAndLeave(dbgCtx: DebugContext) extends Instr 
     // $COVERAGE-ON$
 }
 
-private [internal] class TakeSnapshot(var label: Int, origin: LazyParsley[_], needsBubbling: Boolean, userAssignedName: Option[String])(dtx: DivergenceContext) extends InstrWithLabel {
+private [internal] class TakeSnapshot(var label: Int, origin: LazyParsley[_], isIterative: Boolean, userAssignedName: Option[String])(dtx: DivergenceContext) extends InstrWithLabel {
     override def apply(ctx: Context): Unit = {
         ensureRegularInstruction(ctx)
         val handler = ctx.handlers
         ctx.pushHandler(label)
         val ctxSnap = dtx.CtxSnap(ctx.pc, ctx.instrs, ctx.offset, ctx.regs.toList)
-        dtx.takeSnapshot(origin, needsBubbling, userAssignedName, ctxSnap, if (handler.isEmpty) None else Some(dtx.HandlerSnap(handler.pc, handler.instrs)))
+        dtx.takeSnapshot(origin, isIterative, userAssignedName, ctxSnap, if (handler.isEmpty) None else Some(dtx.HandlerSnap(handler.pc, handler.instrs)))
         ctx.inc()
     }
 

--- a/parsley-debug/shared/src/main/scala/parsley/internal/machine/instructions/debug/DebugInstrs.scala
+++ b/parsley-debug/shared/src/main/scala/parsley/internal/machine/instructions/debug/DebugInstrs.scala
@@ -76,13 +76,13 @@ private [internal] class AddAttemptAndLeave(dbgCtx: DebugContext) extends Instr 
     // $COVERAGE-ON$
 }
 
-private [internal] class TakeSnapshot(var label: Int, origin: LazyParsley[_], isIterative: Boolean, userAssignedName: Option[String])(dtx: DivergenceContext) extends InstrWithLabel {
+private [internal] class TakeSnapshot(var label: Int, origin: LazyParsley[_], userAssignedName: Option[String])(dtx: DivergenceContext) extends InstrWithLabel {
     override def apply(ctx: Context): Unit = {
         ensureRegularInstruction(ctx)
         val handler = ctx.handlers
         ctx.pushHandler(label)
         val ctxSnap = dtx.CtxSnap(ctx.pc, ctx.instrs, ctx.offset, ctx.regs.toList)
-        dtx.takeSnapshot(origin, isIterative, userAssignedName, ctxSnap, if (handler.isEmpty) None else Some(dtx.HandlerSnap(handler.pc, handler.instrs)))
+        dtx.takeSnapshot(origin, userAssignedName, ctxSnap, if (handler.isEmpty) None else Some(dtx.HandlerSnap(handler.pc, handler.instrs)))
         ctx.inc()
     }
 

--- a/parsley-debug/shared/src/test/scala/parsley/debug/DebuggerUsageSpec.scala
+++ b/parsley-debug/shared/src/test/scala/parsley/debug/DebuggerUsageSpec.scala
@@ -25,7 +25,7 @@ class DebuggerUsageSpec extends ParsleyTest {
     "the Debugged internal frontend class" should "not allow nesting of Debugged nodes" in {
         val factory = new Debugging(new DebugContext(parsley.debug.combinator.DefaultStringRules))
         try {
-            val _ = new TaggedWith(factory)(new TaggedWith(factory)(fresh(()).internal, null, None), null, None)
+            val _ = new TaggedWith(factory)(new TaggedWith(factory)(fresh(()).internal, null, false, None), null, false, None)
             fail("Debugged nodes have been nested")
         } catch {
             case _: Throwable => info("assertion exception thrown, as expected")
@@ -34,9 +34,9 @@ class DebuggerUsageSpec extends ParsleyTest {
 
     it should "preserve the prettified names of the parsers" in {
         val factory = new Debugging(new DebugContext(parsley.debug.combinator.DefaultStringRules))
-        new TaggedWith(factory)(named(fresh(()), "foo").internal, null, None).debugName shouldBe "foo"
-        new TaggedWith(factory)(fresh(()).internal, null, None).debugName shouldBe "fresh"
-        new TaggedWith(factory)(fresh(()).internal, null, Some("bar")).debugName shouldBe "bar"
+        new TaggedWith(factory)(named(fresh(()), "foo").internal, null, false, None).debugName shouldBe "foo"
+        new TaggedWith(factory)(fresh(()).internal, null, false, None).debugName shouldBe "fresh"
+        new TaggedWith(factory)(fresh(()).internal, null, false, Some("bar")).debugName shouldBe "bar"
     }
 
     "the debugger runtime" should "preserve the result of parsers" in {

--- a/parsley-debug/shared/src/test/scala/parsley/debug/ReuseSpec.scala
+++ b/parsley-debug/shared/src/test/scala/parsley/debug/ReuseSpec.scala
@@ -33,7 +33,7 @@ class ReuseSpec extends ParsleyTest {
 
             override def nodeChildren: List[DebugTree] = Nil
 
-            override def doesNeedBubbling: Boolean = false
+            override def isIterative: Boolean = false
 
             override def fullInput: String = "bar"
         }

--- a/parsley-debug/shared/src/test/scala/parsley/debug/ReuseSpec.scala
+++ b/parsley-debug/shared/src/test/scala/parsley/debug/ReuseSpec.scala
@@ -33,6 +33,8 @@ class ReuseSpec extends ParsleyTest {
 
             override def nodeChildren: List[DebugTree] = Nil
 
+            override def doesNeedBubbling: Boolean = false
+
             override def fullInput: String = "bar"
         }
 

--- a/parsley-debug/shared/src/test/scala/parsley/internal/deepembedding/RenameSpec.scala
+++ b/parsley-debug/shared/src/test/scala/parsley/internal/deepembedding/RenameSpec.scala
@@ -39,7 +39,7 @@ class RenameSpec extends ParsleyTest {
 
     it should "pass through Debugged parsers and get the inner parser's name" in {
         val symbolic = new <**>
-        val debugged = new TaggedWith[Any](new Debugging(new DebugContext(parsley.debug.combinator.DefaultStringRules)))(symbolic, symbolic, None)
+        val debugged = new TaggedWith[Any](new Debugging(new DebugContext(parsley.debug.combinator.DefaultStringRules)))(symbolic, symbolic, false, None)
 
         Renamer.nameOf(None, debugged) shouldBe "<**>"
     }

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/IterativeEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/IterativeEmbedding.scala
@@ -17,14 +17,14 @@ import parsley.internal.deepembedding.backend, backend.StrictParsley
   * @see [[parsley.internal.deepembedding.frontend.debug.TaggedWith `TaggedWith`]] for how this trait is used to bubble up knowledge of
   * iterative subparsers to the [[parsley.debug.DebugTree `DebugTree`]]
   * 
-  * @example [[Many]]
-  * @example [[ChainPost]]
-  * @example [[ChainPre]]
-  * @example [[Chainl]]
-  * @example [[Chainr]]
-  * @example [[SepEndBy1]]
-  * @example [[ManyTill]]
-  * @example [[SkipManyUntil]]
+  * @example [[parsley.internal.deepembedding.frontend.Many `Many``]]
+  * @example [[parsley.internal.deepembedding.frontend.ChainPost `ChainPost`]]
+  * @example [[parsley.internal.deepembedding.frontend.ChainPre `ChainPre`]]
+  * @example [[parsley.internal.deepembedding.frontend.Chainl `Chainl`]]
+  * @example [[parsley.internal.deepembedding.frontend.Chainr `Chainr`]]
+  * @example [[parsley.internal.deepembedding.frontend.SepEndBy1 `SepEndBy1`]]
+  * @example [[parsley.internal.deepembedding.frontend.ManyTill `ManyTill`]]
+  * @example [[parsley.internal.deepembedding.frontend.SkipManyUntil `SkipManyUntil`]]
   */
 sealed trait Iterative
 

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/IterativeEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/IterativeEmbedding.scala
@@ -10,6 +10,22 @@ import scala.collection.{mutable, Factory}
 import parsley.internal.deepembedding.ContOps, ContOps.{suspend, ContAdapter}
 import parsley.internal.deepembedding.backend, backend.StrictParsley
 
+/**
+  * This trait represents combinators that are iterative, that is, they execute 
+  * parsers multiple times until they cannot match any more
+  * 
+  * @see [[parsley.internal.deepembedding.frontend.debug.TaggedWith `TaggedWith`]] for how this trait is used to bubble up knowledge of
+  * iterative subparsers to the [[parsley.debug.DebugTree `DebugTree`]]
+  * 
+  * @example [[Many]]
+  * @example [[ChainPost]]
+  * @example [[ChainPre]]
+  * @example [[Chainl]]
+  * @example [[Chainr]]
+  * @example [[SepEndBy1]]
+  * @example [[ManyTill]]
+  * @example [[SkipManyUntil]]
+  */
 sealed trait Iterative
 
 private [parsley] final class Many[A, C](init: LazyParsley[mutable.Builder[A, C]], p: =>LazyParsley[A], private [parsley] var debugName: String) 

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/IterativeEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/IterativeEmbedding.scala
@@ -10,15 +10,17 @@ import scala.collection.{mutable, Factory}
 import parsley.internal.deepembedding.ContOps, ContOps.{suspend, ContAdapter}
 import parsley.internal.deepembedding.backend, backend.StrictParsley
 
-private [parsley] final class Many[A, C](init: LazyParsley[mutable.Builder[A, C]], p: =>LazyParsley[A], private [parsley] var debugName: String)
-    extends Binary[mutable.Builder[A, C], A, C](init, p) {
+sealed trait Iterative
+
+private [parsley] final class Many[A, C](init: LazyParsley[mutable.Builder[A, C]], p: =>LazyParsley[A], private [parsley] var debugName: String) 
+    extends Binary[mutable.Builder[A, C], A, C](init, p) with Iterative {
     override def make(init: StrictParsley[mutable.Builder[A, C]], p: StrictParsley[A]): StrictParsley[C] = new backend.Many(init, p)
 
     // $COVERAGE-OFF$
     override def visit[T, U[+_]](visitor: LazyParsleyIVisitor[T, U], context: T): U[C] = visitor.visit(this, context)(init, p)
     // $COVERAGE-ON$
 }
-private [parsley] final class ChainPost[A](p: LazyParsley[A], _op: =>LazyParsley[A => A]) extends Binary[A, A => A, A](p, _op) {
+private [parsley] final class ChainPost[A](p: LazyParsley[A], _op: =>LazyParsley[A => A]) extends Binary[A, A => A, A](p, _op) with Iterative {
     override def make(p: StrictParsley[A], op: StrictParsley[A => A]): StrictParsley[A] = new backend.ChainPost(p, op)
 
     // $COVERAGE-OFF$
@@ -27,7 +29,7 @@ private [parsley] final class ChainPost[A](p: LazyParsley[A], _op: =>LazyParsley
     private [parsley] var debugName = "chain.postfix"
     // $COVERAGE-ON$
 }
-private [parsley] final class ChainPre[A](p: LazyParsley[A], op: LazyParsley[A => A]) extends LazyParsley[A] {
+private [parsley] final class ChainPre[A](p: LazyParsley[A], op: LazyParsley[A => A]) extends LazyParsley[A] with Iterative {
     final override def findLetsAux[M[_, +_]: ContOps, R](seen: Set[LazyParsley[_]])(implicit state: LetFinderState): M[R, Unit] = {
         suspend(p.findLets[M, R](seen)) >> suspend(op.findLets(seen))
     }
@@ -44,7 +46,7 @@ private [parsley] final class ChainPre[A](p: LazyParsley[A], op: LazyParsley[A =
     // $COVERAGE-ON$
 }
 private [parsley] final class Chainl[A, B](init: LazyParsley[B], p: =>LazyParsley[A], op: =>LazyParsley[(B, A) => B], var debugName: String)
-    extends Ternary[B, A, (B, A) => B, B](init, p, op) {
+    extends Ternary[B, A, (B, A) => B, B](init, p, op) with Iterative {
     override def make(init: StrictParsley[B], p: StrictParsley[A], op: StrictParsley[(B, A) => B]): StrictParsley[B] = new backend.Chainl(init, p, op)
 
     // $COVERAGE-OFF$
@@ -52,7 +54,7 @@ private [parsley] final class Chainl[A, B](init: LazyParsley[B], p: =>LazyParsle
     // $COVERAGE-ON$
 }
 private [parsley] final class Chainr[A, B](p: LazyParsley[A], op: =>LazyParsley[(A, B) => B], private [Chainr] val wrap: A => B)
-    extends Binary[A, (A, B) => B, B](p, op) {
+    extends Binary[A, (A, B) => B, B](p, op) with Iterative {
     override def make(p: StrictParsley[A], op: StrictParsley[(A, B) => B]): StrictParsley[B] = new backend.Chainr(p, op, wrap)
 
     // $COVERAGE-OFF$
@@ -61,7 +63,7 @@ private [parsley] final class Chainr[A, B](p: LazyParsley[A], op: =>LazyParsley[
     private [parsley] var debugName = "infix.right1"
     // $COVERAGE-ON$
 }
-private [parsley] final class SepEndBy1[A, C](p: LazyParsley[A], sep: =>LazyParsley[_], factory: Factory[A, C]) extends Binary[A, Any, C](p, sep) {
+private [parsley] final class SepEndBy1[A, C](p: LazyParsley[A], sep: =>LazyParsley[_], factory: Factory[A, C]) extends Binary[A, Any, C](p, sep) with Iterative {
     override def make(p: StrictParsley[A], sep: StrictParsley[Any]): StrictParsley[C] = new backend.SepEndBy1(p, sep, factory)
 
     // $COVERAGE-OFF$
@@ -71,14 +73,14 @@ private [parsley] final class SepEndBy1[A, C](p: LazyParsley[A], sep: =>LazyPars
     // $COVERAGE-ON$
 }
 private [parsley] final class ManyTill[A, C](init: LazyParsley[mutable.Builder[A, C]], body: =>LazyParsley[Any], private [parsley] var debugName: String)
-    extends Binary[mutable.Builder[A, C], Any, C](init, body) {
+    extends Binary[mutable.Builder[A, C], Any, C](init, body) with Iterative {
     override def make(init: StrictParsley[mutable.Builder[A, C]], p: StrictParsley[Any]): StrictParsley[C] = new backend.ManyUntil(init, p)
 
     // $COVERAGE-OFF$
     override def visit[T, U[+_]](visitor: LazyParsleyIVisitor[T, U], context: T): U[C] = visitor.visit(this, context)(init, body)
     // $COVERAGE-ON$
 }
-private [parsley] final class SkipManyUntil(body: LazyParsley[Any]) extends Unary[Any, Unit](body) {
+private [parsley] final class SkipManyUntil(body: LazyParsley[Any]) extends Unary[Any, Unit](body) with Iterative {
     override def make(p: StrictParsley[Any]): StrictParsley[Unit] = new backend.SkipManyUntil(p)
 
     // $COVERAGE-OFF$

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/IterativeEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/IterativeEmbedding.scala
@@ -13,18 +13,6 @@ import parsley.internal.deepembedding.backend, backend.StrictParsley
 /**
   * This trait represents combinators that are iterative, that is, they execute 
   * parsers multiple times until they cannot match any more
-  * 
-  * @see [[parsley.internal.deepembedding.frontend.debug.TaggedWith `TaggedWith`]] for how this trait is used to bubble up knowledge of
-  * iterative subparsers to the [[parsley.debug.DebugTree `DebugTree`]]
-  * 
-  * @example [[parsley.internal.deepembedding.frontend.Many `Many``]]
-  * @example [[parsley.internal.deepembedding.frontend.ChainPost `ChainPost`]]
-  * @example [[parsley.internal.deepembedding.frontend.ChainPre `ChainPre`]]
-  * @example [[parsley.internal.deepembedding.frontend.Chainl `Chainl`]]
-  * @example [[parsley.internal.deepembedding.frontend.Chainr `Chainr`]]
-  * @example [[parsley.internal.deepembedding.frontend.SepEndBy1 `SepEndBy1`]]
-  * @example [[parsley.internal.deepembedding.frontend.ManyTill `ManyTill`]]
-  * @example [[parsley.internal.deepembedding.frontend.SkipManyUntil `SkipManyUntil`]]
   */
 sealed trait Iterative
 

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/IterativeEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/IterativeEmbedding.scala
@@ -14,7 +14,7 @@ import parsley.internal.deepembedding.backend, backend.StrictParsley
   * This trait represents combinators that are iterative, that is, they execute 
   * parsers multiple times until they cannot match any more
   */
-sealed trait Iterative
+private [parsley] sealed trait Iterative
 
 private [parsley] final class Many[A, C](init: LazyParsley[mutable.Builder[A, C]], p: =>LazyParsley[A], private [parsley] var debugName: String) 
     extends Binary[mutable.Builder[A, C], A, C](init, p) with Iterative {

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/LazyParsley.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/LazyParsley.scala
@@ -186,7 +186,10 @@ private [parsley] abstract class LazyParsley[+A] private [deepembedding] {
     private [parsley] def transparent(): Unit = debugName = null
     private [parsley] def opaque(name: String): Unit = debugName = name
     private [parsley] def isOpaque: Boolean = debugName != null
-    private [parsley] def isIterative: Boolean = this.isInstanceOf[Iterative]
+    private [parsley] def isIterative: Boolean = this match {
+        case _: Iterative => true
+        case _            => false
+    }
 
     /** Pretty-prints a combinator tree, for internal debugging purposes only. */
     final private [internal] def prettyAST: String = {

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/LazyParsley.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/LazyParsley.scala
@@ -186,6 +186,7 @@ private [parsley] abstract class LazyParsley[+A] private [deepembedding] {
     private [parsley] def transparent(): Unit = debugName = null
     private [parsley] def opaque(name: String): Unit = debugName = name
     private [parsley] def isOpaque: Boolean = debugName != null
+    private [parsley] def isIterative: Boolean = this.isInstanceOf[Iterative]
 
     /** Pretty-prints a combinator tree, for internal debugging purposes only. */
     final private [internal] def prettyAST: String = {

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/Visitors.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/Visitors.scala
@@ -170,24 +170,6 @@ private [frontend] abstract class GenericLazyParsleyIVisitor[-T, +U[+_]] extends
     def visitBinary[A, B, C](self: Binary[A, B, C], context: T)(l: LazyParsley[A], r: =>LazyParsley[B]): U[C]
     def visitTernary[A, B, C, D](self: Ternary[A, B, C, D], context: T)(f: LazyParsley[A], s: =>LazyParsley[B], t: =>LazyParsley[C]): U[D]
 
-    private def handleIterative[A](parser: LazyParsley[A]): Unit = {
-        println(s"Processing iterative combinator: ${parser.getClass.getSimpleName}")
-
-        /* Ensure iterative combinators are properly wrapped to be visible */
-        if (!parser.isOpaque) {
-            /* Make the first transparent parser opaque so the debugger can latch onto it */
-            parser.opaque() 
-            /* Now that the debugger is latched on, bubble up to the first opaque parent */
-            parser.parent match {
-                /* If the parent is an iterative combinator, continue bubbling */
-                case Some(parent) if parent.isInstanceOf[Iterative] =>
-                    handleIterative(parent.asInstanceOf[LazyParsley[A]])
-                case  => /* Stop bubbling if we hit a non-iterative or opaque parser */
-            }
-        }
-    }
-
-
     // Forward the generic parser to one of the defined methods.
     // $COVERAGE-OFF$
     override def visitGeneric[A](self: GenericLazyParsley[A], context: T): U[A] = self match {
@@ -292,34 +274,13 @@ private [frontend] abstract class GenericLazyParsleyIVisitor[-T, +U[+_]] extends
     override def visit[A](self: <*[A], context: T)(p: LazyParsley[A], _q: =>LazyParsley[_]): U[A] = visitBinary[A, Any, A](self, context)(p, _q)
 
     // Iterative overrides.
-    override def visit[A, C](self: Many[A, C], context: T)(init: LazyParsley[mutable.Builder[A, C]], p: LazyParsley[A]): U[C] = {
-        handleIterative(self)
-        visitBinary(self, context)(init, p)
-    }
-    override def visit[A](self: ChainPost[A], context: T)(p: LazyParsley[A], _op: =>LazyParsley[A => A]): U[A] = {
-        handleIterative(self)
-        visitBinary(self, context)(p, _op)
-    }
-    override def visit[A, B](self: Chainl[A, B], context: T)(init: LazyParsley[B], p: =>LazyParsley[A], op: =>LazyParsley[(B, A) => B]): U[B] = {
-        handleIterative(self)
-        visitTernary(self, context)(init, p, op)
-    }
-    override def visit[A, B](self: Chainr[A, B], context: T)(p: LazyParsley[A], op: =>LazyParsley[(A, B) => B], wrap: A => B): U[B] = {
-        handleIterative(self)
-        visitBinary(self, context)(p, op)
-    }
-    override def visit[A, C](self: SepEndBy1[A, C], context: T)(p: LazyParsley[A], sep: =>LazyParsley[_], factory: Factory[A, C]): U[C] = {
-        handleIterative(self)
-        visitBinary[A, Any, C](self, context)(p, sep)
-    }
-    override def visit[A, C](self: ManyTill[A, C], context: T)(init: LazyParsley[mutable.Builder[A, C]], body: LazyParsley[Any]): U[C] = {
-        handleIterative(self)
-        visitBinary[mutable.Builder[A, C], Any, C](self, context)(init, body)
-    }
-    override def visit(self: SkipManyUntil, context: T)(body: LazyParsley[Any]): U[Unit] = {
-        handleIterative(self)
-        visitUnary[Any, Unit](self, context)(body)
-    } 
+    override def visit[A, C](self: Many[A, C], context: T)(init: LazyParsley[mutable.Builder[A, C]], p: LazyParsley[A]): U[C] = visitBinary(self, context)(init, p)
+    override def visit[A](self: ChainPost[A], context: T)(p: LazyParsley[A], _op: =>LazyParsley[A => A]): U[A] = visitBinary(self, context)(p, _op)
+    override def visit[A, B](self: Chainl[A, B], context: T)(init: LazyParsley[B], p: =>LazyParsley[A], op: =>LazyParsley[(B, A) => B]): U[B] = visitTernary(self, context)(init, p, op)
+    override def visit[A, B](self: Chainr[A, B], context: T)(p: LazyParsley[A], op: =>LazyParsley[(A, B) => B], wrap: A => B): U[B] = visitBinary(self, context)(p, op)
+    override def visit[A, C](self: SepEndBy1[A, C], context: T)(p: LazyParsley[A], sep: =>LazyParsley[_], factory: Factory[A, C]): U[C] = visitBinary[A, Any, C](self, context)(p, sep)
+    override def visit[A, C](self: ManyTill[A, C], context: T)(init: LazyParsley[mutable.Builder[A, C]], body: LazyParsley[Any]): U[C] = visitBinary[mutable.Builder[A, C], Any, C](self, context)(init, body)
+    override def visit(self: SkipManyUntil, context: T)(body: LazyParsley[Any]): U[Unit] = visitUnary[Any, Unit](self, context)(body) 
 
     // Error overrides.
     override def visit[A](self: ErrorLabel[A], context: T)(p: LazyParsley[A], label: String, labels: Seq[String]): U[A] = visitUnary(self, context)(p)


### PR DESCRIPTION
Prior to these changes, there was no consistent way of identifying or handling parsers that performed iterative operations. This was problematic in scenarios where debugging needed to differentiate between parsers that may recurse in more complex ways (for example, chain or many-based parsers).

This PR introduces a new `Iterative` trait for chain/many-based combinators and modifies the `TaggedWith` infrastructure so that `isIterative` is properly propagated during debugging. It also introduces a `TaggingResult` case class for storing debug-related data in a more structured way.

Additionally, `DebugTree`, `TransientDebugTree`, and other files are updated to pass along this information, streamlining how iterative parsers are handled and improving the clarity of debug output.