### PR TITLE
Improving the asymptotics of precedence and choice

### DIFF
--- a/parsley/shared/src/main/scala/parsley/expr/Fixity.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/Fixity.scala
@@ -69,17 +69,17 @@ case object InfixN extends Fixity {
 }
 
 private [parsley] object Fixity {
-  final val PR = 0
-  final val PO = 1
-  final val IL = 2
-  final val IR = 3
-  final val IN = 4
+  final val PrefixTag = 0
+  final val PostfixTag = 1
+  final val InfixLTag = 2
+  final val InfixRTag = 3
+  final val InfixNTag = 4
 
   def ordinal(f: Fixity): Int = f match {
-    case InfixL => IL
-    case InfixR => IR
-    case Prefix  => PR
-    case Postfix => PO
-    case InfixN  => IN
+    case InfixL => InfixLTag
+    case InfixR => InfixRTag
+    case Prefix  => PrefixTag
+    case Postfix => PostfixTag
+    case InfixN  => InfixNTag
   }
 }

--- a/parsley/shared/src/main/scala/parsley/expr/Fixity.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/Fixity.scala
@@ -67,3 +67,19 @@ case object InfixN extends Fixity {
     override type Op[-A, +B] = (A, A) => B
     private [expr] def chain[A, B](p: Parsley[A], op: Parsley[Op[A, B]])(implicit wrap: A => B): Parsley[B] = infix.nonassoc(p)(op)
 }
+
+private [parsley] object Fixity {
+  final val PR = 0
+  final val PO = 1
+  final val IL = 2
+  final val IR = 3
+  final val IN = 4
+
+  def ordinal(f: Fixity): Int = f match {
+    case InfixL => IL
+    case InfixR => IR
+    case Prefix  => PR
+    case Postfix => PO
+    case InfixN  => IN
+  }
+}

--- a/parsley/shared/src/main/scala/parsley/expr/Levels.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/Levels.scala
@@ -45,7 +45,7 @@ sealed abstract class Prec[+A] private [expr] {
       */
     final def +:[Aʹ >: A, B](ops: Ops[Aʹ, B]): Prec[B] = new Level(this, ops)
 }
-private [expr] case class Level[A, B](lvls: Prec[A], ops: Ops[A, B]) extends Prec[B]
+private [parsley] case class Level[A, B](lvls: Prec[A], ops: Ops[A, B]) extends Prec[B]
 
 /** This class is the base of a precedence table.
   *

--- a/parsley/shared/src/main/scala/parsley/expr/Ops.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/Ops.scala
@@ -23,7 +23,6 @@ abstract class Ops[-A, B] {
   private[parsley] val f: Fixity
   private[parsley] val operators: Seq[Parsley[f.Op[A @uncheckedVariance, B]]]
   private[parsley] val wrap: A => B
-  private[parsley] val wrapIsIdentity: Boolean
 }
 
 /** This helper object is used to build values of `Ops[A, A]`, for homogeneous precedence parsing.

--- a/parsley/shared/src/main/scala/parsley/expr/Ops.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/Ops.scala
@@ -6,6 +6,7 @@
 package parsley.expr
 
 import parsley.Parsley
+import scala.annotation.unchecked.uncheckedVariance
 
 /** This class allows for the description of a single layer of operators in the precedence tree.
   *
@@ -18,8 +19,9 @@ import parsley.Parsley
   * @since 2.2.0
   * @group Table
   */
-sealed abstract class Ops[-A, B] {
-    private [expr] def chain(p: Parsley[A]): Parsley[B]
+abstract class Ops[-A, B] {
+  private[parsley] val f: Fixity
+  private[parsley] val operators: Seq[Parsley[f.Op[A @uncheckedVariance, B]]]
 }
 
 /** This helper object is used to build values of `Ops[A, A]`, for homogeneous precedence parsing.
@@ -46,7 +48,8 @@ object Ops {
       */
     def apply[A](fixity: Fixity)(op0: Parsley[fixity.Op[A, A]], ops: Parsley[fixity.Op[A, A]]*): Ops[A, A] = GOps[A, A](fixity)(op0, ops: _*)
 
-    private [expr] def apply[A, B](fixity: Fixity)(op: Parsley[fixity.Op[A, B]])(implicit wrap: A => B): Ops[A, B] = new Ops[A, B] {
-        private [expr] def chain(p: Parsley[A]): Parsley[B] = fixity.chain(p, op)
+    private [expr] def apply[A, B](fixity: Fixity)(op: Parsley[fixity.Op[A, B]])(implicit wrap: A => B) = new Ops[A, B] {
+      val f: fixity.type = fixity
+      val operators = Seq(op)
     }
 }

--- a/parsley/shared/src/main/scala/parsley/expr/Ops.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/Ops.scala
@@ -20,8 +20,8 @@ import scala.annotation.unchecked.uncheckedVariance
   * @group Table
   */
 abstract class Ops[-A, B] {
-  private[parsley] val f: Fixity
-  private[parsley] val operators: Seq[Parsley[f.Op[A @uncheckedVariance, B]]]
+  private[parsley] val fixity: Fixity
+  private[parsley] val ops: Seq[Parsley[fixity.Op[A @uncheckedVariance, B]]]
   private[parsley] val wrap: A => B
 }
 

--- a/parsley/shared/src/main/scala/parsley/expr/Ops.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/Ops.scala
@@ -23,6 +23,7 @@ abstract class Ops[-A, B] {
   private[parsley] val f: Fixity
   private[parsley] val operators: Seq[Parsley[f.Op[A @uncheckedVariance, B]]]
   private[parsley] val wrap: A => B
+  private[parsley] val wrapIsIdentity: Boolean
 }
 
 /** This helper object is used to build values of `Ops[A, A]`, for homogeneous precedence parsing.

--- a/parsley/shared/src/main/scala/parsley/expr/Ops.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/Ops.scala
@@ -22,6 +22,7 @@ import scala.annotation.unchecked.uncheckedVariance
 abstract class Ops[-A, B] {
   private[parsley] val f: Fixity
   private[parsley] val operators: Seq[Parsley[f.Op[A @uncheckedVariance, B]]]
+  private[parsley] val wrap: A => B
 }
 
 /** This helper object is used to build values of `Ops[A, A]`, for homogeneous precedence parsing.
@@ -48,8 +49,12 @@ object Ops {
       */
     def apply[A](fixity: Fixity)(op0: Parsley[fixity.Op[A, A]], ops: Parsley[fixity.Op[A, A]]*): Ops[A, A] = GOps[A, A](fixity)(op0, ops: _*)
 
-    private [expr] def apply[A, B](fixity: Fixity)(op: Parsley[fixity.Op[A, B]])(implicit wrap: A => B): Ops[A, B] = new Ops[A, B] {
-      val f: fixity.type = fixity
-      val operators = Seq(op)
+    private [expr] def apply[A, B](fixity: Fixity)(op: Parsley[fixity.Op[A, B]])(implicit wrap: A => B): Ops[A, B] = {
+      val w = wrap
+      new Ops[A, B] {
+        val f: fixity.type = fixity
+        val operators = Seq(op)
+        val wrap = w
+      }
     }
 }

--- a/parsley/shared/src/main/scala/parsley/expr/Ops.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/Ops.scala
@@ -48,7 +48,7 @@ object Ops {
       */
     def apply[A](fixity: Fixity)(op0: Parsley[fixity.Op[A, A]], ops: Parsley[fixity.Op[A, A]]*): Ops[A, A] = GOps[A, A](fixity)(op0, ops: _*)
 
-    private [expr] def apply[A, B](fixity: Fixity)(op: Parsley[fixity.Op[A, B]])(implicit wrap: A => B) = new Ops[A, B] {
+    private [expr] def apply[A, B](fixity: Fixity)(op: Parsley[fixity.Op[A, B]])(implicit wrap: A => B): Ops[A, B] = new Ops[A, B] {
       val f: fixity.type = fixity
       val operators = Seq(op)
     }

--- a/parsley/shared/src/main/scala/parsley/expr/Ops.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/Ops.scala
@@ -48,13 +48,4 @@ object Ops {
       * @since 2.2.0
       */
     def apply[A](fixity: Fixity)(op0: Parsley[fixity.Op[A, A]], ops: Parsley[fixity.Op[A, A]]*): Ops[A, A] = GOps[A, A](fixity)(op0, ops: _*)
-
-    private [expr] def apply[A, B](fixity: Fixity)(op: Parsley[fixity.Op[A, B]])(implicit wrap: A => B): Ops[A, B] = {
-      val w = wrap
-      new Ops[A, B] {
-        val f: fixity.type = fixity
-        val operators = Seq(op)
-        val wrap = w
-      }
-    }
 }

--- a/parsley/shared/src/main/scala/parsley/expr/SmartOps.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/SmartOps.scala
@@ -34,9 +34,13 @@ object GOps {
       * @note currently a bug in scaladoc incorrect displays this functions type, it should be: `fixity.Op[A, B]`, NOT `Op[A, B]`.
       * @since 2.2.0
       */
-    def apply[A, B](fixity: Fixity)(op0: Parsley[fixity.Op[A, B]], ops: Parsley[fixity.Op[A, B]]*)(implicit wrap: A => B): Ops[A, B] = new Ops[A, B] {
-      val f: fixity.type = fixity
-      val operators = op0 +: ops
+    def apply[A, B](fixity: Fixity)(op0: Parsley[fixity.Op[A, B]], ops: Parsley[fixity.Op[A, B]]*)(implicit wrap: A => B): Ops[A, B] = {
+      val w = wrap
+      new Ops[A, B] {
+        val f: fixity.type = fixity
+        val operators = op0 +: ops
+        val wrap = w
+      }
     }
 }
 

--- a/parsley/shared/src/main/scala/parsley/expr/SmartOps.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/SmartOps.scala
@@ -34,7 +34,7 @@ object GOps {
       * @note currently a bug in scaladoc incorrect displays this functions type, it should be: `fixity.Op[A, B]`, NOT `Op[A, B]`.
       * @since 2.2.0
       */
-    def apply[A, B](fixity: Fixity)(op0: Parsley[fixity.Op[A, B]], ops: Parsley[fixity.Op[A, B]]*)(implicit wrap: A => B) = new Ops[A, B] {
+    def apply[A, B](fixity: Fixity)(op0: Parsley[fixity.Op[A, B]], ops: Parsley[fixity.Op[A, B]]*)(implicit wrap: A => B): Ops[A, B] = new Ops[A, B] {
       val f: fixity.type = fixity
       val operators = op0 +: ops
     }
@@ -65,5 +65,5 @@ object SOps {
       * @note currently a bug in scaladoc incorrect displays this functions type, it should be: `fixity.Op[A, B]`, NOT `Op[A, B]`.
       * @note the order of types in this method is reversed compared with [[GOps.apply]], this is due to a Scala typing issue.
       */
-    def apply[B, A <: B](fixity: Fixity)(op0: Parsley[fixity.Op[A, B]], ops: Parsley[fixity.Op[A, B]]*) = GOps(fixity)(op0, ops: _*)
+    def apply[B, A <: B](fixity: Fixity)(op0: Parsley[fixity.Op[A, B]], ops: Parsley[fixity.Op[A, B]]*): Ops[A, B] = GOps(fixity)(op0, ops: _*)
 }

--- a/parsley/shared/src/main/scala/parsley/expr/SmartOps.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/SmartOps.scala
@@ -40,10 +40,6 @@ object GOps {
         val f: fixity.type = fixity
         val operators = op0 +: ops
         val wrap = w
-        val wrapIsIdentity = w match {
-          case _: (A <:< B) => true
-          case _ => false
-        }
       }
     }
 }

--- a/parsley/shared/src/main/scala/parsley/expr/SmartOps.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/SmartOps.scala
@@ -40,6 +40,10 @@ object GOps {
         val f: fixity.type = fixity
         val operators = op0 +: ops
         val wrap = w
+        val wrapIsIdentity = w match {
+          case _: (A <:< B) => true
+          case _ => false
+        }
       }
     }
 }

--- a/parsley/shared/src/main/scala/parsley/expr/SmartOps.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/SmartOps.scala
@@ -36,9 +36,11 @@ object GOps {
       */
     def apply[A, B](fixity: Fixity)(op0: Parsley[fixity.Op[A, B]], ops: Parsley[fixity.Op[A, B]]*)(implicit wrap: A => B): Ops[A, B] = {
       val w = wrap
+      val f: fixity.type = fixity
+      val os = op0 +: ops
       new Ops[A, B] {
-        val f: fixity.type = fixity
-        val operators = op0 +: ops
+        val fixity: f.type = f
+        val ops = os
         val wrap = w
       }
     }

--- a/parsley/shared/src/main/scala/parsley/expr/SmartOps.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/SmartOps.scala
@@ -6,7 +6,6 @@
 package parsley.expr
 
 import parsley.Parsley
-import parsley.combinator.choice
 
 /** This helper object builds values of `Ops[A, B]`, for fully heterogeneous precedence parsing.
   *
@@ -35,8 +34,9 @@ object GOps {
       * @note currently a bug in scaladoc incorrect displays this functions type, it should be: `fixity.Op[A, B]`, NOT `Op[A, B]`.
       * @since 2.2.0
       */
-    def apply[A, B](fixity: Fixity)(op0: Parsley[fixity.Op[A, B]], ops: Parsley[fixity.Op[A, B]]*)(implicit wrap: A => B): Ops[A, B] = {
-        Ops[A, B](fixity)(choice((op0 +: ops): _*))(wrap)
+    def apply[A, B](fixity: Fixity)(op0: Parsley[fixity.Op[A, B]], ops: Parsley[fixity.Op[A, B]]*)(implicit wrap: A => B) = new Ops[A, B] {
+      val f: fixity.type = fixity
+      val operators = op0 +: ops
     }
 }
 
@@ -65,5 +65,5 @@ object SOps {
       * @note currently a bug in scaladoc incorrect displays this functions type, it should be: `fixity.Op[A, B]`, NOT `Op[A, B]`.
       * @note the order of types in this method is reversed compared with [[GOps.apply]], this is due to a Scala typing issue.
       */
-    def apply[B, A <: B](fixity: Fixity)(op0: Parsley[fixity.Op[A, B]], ops: Parsley[fixity.Op[A, B]]*): Ops[A, B] = GOps(fixity)(op0, ops: _*)
+    def apply[B, A <: B](fixity: Fixity)(op0: Parsley[fixity.Op[A, B]], ops: Parsley[fixity.Op[A, B]]*) = GOps(fixity)(op0, ops: _*)
 }

--- a/parsley/shared/src/main/scala/parsley/expr/infix.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/infix.scala
@@ -5,12 +5,12 @@
  */
 package parsley.expr
 
-import parsley.Parsley, Parsley.notFollowedBy
+import parsley.Parsley
 import parsley.XAnnotation.{implicitNotFound212, implicitNotFound213}
-import parsley.errors.combinator.ErrorMethods
 import parsley.syntax.zipped.zippedSyntax2
 
 import parsley.internal.deepembedding.frontend
+import parsley.errors.patterns.PreventativeErrors
 
 /** This module contains the very useful chaining family of combinators,
   * which are mostly used to parse operators and expressions of varying fixities.
@@ -184,7 +184,7 @@ object infix {
 
     //TODO: document
     def nonassoc[A, B](p: Parsley[A])(op: Parsley[(A, A) => B])(implicit wrap: A => B): Parsley[B] = {
-        val guardNonAssoc = notFollowedBy(op).explain("non-associative operators cannot be chained together")
+        val guardNonAssoc = op.preventativeExplain("operator cannot be applied in sequence as it is non-associative")
         p <**> ((op, p).zipped((f, y) => f(_, y)) </> wrap) <~ guardNonAssoc
     }
 

--- a/parsley/shared/src/main/scala/parsley/expr/originalPrecedence.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/originalPrecedence.scala
@@ -1,0 +1,48 @@
+package parsley.expr
+
+import parsley.Parsley
+import parsley.combinator.choice
+
+object originalPrecedence {
+    def apply[A](atom0: Parsley[A], atoms: Parsley[A]*)(lvlTightest: OriginalOps[A, A], lvls: OriginalOps[A, A]*): Parsley[A] = {
+        apply(lvls.foldLeft[OriginalPrec[A]](new OriginalLevel(OriginalAtoms(atom0, atoms: _*), lvlTightest))(new OriginalLevel(_, _)))
+    }
+
+    def apply[A](lvlWeakest: OriginalOps[A, A], lvls: OriginalOps[A, A]*)(atom0: Parsley[A], atoms: Parsley[A]*): Parsley[A] = {
+        val (lvlTightest +: lvls_) = (lvlWeakest +: lvls).reverse: @unchecked
+        apply(atom0, atoms: _*)(lvlTightest, lvls_ : _*)
+    }
+
+    def apply[A](table: OriginalPrec[A]): Parsley[A] = crushLevels(table)
+
+    private def crushLevels[A](lvls: OriginalPrec[A]): Parsley[A] = lvls match {
+        case OriginalAtoms(atom0, atoms @ _*) => choice((atom0 +: atoms): _*)
+        case OriginalLevel(lvls, ops) => ops.chain(crushLevels(lvls))
+    }
+}
+
+sealed abstract class OriginalPrec[+A] private [expr] {
+    final def :+[Aʹ >: A, B](ops: OriginalOps[Aʹ, B]): OriginalPrec[B] = new OriginalLevel(this, ops)
+    final def +:[Aʹ >: A, B](ops: OriginalOps[Aʹ, B]): OriginalPrec[B] = new OriginalLevel(this, ops)
+}
+private [expr] case class OriginalLevel[A, B](lvls: OriginalPrec[A], ops: OriginalOps[A, B]) extends OriginalPrec[B]
+
+case class OriginalAtoms[+A](atom0: Parsley[A], atoms: Parsley[A]*) extends OriginalPrec[A]
+
+abstract class OriginalOps[-A, B] {
+    private [expr] def chain(p: Parsley[A]): Parsley[B]
+}
+
+object OriginalOps {
+    def apply[A](fixity: Fixity)(op0: Parsley[fixity.Op[A, A]], ops: Parsley[fixity.Op[A, A]]*): OriginalOps[A, A] = OriginalGOps[A, A](fixity)(op0, ops: _*)
+}
+
+object OriginalGOps {
+    def apply[A, B](fixity: Fixity)(op0: Parsley[fixity.Op[A, B]], ops: Parsley[fixity.Op[A, B]]*)(implicit wrap: A => B): OriginalOps[A, B] = new OriginalOps[A, B] {
+        private [expr] def chain(p: Parsley[A]): Parsley[B] = fixity.chain(p, choice((op0 +: ops): _*))
+    }
+}
+
+object OriginalSOps {
+    def apply[B, A <: B](fixity: Fixity)(op0: Parsley[fixity.Op[A, B]], ops: Parsley[fixity.Op[A, B]]*): OriginalOps[A, B] = OriginalGOps(fixity)(op0, ops: _*)
+}

--- a/parsley/shared/src/main/scala/parsley/expr/originalPrecedence.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/originalPrecedence.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2020 Parsley Contributors <https://github.com/j-mie6/Parsley/graphs/contributors>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 package parsley.expr
 
 import parsley.Parsley

--- a/parsley/shared/src/main/scala/parsley/expr/precedence.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/precedence.scala
@@ -107,6 +107,10 @@ object precedence {
       * @since 4.0.0
       */
     def apply[A](table: Prec[A]): Parsley[A] = {
-      new Parsley(new frontend.Precedence(frontend.LazyPrec(table)))
+      val lazyPrec = frontend.LazyPrec(table)
+      val postfixOpPrecs = lazyPrec.ops.filter(_.fixity == Postfix).map(_.prec)
+      val infixOpPrecs = lazyPrec.ops.filter((op) => op.fixity == InfixL || op.fixity == InfixR || op.fixity == InfixN).map(_.prec)
+      require(postfixOpPrecs == Nil || infixOpPrecs == Nil || postfixOpPrecs.min > infixOpPrecs.max, "Postfix operators may not have lower precedence than an infix operator")
+      new Parsley(new frontend.Precedence(lazyPrec))
     }
 }

--- a/parsley/shared/src/main/scala/parsley/expr/precedence.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/precedence.scala
@@ -108,8 +108,11 @@ object precedence {
       */
     def apply[A](table: Prec[A]): Parsley[A] = crushLevels(table)
 
-    private def crushLevels[A](lvls: Prec[A]): Parsley[A] = lvls match {
-        case Atoms(atom0, atoms @ _*) => choice((atom0 +: atoms): _*)
-        case Level(lvls, ops) => ops.chain(crushLevels(lvls))
+    private def crushLevels[A](lvls: Prec[A]): Parsley[A] = {
+        print("crushing it...")
+        lvls match {
+            case Atoms(atom0, atoms @ _*) => choice((atom0 +: atoms): _*)
+            case Level(lvls, ops) => ops.chain(crushLevels(lvls))
+        }
     }
 }

--- a/parsley/shared/src/main/scala/parsley/expr/precedence.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/precedence.scala
@@ -6,7 +6,7 @@
 package parsley.expr
 
 import parsley.Parsley
-import parsley.combinator.choice
+import parsley.internal.deepembedding.frontend
 
 /** This object is used to construct precedence parsers from either a `Prec` or many `Ops[A, A]`.
   *
@@ -106,13 +106,8 @@ object precedence {
       * @see         [[Prec `Prec`]] and its subtypes for a description of how the types work.
       * @since 4.0.0
       */
-    def apply[A](table: Prec[A]): Parsley[A] = crushLevels(table)
-
-    private def crushLevels[A](lvls: Prec[A]): Parsley[A] = {
-        print("crushing it...")
-        lvls match {
-            case Atoms(atom0, atoms @ _*) => choice((atom0 +: atoms): _*)
-            case Level(lvls, ops) => ops.chain(crushLevels(lvls))
-        }
+    def apply[A](table: Prec[A]): Parsley[A] = {
+      val lazyPrec = frontend.LazyPrec.fromPrec(table)
+      new Parsley(new frontend.Precedence(lazyPrec))
     }
 }

--- a/parsley/shared/src/main/scala/parsley/expr/precedence.scala
+++ b/parsley/shared/src/main/scala/parsley/expr/precedence.scala
@@ -107,7 +107,6 @@ object precedence {
       * @since 4.0.0
       */
     def apply[A](table: Prec[A]): Parsley[A] = {
-      val lazyPrec = frontend.LazyPrec.fromPrec(table)
-      new Parsley(new frontend.Precedence(lazyPrec))
+      new Parsley(new frontend.Precedence(frontend.LazyPrec(table)))
     }
 }

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/Traverse.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/Traverse.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2020 Parsley Contributors <https://github.com/j-mie6/Parsley/graphs/contributors>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 package parsley.internal.deepembedding
 
 import parsley.internal.deepembedding.ContOps.{result, ContAdapter}

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/Traverse.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/Traverse.scala
@@ -1,0 +1,18 @@
+package parsley.internal.deepembedding
+
+import parsley.internal.deepembedding.ContOps.{result, ContAdapter}
+
+object Traverse {
+  def traverse[M[_, +_]: ContOps, R, A, B](xs: List[A])(f: A => M[R, B]): M[R, List[B]] = xs match {
+    case Nil => result(Nil)
+    case x :: xs => for {
+        y <- f(x)
+        ys <- traverse(xs)(f)
+    } yield y :: ys
+  }
+
+  def traverse_[M[_, +_]: ContOps, R, A, B](xs: List[A])(f: A => M[R, B]): M[R, Unit] = xs match {
+    case Nil => result(())
+    case x :: xs => f(x) >> traverse_(xs)(f)
+  }
+}

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/AlternativeEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/AlternativeEmbedding.scala
@@ -64,7 +64,7 @@ private [deepembedding] final class Choice[A](private [backend] val alt1: Strict
     override def codeGen[M[_, +_]: ContOps, R](producesResults: Boolean)(implicit instrs: InstrBuffer, state: CodeGenState): M[R, Unit] = codeGenTablified(this.tablify, producesResults)
 
     private def tablify: List[Either[StrictParsley[_], JumpTableDefinition]] =
-        tablify((alt1::alt2::alts).iterator, mutable.ListBuffer.empty, mutable.ListBuffer.empty, mutable.ListBuffer.empty, mutable.Set.empty, None)
+        tablify((alt1::alt2::alts).iterator, mutable.ListBuffer.empty, mutable.ListBuffer.empty, mutable.ListBuffer.empty, mutable.Set.empty, None, false)
 
     @tailrec private def tablify(
         it: LinkedListIterator[StrictParsley[A]],
@@ -72,20 +72,24 @@ private [deepembedding] final class Choice[A](private [backend] val alt1: Strict
         tableAcc: mutable.ListBuffer[Either[List[JumpTableCharOption], JumpTablePredOption]],
         groupAcc: mutable.ListBuffer[JumpTableCharOption],
         seen: mutable.Set[Char],
-        lastSeen: Option[Char]
+        lastSeen: Option[Char],
+        backtrackingPred: Boolean
     ): List[Either[StrictParsley[_], JumpTableDefinition]] = if (it.hasNext) {
         val u = it.next()
         tablable(u, backtracks = false) match {
             // Character, if we've not seen it before that's ok
-            case Some(Left(lI@(c, _, _, _))) if !seen.contains(c) => tablify(it, acc, tableAcc, groupAcc += ((u, lI)), seen += c, Some(c))
+            case Some(Left(lI@(c, _, _, _))) if !seen.contains(c) => tablify(it, acc, tableAcc, groupAcc += ((u, lI)), seen += c, Some(c), backtrackingPred)
             // Character, if we've seen it, then only a repeat of the last character is allowed
-            case Some(Left(lI@(c, _, _, _))) if lastSeen.contains(c) => tablify(it, acc, tableAcc, groupAcc += ((u, lI)), seen, lastSeen)
+            case Some(Left(lI@(c, _, _, _))) if lastSeen.contains(c) => tablify(it, acc, tableAcc, groupAcc += ((u, lI)), seen, lastSeen, backtrackingPred)
             // Character, if it's seen and not the last character we have to stop building the table
-            case Some(Left(lI@(c, _, _, _))) => tablify(it, appendTable(acc, appendGroup(tableAcc, groupAcc)), mutable.ListBuffer.empty, mutable.ListBuffer((u, lI)), mutable.Set(c), Some(c))
+            case Some(Left(lI@(c, _, _, _))) => tablify(it, appendTable(acc, appendGroup(tableAcc, groupAcc)), mutable.ListBuffer.empty, mutable.ListBuffer((u, lI)), mutable.Set(c), Some(c), backtrackingPred)
             // Predicate, this is an option on it's own, create a new group
-            case Some(Right(lI)) => tablify(it, acc, appendGroup(tableAcc, groupAcc) += Right((u, lI)), mutable.ListBuffer.empty, seen, lastSeen)
+            case Some(Right(lI@(_, _, _, b))) => {
+                if (backtrackingPred) tablify(it, appendTable(acc, appendGroup(tableAcc, groupAcc)), mutable.ListBuffer(Right((u, lI))), mutable.ListBuffer.empty, mutable.Set.empty, None, false)
+                else tablify(it, acc, appendGroup(tableAcc, groupAcc) += Right((u, lI)), mutable.ListBuffer.empty, seen, lastSeen, b)
+            }
             // Non-tablable, this is a Right(...) in the list
-            case _ => tablify(it, appendTable(acc, (appendGroup(tableAcc, groupAcc))) += Left(u), mutable.ListBuffer.empty, mutable.ListBuffer.empty, mutable.Set.empty, None)
+            case _ => tablify(it, appendTable(acc, (appendGroup(tableAcc, groupAcc))) += Left(u), mutable.ListBuffer.empty, mutable.ListBuffer.empty, mutable.Set.empty, None, backtrackingPred)
         }
     } else appendTable(acc, (appendGroup(tableAcc, groupAcc))).toList
 

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/IterativeEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/IterativeEmbedding.scala
@@ -55,7 +55,7 @@ private [backend] sealed abstract class ChainLike[A](p: StrictParsley[A], op: St
     // $COVERAGE-ON$
 }
 
-private [deepembedding] final class ChainPost[A](p: StrictParsley[A], op: StrictParsley[A => A]) extends ChainLike[A](p, op) {
+private [deepembedding] final class ChainPost[A](val p: StrictParsley[A], val op: StrictParsley[A => A]) extends ChainLike[A](p, op) {
     override def codeGen[M[_, +_]: ContOps, R](producesResults: Boolean)(implicit instrs: InstrBuffer, state: CodeGenState): M[R, Unit] = {
         val body = state.freshLabel()
         val handler = state.freshLabel()
@@ -71,6 +71,10 @@ private [deepembedding] final class ChainPost[A](p: StrictParsley[A], op: Strict
     // $COVERAGE-OFF$
     final override def pretty(p: String, op: String): String = s"chainPost($p, $op)"
     // $COVERAGE-ON$
+}
+
+private [backend] object ChainPost {
+    def unapply[A](p: ChainPost[A]): Option[(StrictParsley[A], StrictParsley[A => A])] = Some((p.p, p.op))
 }
 
 private [deepembedding] final class ChainPre[A](p: StrictParsley[A], op: StrictParsley[A => A]) extends ChainLike[A](p, op) {

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrecedenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrecedenceEmbedding.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2020 Parsley Contributors <https://github.com/j-mie6/Parsley/graphs/contributors>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 package parsley.internal.deepembedding.backend
 
 import parsley.internal.deepembedding.ContOps

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrecedenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrecedenceEmbedding.scala
@@ -1,0 +1,30 @@
+package parsley.internal.deepembedding.backend
+
+import parsley.expr.Fixity
+import parsley.internal.deepembedding.ContOps
+
+sealed trait StrictPrec[+Out] {
+  type In
+}
+
+object StrictPrec {
+  final case class Atoms[A](atoms: List[StrictParsley[A]]) extends StrictPrec[A] {
+    type In = A // never used
+  }
+
+  final case class Level[A, B](
+    lower: StrictPrec[A],
+    fixity: Fixity,
+    operators: List[StrictParsley[Fixity#Op[A, B]]]
+  ) extends StrictPrec[B] {
+    type In = A
+  }
+}
+
+private [deepembedding] final class Precedence[A](table: StrictPrec[A]) extends StrictParsley[A] {
+  override protected[backend] def codeGen[M[_, +_]: ContOps, R](producesResults: Boolean)(implicit instrs: StrictParsley.InstrBuffer, state: CodeGenState): M[R,Unit] = ???
+
+  override private[deepembedding] def inlinable: Boolean = ???
+
+  override private[deepembedding] def pretty: String = ???
+}

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrecedenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrecedenceEmbedding.scala
@@ -10,7 +10,7 @@ import parsley.expr.Prefix
 import parsley.internal.deepembedding.singletons.Fail
 import parsley.internal.errors.FlexibleCaret
 
-private [deepembedding] final class Precedence[A](prefixAtomChoice: StrictParsley[ShuntInput], postfixInfixChoice: StrictParsley[ShuntInput], wraps: List[Any => Any]) extends StrictParsley[A] {
+private [deepembedding] final class Precedence[A](prefixAtomChoice: StrictParsley[ShuntInput], postfixInfixChoice: StrictParsley[ShuntInput], wraps: Array[Any => Any]) extends StrictParsley[A] {
   override protected[backend] def codeGen[M[_, +_]: ContOps, R](producesResults: Boolean)(implicit instrs: StrictParsley.InstrBuffer, state: CodeGenState): M[R,Unit] = {
     val prefixAtomLabel = state.freshLabel()
     val postfixInfixLabel = state.freshLabel()

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrecedenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrecedenceEmbedding.scala
@@ -49,12 +49,10 @@ private [deepembedding] object Precedence {
     case a :: b :: rest => new Choice(a, b, SinglyLinkedList(rest.head, rest.tail: _*))
   }
 
-  private def buildChoiceOptions(table: StrictPrec): (List[StrictParsley[ShuntInput]], List[StrictParsley[ShuntInput]]) = {
-    return (
-      table.atoms.map(a => <*>(new Pure(r => Atom(r, table.wraps.length)), a).optimise) ++ table.ops.filter(_.fixity == Prefix).map(o => <*>(new Pure(r => Operator(r, Fixity.ordinal(o.fixity), o.prec)), o.op).optimise),
-      table.ops.filter(_.fixity != Prefix).map(o => <*>(new Pure(r => Operator(r, Fixity.ordinal(o.fixity), o.prec)), o.op).optimise)
-    )
-  }
+  private def buildChoiceOptions(table: StrictPrec): (List[StrictParsley[ShuntInput]], List[StrictParsley[ShuntInput]]) = (
+    table.atoms.map(a => <*>(new Pure(r => Atom(r, table.wraps.length)), a).optimise) ++ table.ops.filter(_.fixity == Prefix).map(o => <*>(new Pure(r => Operator(r, Fixity.ordinal(o.fixity), o.prec)), o.op).optimise),
+    table.ops.filter(_.fixity != Prefix).map(o => <*>(new Pure(r => Operator(r, Fixity.ordinal(o.fixity), o.prec)), o.op).optimise)
+  )
 
   private def buildPrecomputedWraps(wraps: Array[Any => Any]): Array[Array[Any => Any]] = {
     val d = wraps.length + 1

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrecedenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrecedenceEmbedding.scala
@@ -62,7 +62,14 @@ private [deepembedding] object Precedence {
     
     for (from <- 0 until d) {
       for (to <- from - 1 to 0 by -1) {
-        output(from)(to) = output(from)(to + 1) andThen wraps(to)
+        output(from)(to) = output(from)(to + 1) match {
+          case _: <:<[_, _] => wraps(to)
+          case prev => wraps(to) match {
+            case _: <:<[_, _] => prev
+            case next => prev andThen next
+          }
+        }
+        // output(from)(to) = output(from)(to + 1) andThen wraps(to)
       }
     }
     output

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrecedenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrecedenceEmbedding.scala
@@ -72,13 +72,6 @@ private [deepembedding] object Precedence {
         else output(from)(to) = (f andThen g, false)
       }
     }
-    // for (from <- 0 until d) {
-    //   for (to <- 0 until d) {
-    //     println(s"$from, $to")
-    //     if (to > from) println("X")
-    //     else println(s"(${output(from)(to)._1}, ${output(from)(to)._2})")
-    //   }
-    // }
     output
   }
 }

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrecedenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrecedenceEmbedding.scala
@@ -1,17 +1,51 @@
 package parsley.internal.deepembedding.backend
 
-import parsley.expr.Fixity
 import parsley.internal.deepembedding.ContOps
-import parsley.internal.deepembedding.ContOps.{result}
+import parsley.internal.deepembedding.ContOps.{suspend, ContAdapter}
+import parsley.internal.deepembedding.singletons.Pure
+import parsley.internal.collection.mutable.SinglyLinkedList
 import parsley.internal.machine.instructions
+import parsley.internal.machine.instructions.{ShuntInput, Atom, Operator}
 
-private [deepembedding] final class Precedence[A](table: StrictPrec[A]) extends StrictParsley[A] {
+private[deepembedding] case class PrecOperators[A, B](val ops: StrictOps[A, B], val precedence: Int)
+
+private [deepembedding] final class Precedence[A](choice: StrictParsley[ShuntInput]) extends StrictParsley[A] {
   override protected[backend] def codeGen[M[_, +_]: ContOps, R](producesResults: Boolean)(implicit instrs: StrictParsley.InstrBuffer, state: CodeGenState): M[R,Unit] = {
+    val start = state.freshLabel()
     val handler = state.freshLabel()
-    result { instrs += new instructions.Label(handler) }
+    instrs += new instructions.Fresh(instructions.ShuntingYardState.empty)
+    instrs += new instructions.PushHandler(handler)
+    instrs += new instructions.Label(start)
+    suspend(choice.codeGen[M, R](producesResults = true)) |> {
+      instrs += new instructions.Label(handler)
+      instrs += new instructions.Shunt(start)
+    }
   }
 
   override private[deepembedding] def inlinable: Boolean = false
 
   override private[deepembedding] def pretty: String = "precedence" // TODO: implement pretty printing
+}
+
+private [deepembedding] object Precedence {
+  def apply[A](table: StrictPrec[A]): Precedence[A] = {
+    val options = buildChoiceOptions(table, 0)
+    if (options.isEmpty) {
+      throw new IllegalArgumentException("Precedence table must have at least one operator")
+    } else if (options.length == 1) {
+      new Precedence(options.head)
+    } else if (options.length == 2) {
+      new Precedence(<|>(options.head, options(1)))
+    } else {
+      new Precedence(new Choice(options.head, options(1), SinglyLinkedList(options(2), options.drop(3): _*)))
+    }
+  }
+
+  private def buildChoiceOptions(table: StrictPrec[_], lvl: Int): List[StrictParsley[ShuntInput]] = table match {
+    case StrictPrec.Atoms(atoms) => atoms.map(a => <*>(new Pure(r => Atom(r)), a))
+    case StrictPrec.Level(lower, ops) =>
+      val lowerChoice = buildChoiceOptions(lower, lvl + 1)
+      val opChoice = ops.ops.map(o => <*>(new Pure(r => Operator(r, ops.f, lvl)), o))
+      lowerChoice ++ opChoice
+  }
 }

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrecedenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrecedenceEmbedding.scala
@@ -37,7 +37,6 @@ private [deepembedding] final class Precedence[A](prefixAtomChoice: StrictParsle
 private [deepembedding] object Precedence {
   def apply[A](table: StrictPrec): Precedence[A] = {
     val (prefixAtomOptions, postfixInfixOptions) = buildChoiceOptions(table)
-    println(prefixAtomOptions)
     val prefixAtomChoice = buildChoiceNode(prefixAtomOptions)
     val postfixInfixChoice = buildChoiceNode(postfixInfixOptions)
     new Precedence(prefixAtomChoice, postfixInfixChoice, buildPrecomputedWraps(table.wraps))

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrecedenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrecedenceEmbedding.scala
@@ -2,29 +2,16 @@ package parsley.internal.deepembedding.backend
 
 import parsley.expr.Fixity
 import parsley.internal.deepembedding.ContOps
-
-sealed trait StrictPrec[+Out] {
-  type In
-}
-
-object StrictPrec {
-  final case class Atoms[A](atoms: List[StrictParsley[A]]) extends StrictPrec[A] {
-    type In = A // never used
-  }
-
-  final case class Level[A, B](
-    lower: StrictPrec[A],
-    fixity: Fixity,
-    operators: List[StrictParsley[Fixity#Op[A, B]]]
-  ) extends StrictPrec[B] {
-    type In = A
-  }
-}
+import parsley.internal.deepembedding.ContOps.{result}
+import parsley.internal.machine.instructions
 
 private [deepembedding] final class Precedence[A](table: StrictPrec[A]) extends StrictParsley[A] {
-  override protected[backend] def codeGen[M[_, +_]: ContOps, R](producesResults: Boolean)(implicit instrs: StrictParsley.InstrBuffer, state: CodeGenState): M[R,Unit] = ???
+  override protected[backend] def codeGen[M[_, +_]: ContOps, R](producesResults: Boolean)(implicit instrs: StrictParsley.InstrBuffer, state: CodeGenState): M[R,Unit] = {
+    val handler = state.freshLabel()
+    result { instrs += new instructions.Label(handler) }
+  }
 
-  override private[deepembedding] def inlinable: Boolean = ???
+  override private[deepembedding] def inlinable: Boolean = false
 
-  override private[deepembedding] def pretty: String = ???
+  override private[deepembedding] def pretty: String = "precedence" // TODO: implement pretty printing
 }

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrecedenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrecedenceEmbedding.scala
@@ -8,9 +8,7 @@ import parsley.internal.machine.instructions
 import parsley.internal.machine.instructions.{ShuntInput, Atom, Operator}
 import parsley.expr.Prefix
 
-private[deepembedding] case class PrecOperators[A, B](val ops: StrictOps[A, B], val precedence: Int)
-
-private [deepembedding] final class Precedence[A](prefixAtomChoice: StrictParsley[ShuntInput], postfixInfixChoice: StrictParsley[ShuntInput]) extends StrictParsley[A] {
+private [deepembedding] final class Precedence[A](prefixAtomChoice: StrictParsley[ShuntInput], postfixInfixChoice: StrictParsley[ShuntInput], wraps: List[Any => Any]) extends StrictParsley[A] {
   override protected[backend] def codeGen[M[_, +_]: ContOps, R](producesResults: Boolean)(implicit instrs: StrictParsley.InstrBuffer, state: CodeGenState): M[R,Unit] = {
     val prefixAtomLabel = state.freshLabel()
     val postfixInfixLabel = state.freshLabel()
@@ -23,7 +21,7 @@ private [deepembedding] final class Precedence[A](prefixAtomChoice: StrictParsle
       instrs += new instructions.Label(postfixInfixLabel)
       suspend(postfixInfixChoice.codeGen[M, R](producesResults = true)) |> {
         instrs += new instructions.Label(shuntLabel)
-        instrs += new instructions.Shunt(prefixAtomLabel, postfixInfixLabel)
+        instrs += new instructions.Shunt(prefixAtomLabel, postfixInfixLabel, wraps)
       }
     }
   }
@@ -34,11 +32,11 @@ private [deepembedding] final class Precedence[A](prefixAtomChoice: StrictParsle
 }
 
 private [deepembedding] object Precedence {
-  def apply[A](table: StrictPrec[A]): Precedence[A] = {
-    val (prefixAtomOptions, postfixInfixOptions) = buildChoiceOptions(table, 0)
+  def apply[A](table: StrictPrec): Precedence[A] = {
+    val (prefixAtomOptions, postfixInfixOptions) = buildChoiceOptions(table)
     val prefixAtomChoice = buildChoiceNode(prefixAtomOptions)
     val postfixInfixChoice = buildChoiceNode(postfixInfixOptions)
-    new Precedence(prefixAtomChoice, postfixInfixChoice)
+    new Precedence(prefixAtomChoice, postfixInfixChoice, table.wraps)
   }
 
   private def buildChoiceNode[A](options: List[StrictParsley[A]]): StrictParsley[A] = options match {
@@ -48,14 +46,21 @@ private [deepembedding] object Precedence {
     case a :: b :: rest => new Choice(a, b, SinglyLinkedList(rest.head, rest.tail: _*))
   }
 
-  private def buildChoiceOptions(table: StrictPrec[_], lvl: Int): (List[StrictParsley[ShuntInput]], List[StrictParsley[ShuntInput]]) = table match {
-    case StrictPrec.Atoms(atoms) => (atoms.map(a => <*>(new Pure(r => Atom(r)), a)), Nil)
-    case StrictPrec.Level(lower, ops) =>
-      val lowerOptions = buildChoiceOptions(lower, lvl + 1)
-      val opOptions = ops.ops.map(o => <*>(new Pure(r => Operator(r, ops.f, lvl)), o))
-      ops.f match {
-        case Prefix => (lowerOptions._1 ++ opOptions, lowerOptions._2)
-        case _      => (lowerOptions._1, lowerOptions._2 ++ opOptions)
-      }
+  private def buildChoiceOptions(table: StrictPrec): (List[StrictParsley[ShuntInput]], List[StrictParsley[ShuntInput]]) = {
+    return (
+      table.atoms.map(a => <*>(new Pure(r => Atom(r, table.wraps.length)), a)) ++ table.ops.filter(_.fixity == Prefix).map(o => <*>(new Pure(r => Operator(r, o.fixity, o.prec)), o.op)),
+      table.ops.filter(_.fixity != Prefix).map(o => <*>(new Pure(r => Operator(r, o.fixity, o.prec)), o.op))
+    )    
   }
+
+  // private def buildChoiceOptions(table: StrictPrec[_], lvl: Int): (List[StrictParsley[ShuntInput]], List[StrictParsley[ShuntInput]]) = table match {
+  //   case StrictPrec.Atoms(atoms) => (atoms.map(a => <*>(new Pure(r => Atom(r)), a)), Nil)
+  //   case StrictPrec.Level(lower, ops) =>
+  //     val lowerOptions = buildChoiceOptions(lower, lvl + 1)
+  //     val opOptions = ops.ops.map(o => <*>(new Pure(r => Operator(r, ops.f, lvl)), o))
+  //     ops.f match {
+  //       case Prefix => (lowerOptions._1 ++ opOptions, lowerOptions._2)
+  //       case _      => (lowerOptions._1, lowerOptions._2 ++ opOptions)
+  //     }
+  // }
 }

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrecedenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrecedenceEmbedding.scala
@@ -9,6 +9,7 @@ import parsley.internal.machine.instructions.{ShuntInput, Atom, Operator}
 import parsley.expr.Prefix
 import parsley.internal.deepembedding.singletons.Fail
 import parsley.internal.errors.FlexibleCaret
+import parsley.expr.Fixity
 
 private [deepembedding] final class Precedence[A](prefixAtomChoice: StrictParsley[ShuntInput], postfixInfixChoice: StrictParsley[ShuntInput], wraps: Array[Any => Any]) extends StrictParsley[A] {
   override protected[backend] def codeGen[M[_, +_]: ContOps, R](producesResults: Boolean)(implicit instrs: StrictParsley.InstrBuffer, state: CodeGenState): M[R,Unit] = {
@@ -50,8 +51,8 @@ private [deepembedding] object Precedence {
 
   private def buildChoiceOptions(table: StrictPrec): (List[StrictParsley[ShuntInput]], List[StrictParsley[ShuntInput]]) = {
     return (
-      table.atoms.map(a => <*>(new Pure(r => Atom(r, table.wraps.length)), a)) ++ table.ops.filter(_.fixity == Prefix).map(o => <*>(new Pure(r => Operator(r, o.fixity, o.prec)), o.op)),
-      table.ops.filter(_.fixity != Prefix).map(o => <*>(new Pure(r => Operator(r, o.fixity, o.prec)), o.op))
+      table.atoms.map(a => <*>(new Pure(r => Atom(r, table.wraps.length)), a)) ++ table.ops.filter(_.fixity == Prefix).map(o => <*>(new Pure(r => Operator(r, Fixity.ordinal(o.fixity), o.prec)), o.op)),
+      table.ops.filter(_.fixity != Prefix).map(o => <*>(new Pure(r => Operator(r, Fixity.ordinal(o.fixity), o.prec)), o.op))
     )    
   }
 }

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrecedenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrecedenceEmbedding.scala
@@ -51,8 +51,8 @@ private [deepembedding] object Precedence {
 
   private def buildChoiceOptions(table: StrictPrec): (List[StrictParsley[ShuntInput]], List[StrictParsley[ShuntInput]]) = {
     return (
-      table.atoms.map(a => <*>(new Pure(r => Atom(r, table.wraps.length)), a)) ++ table.ops.filter(_.fixity == Prefix).map(o => <*>(new Pure(r => Operator(r, Fixity.ordinal(o.fixity), o.prec)), o.op)),
-      table.ops.filter(_.fixity != Prefix).map(o => <*>(new Pure(r => Operator(r, Fixity.ordinal(o.fixity), o.prec)), o.op))
+      table.atoms.map(a => <*>(new Pure(r => Atom(r, table.wraps.length)), a).optimise) ++ table.ops.filter(_.fixity == Prefix).map(o => <*>(new Pure(r => Operator(r, Fixity.ordinal(o.fixity), o.prec)), o.op).optimise),
+      table.ops.filter(_.fixity != Prefix).map(o => <*>(new Pure(r => Operator(r, Fixity.ordinal(o.fixity), o.prec)), o.op).optimise)
     )
   }
 

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrecedenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrecedenceEmbedding.scala
@@ -16,7 +16,7 @@ private [deepembedding] final class Precedence[A](prefixAtomChoice: StrictParsle
     val postfixInfixLabel = state.freshLabel()
     val shuntLabel = state.freshLabel()
     instrs += new instructions.Fresh(instructions.ShuntingYardState.empty)
-    instrs += new instructions.PushHandler(shuntLabel)
+    instrs += new instructions.PushHandlerAndState(shuntLabel)
     instrs += new instructions.Label(prefixAtomLabel)
     suspend(prefixAtomChoice.codeGen[M, R](producesResults = true)) >> {
       instrs += new instructions.Jump(shuntLabel)

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrecedenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/PrecedenceEmbedding.scala
@@ -50,7 +50,7 @@ private [deepembedding] object Precedence {
   }
 
   private def buildChoiceOptions(table: StrictPrec): (List[StrictParsley[ShuntInput]], List[StrictParsley[ShuntInput]]) = (
-    table.atoms.map(a => <*>(new Pure(r => Atom(r, table.wraps.length)), a).optimise) ++ table.ops.filter(_.fixity == Prefix).map(o => <*>(new Pure(r => Operator(r, Fixity.ordinal(o.fixity), o.prec)), o.op).optimise),
+    table.ops.filter(_.fixity == Prefix).map(o => <*>(new Pure(r => Operator(r, Fixity.ordinal(o.fixity), o.prec)), o.op).optimise) ++ table.atoms.map(a => <*>(new Pure(r => Atom(r, table.wraps.length)), a).optimise),
     table.ops.filter(_.fixity != Prefix).map(o => <*>(new Pure(r => Operator(r, Fixity.ordinal(o.fixity), o.prec)), o.op).optimise)
   )
 

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/SelectiveEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/SelectiveEmbedding.scala
@@ -111,5 +111,9 @@ private [deepembedding] final class MapFilter[A, B](val p: StrictParsley[A], pre
 }
 
 private [backend] object Branch {
+    def unapply[A, B, C](p: Branch[A, B, C]): Option[(StrictParsley[Either[A, B]], StrictParsley[A => C], StrictParsley[B => C])] = {
+        Some((p.b, p.p, p.q))
+    }
+    
     val FlipApp = instructions.Lift2[Any, Any => Any, Any]((x, f) => f(x))
 }

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/StrictPrec.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/StrictPrec.scala
@@ -2,6 +2,6 @@ package parsley.internal.deepembedding.backend
 
 import parsley.expr.Fixity
 
-private [parsley] case class StrictPrec(atoms: List[StrictParsley[Any]], ops: List[StrictOp], wraps: Array[(Any => Any, Boolean)])
+private [parsley] case class StrictPrec(atoms: List[StrictParsley[Any]], ops: List[StrictOp], wraps: Array[Any => Any])
 
 private [parsley] case class StrictOp(fixity: Fixity, op: StrictParsley[Any], prec: Int)

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/StrictPrec.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/StrictPrec.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2020 Parsley Contributors <https://github.com/j-mie6/Parsley/graphs/contributors>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 package parsley.internal.deepembedding.backend
 
 import parsley.expr.Fixity

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/StrictPrec.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/StrictPrec.scala
@@ -2,6 +2,6 @@ package parsley.internal.deepembedding.backend
 
 import parsley.expr.Fixity
 
-private [parsley] case class StrictPrec(atoms: List[StrictParsley[Any]], ops: List[StrictOp], wraps: List[Any => Any])
+private [parsley] case class StrictPrec(atoms: List[StrictParsley[Any]], ops: List[StrictOp], wraps: Array[Any => Any])
 
 private [parsley] case class StrictOp(fixity: Fixity, op: StrictParsley[Any], prec: Int)

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/StrictPrec.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/StrictPrec.scala
@@ -2,6 +2,6 @@ package parsley.internal.deepembedding.backend
 
 import parsley.expr.Fixity
 
-private [parsley] case class StrictPrec(atoms: List[StrictParsley[Any]], ops: List[StrictOp], wraps: Array[Any => Any])
+private [parsley] case class StrictPrec(atoms: List[StrictParsley[Any]], ops: List[StrictOp], wraps: Array[(Any => Any, Boolean)])
 
 private [parsley] case class StrictOp(fixity: Fixity, op: StrictParsley[Any], prec: Int)

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/StrictPrec.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/StrictPrec.scala
@@ -1,0 +1,30 @@
+package parsley.internal.deepembedding.backend
+
+import parsley.expr.Fixity
+import scala.annotation.unchecked.uncheckedVariance
+import scala.collection.immutable.Seq
+
+sealed abstract class StrictOps[-A, B] {
+    private [parsley] val f: Fixity
+    private [parsley] val ops: List[StrictParsley[f.Op[A @uncheckedVariance, B]]]
+}
+
+object StrictOps {
+    private [parsley] def apply[A, B](fixity: Fixity)(operators: Seq[StrictParsley[fixity.Op[A, B]]]) = new StrictOps[A, B] {
+    val f: fixity.type = fixity
+    val ops = operators.toList
+  }
+}
+
+sealed trait StrictPrec[+Out]
+
+object StrictPrec {
+  final case class Atoms[A](atoms: List[StrictParsley[A]]) extends StrictPrec[A]
+
+  final case class Level[A, B](
+    lower: StrictPrec[A],
+    ops: StrictOps[A, B]
+  ) extends StrictPrec[B] {
+    type In = A
+  }
+}

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/StrictPrec.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/backend/StrictPrec.scala
@@ -1,30 +1,7 @@
 package parsley.internal.deepembedding.backend
 
 import parsley.expr.Fixity
-import scala.annotation.unchecked.uncheckedVariance
-import scala.collection.immutable.Seq
 
-sealed abstract class StrictOps[-A, B] {
-    private [parsley] val f: Fixity
-    private [parsley] val ops: List[StrictParsley[f.Op[A @uncheckedVariance, B]]]
-}
+private [parsley] case class StrictPrec(atoms: List[StrictParsley[Any]], ops: List[StrictOp], wraps: List[Any => Any])
 
-object StrictOps {
-    private [parsley] def apply[A, B](fixity: Fixity)(operators: Seq[StrictParsley[fixity.Op[A, B]]]) = new StrictOps[A, B] {
-    val f: fixity.type = fixity
-    val ops = operators.toList
-  }
-}
-
-sealed trait StrictPrec[+Out]
-
-object StrictPrec {
-  final case class Atoms[A](atoms: List[StrictParsley[A]]) extends StrictPrec[A]
-
-  final case class Level[A, B](
-    lower: StrictPrec[A],
-    ops: StrictOps[A, B]
-  ) extends StrictPrec[B] {
-    type In = A
-  }
-}
+private [parsley] case class StrictOp(fixity: Fixity, op: StrictParsley[Any], prec: Int)

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/LazyPrec.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/LazyPrec.scala
@@ -16,17 +16,8 @@ object LazyPrec {
   def fromPrec(table: Prec[_], level: Int = 0, accOps: List[LazyOp] = Nil, accWraps: List[Any => Any] = Nil): LazyPrec = table match {
     case Atoms(atom0, atoms @ _*) => LazyPrec((atom0 +: atoms).toList.map(_.internal), accOps, accWraps)
     case Level(lower, ops) => {
-      val newOps = ops.operators.map(op => LazyOp(ops.f, op.internal, level))
+      val newOps = ops.ops.map(op => LazyOp(ops.fixity, op.internal, level))
       fromPrec(lower, level + 1, newOps.toList ++ accOps, accWraps :+ ops.wrap)
     }
   }
-
-  // def fromPrec(table: Prec[_], level: Int = 0): LazyPrec = table match {
-  //   case Atoms(atom0, atoms @ _*) => new LazyPrec((atom0 +: atoms).toList.map(_.internal), Nil, Nil)
-  //   case Level(lower, ops) => {
-  //     val LazyPrec(lowerAtoms, lowerOps, lowerWraps) = fromPrec(lower, level + 1)
-  //     val newOps = ops.operators.map(op => LazyOp(ops.f, op.internal, level))
-  //     new LazyPrec(lowerAtoms, lowerOps ++ newOps, ops.wrap +: lowerWraps)
-  //   }
-  // }
 }

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/LazyPrec.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/LazyPrec.scala
@@ -3,6 +3,7 @@ package parsley.internal.deepembedding.frontend
 import parsley.expr.Fixity
 import parsley.internal.deepembedding.ContOps
 import parsley.internal.deepembedding.ContOps.{ContAdapter}
+import parsley.internal.deepembedding.Traverse.{traverse_ => ltraverse_}
 import parsley.expr.Ops
 import scala.annotation.unchecked.uncheckedVariance
 
@@ -53,7 +54,7 @@ object LazyPrec {
     fAtom: LazyParsley[_] => M[R, B],
     fOp: LazyParsley[_] => M[R, B]
   ): M[R, Unit] = table match {
-    case Atoms(atoms) => TraverseHelper.traverse_[M, R, LazyParsley[_], B](atoms)(fAtom)
-    case Level(lower, lOps) => traverse_[M, R, B](lower)(fAtom, fOp) >> TraverseHelper.traverse_[M, R, LazyParsley[_], B](lOps.ops)(fOp)
+    case Atoms(atoms) => ltraverse_[M, R, LazyParsley[_], B](atoms)(fAtom)
+    case Level(lower, lOps) => traverse_[M, R, B](lower)(fAtom, fOp) >> ltraverse_[M, R, LazyParsley[_], B](lOps.ops)(fOp)
   }
 }

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/LazyPrec.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/LazyPrec.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2020 Parsley Contributors <https://github.com/j-mie6/Parsley/graphs/contributors>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 package parsley.internal.deepembedding.frontend
 
 import scala.annotation.tailrec

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/LazyPrec.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/LazyPrec.scala
@@ -17,7 +17,7 @@ object LazyPrec {
     case Atoms(atom0, atoms @ _*) => LazyPrec((atom0 +: atoms).toList.map(_.internal), accOps, accWraps)
     case Level(lower, ops) => {
       val newOps = ops.ops.map(op => LazyOp(ops.fixity, op.internal, level))
-      fromPrec(lower, level + 1, newOps.toList ++ accOps, accWraps :+ ops.wrap)
+      fromPrec(lower, level + 1, newOps.toList ++ accOps, accWraps :+ ops.wrap.asInstanceOf[Any => Any])
     }
   }
 }

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/LazyPrec.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/LazyPrec.scala
@@ -5,19 +5,28 @@ import scala.annotation.tailrec
 import parsley.expr.Fixity
 import parsley.expr.{Prec, Atoms, Level}
 
-private [parsley] case class LazyPrec(atoms: List[LazyParsley[Any]], ops: List[LazyOp], wraps: List[Any => Any])
-
 private [parsley] case class LazyOp(fixity: Fixity, op: LazyParsley[Any], prec: Int)
 
+private [parsley] case class LazyPrec(atoms: List[LazyParsley[Any]], ops: List[LazyOp], wraps: List[Any => Any])
+
 object LazyPrec {
-  def apply(table: Prec[_]): LazyPrec = fromPrec(table, 0)
+  def apply(table: Prec[_]): LazyPrec = fromPrec(table)
 
   @tailrec
-  def fromPrec(table: Prec[_], level: Int = 0, accAtoms: List[LazyParsley[Any]] = Nil, accOps: List[LazyOp] = Nil, accWraps: List[Any => Any] = Nil): LazyPrec = table match {
-    case Atoms(atom0, atoms @ _*) => LazyPrec((atom0 +: atoms).toList.map(_.internal) ++ accAtoms, accOps, accWraps)
+  def fromPrec(table: Prec[_], level: Int = 0, accOps: List[LazyOp] = Nil, accWraps: List[Any => Any] = Nil): LazyPrec = table match {
+    case Atoms(atom0, atoms @ _*) => LazyPrec((atom0 +: atoms).toList.map(_.internal), accOps, accWraps)
     case Level(lower, ops) => {
       val newOps = ops.operators.map(op => LazyOp(ops.f, op.internal, level))
-      fromPrec(lower, level + 1, accAtoms, accOps ++ newOps, accWraps :+ ops.wrap)
+      fromPrec(lower, level + 1, newOps.toList ++ accOps, accWraps :+ ops.wrap)
     }
   }
+
+  // def fromPrec(table: Prec[_], level: Int = 0): LazyPrec = table match {
+  //   case Atoms(atom0, atoms @ _*) => new LazyPrec((atom0 +: atoms).toList.map(_.internal), Nil, Nil)
+  //   case Level(lower, ops) => {
+  //     val LazyPrec(lowerAtoms, lowerOps, lowerWraps) = fromPrec(lower, level + 1)
+  //     val newOps = ops.operators.map(op => LazyOp(ops.f, op.internal, level))
+  //     new LazyPrec(lowerAtoms, lowerOps ++ newOps, ops.wrap +: lowerWraps)
+  //   }
+  // }
 }

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/LazyPrec.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/LazyPrec.scala
@@ -1,60 +1,21 @@
 package parsley.internal.deepembedding.frontend
 
 import parsley.expr.Fixity
-import parsley.internal.deepembedding.ContOps
-import parsley.internal.deepembedding.ContOps.{ContAdapter}
-import parsley.internal.deepembedding.Traverse.{traverse_ => ltraverse_}
-import parsley.expr.Ops
-import scala.annotation.unchecked.uncheckedVariance
+import parsley.expr.{Prec, Atoms, Level}
 
-sealed abstract class LazyOps[-A, B] {
-  private [parsley] val f: Fixity
-  private [parsley] val ops: List[LazyParsley[f.Op[A @uncheckedVariance, B]]]
-}
+private [parsley] case class LazyPrec(atoms: List[LazyParsley[Any]], ops: List[LazyOp], wraps: List[Any => Any])
 
-object LazyOps {
-  private [parsley] def apply[A, B](fixity: Fixity)(operators: Seq[LazyParsley[fixity.Op[A, B]]]) = new LazyOps[A, B] {
-    val f: fixity.type = fixity
-    val ops = operators.toList
-  }
-
-  private [parsley] def apply[A, B](ops: Ops[A,B]): LazyOps[A, B] = {
-    val o = ops
-    new LazyOps[A, B] {
-      val f: o.f.type = o.f
-      val ops = o.operators.toList.map(_.internal)
-    }
-  }
-}
-
-sealed trait LazyPrec[+Out]
+private [parsley] case class LazyOp(fixity: Fixity, op: LazyParsley[Any], prec: Int)
 
 object LazyPrec {
-  final case class Atoms[A](atoms: List[LazyParsley[A]]) extends LazyPrec[A]
-  
-  final case class Level[A, B](
-    lvls: LazyPrec[A],
-    ops: LazyOps[A, B]
-  ) extends LazyPrec[B] {
-    type In = A
-  }
+  def apply(table: Prec[_]): LazyPrec = fromPrec(table, 0)
 
-  def fromPrec[A](table: parsley.expr.Prec[A]): LazyPrec[A] = {
-    import parsley.expr.{Atoms => PAtoms, Level => PLevel}
-
-    table match {
-      case PAtoms(atom0, atoms @ _*) => Atoms((atom0 +: atoms).toList.map(_.internal))
-      case PLevel(lower, ops) => Level(fromPrec(lower), LazyOps(ops))
+  def fromPrec(table: Prec[_], level: Int = 0): LazyPrec = table match {
+    case Atoms(atom0, atoms @ _*) => new LazyPrec((atom0 +: atoms).toList.map(_.internal), Nil, Nil)
+    case Level(lower, ops) => {
+      val LazyPrec(lowerAtoms, lowerOps, lowerWraps) = fromPrec(lower, level + 1)
+      val newOps = ops.operators.map(op => LazyOp(ops.f, op.internal, level))
+      new LazyPrec(lowerAtoms, lowerOps ++ newOps, ops.wrap +: lowerWraps)
     }
-  }
-
-  def traverse_[M[_, +_]: ContOps, R, B](
-    table: LazyPrec[_]
-  )(
-    fAtom: LazyParsley[_] => M[R, B],
-    fOp: LazyParsley[_] => M[R, B]
-  ): M[R, Unit] = table match {
-    case Atoms(atoms) => ltraverse_[M, R, LazyParsley[_], B](atoms)(fAtom)
-    case Level(lower, lOps) => traverse_[M, R, B](lower)(fAtom, fOp) >> ltraverse_[M, R, LazyParsley[_], B](lOps.ops)(fOp)
   }
 }

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/LazyPrec.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/LazyPrec.scala
@@ -1,0 +1,42 @@
+package parsley.internal.deepembedding.frontend
+
+import parsley.expr.Fixity
+import parsley.internal.deepembedding.ContOps
+import parsley.internal.deepembedding.ContOps.{ContAdapter}
+
+sealed trait LazyPrec[+Out] {
+  type In
+}
+
+object LazyPrec {
+  final case class Atoms[A](atoms: List[LazyParsley[A]]) extends LazyPrec[A] {
+    type In = A
+  }
+  
+  final case class Level[A, B](
+    lower: LazyPrec[A],
+    fixity: Fixity,
+    operators: List[LazyParsley[Fixity#Op[A, B]]]
+  ) extends LazyPrec[B] {
+    type In = A
+  }
+
+  def fromPrec[A](table: parsley.expr.Prec[A]): LazyPrec[A] = {
+    import parsley.expr.{Atoms => PAtoms, Level => PLevel}
+
+    table match {
+      case PAtoms(atom0, atoms @ _*) => Atoms((atom0 +: atoms).toList.map(_.internal))
+      case PLevel(lower, ops) => Level(fromPrec(lower), ops.f, ops.operators.toList.map(_.internal))
+    }
+  }
+
+  def traverse_[M[_, +_]: ContOps, R, B](
+    table: LazyPrec[_]
+  )(
+    fAtom: LazyParsley[_] => M[R, B],
+    fOp: LazyParsley[_] => M[R, B]
+  ): M[R, Unit] = table match {
+    case Atoms(atoms) => TraverseHelper.traverse_[M, R, LazyParsley[_], B](atoms)(fAtom)
+    case Level(lower, _, ops) => traverse_[M, R, B](lower)(fAtom, fOp) >> TraverseHelper.traverse_[M, R, LazyParsley[_], B](ops)(fOp)
+  }
+}

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/LazyPrec.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/LazyPrec.scala
@@ -3,7 +3,7 @@ package parsley.internal.deepembedding.frontend
 import parsley.expr.Fixity
 import parsley.expr.{Prec, Atoms, Level}
 
-private [parsley] case class LazyPrec(atoms: List[LazyParsley[Any]], ops: List[LazyOp], wraps: List[Any => Any])
+private [parsley] case class LazyPrec(atoms: List[LazyParsley[Any]], ops: List[LazyOp], wraps: List[(Any => Any, Boolean)])
 
 private [parsley] case class LazyOp(fixity: Fixity, op: LazyParsley[Any], prec: Int)
 
@@ -15,7 +15,7 @@ object LazyPrec {
     case Level(lower, ops) => {
       val LazyPrec(lowerAtoms, lowerOps, lowerWraps) = fromPrec(lower, level + 1)
       val newOps = ops.operators.map(op => LazyOp(ops.f, op.internal, level))
-      new LazyPrec(lowerAtoms, lowerOps ++ newOps, ops.wrap +: lowerWraps)
+      new LazyPrec(lowerAtoms, lowerOps ++ newOps, (ops.wrap, ops.wrapIsIdentity) +: lowerWraps)
     }
   }
 }

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/LazyPrec.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/LazyPrec.scala
@@ -3,7 +3,7 @@ package parsley.internal.deepembedding.frontend
 import parsley.expr.Fixity
 import parsley.expr.{Prec, Atoms, Level}
 
-private [parsley] case class LazyPrec(atoms: List[LazyParsley[Any]], ops: List[LazyOp], wraps: List[(Any => Any, Boolean)])
+private [parsley] case class LazyPrec(atoms: List[LazyParsley[Any]], ops: List[LazyOp], wraps: List[Any => Any])
 
 private [parsley] case class LazyOp(fixity: Fixity, op: LazyParsley[Any], prec: Int)
 
@@ -15,7 +15,7 @@ object LazyPrec {
     case Level(lower, ops) => {
       val LazyPrec(lowerAtoms, lowerOps, lowerWraps) = fromPrec(lower, level + 1)
       val newOps = ops.operators.map(op => LazyOp(ops.f, op.internal, level))
-      new LazyPrec(lowerAtoms, lowerOps ++ newOps, (ops.wrap, ops.wrapIsIdentity) +: lowerWraps)
+      new LazyPrec(lowerAtoms, lowerOps ++ newOps, ops.wrap +: lowerWraps)
     }
   }
 }

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/LazyPrec.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/LazyPrec.scala
@@ -3,20 +3,37 @@ package parsley.internal.deepembedding.frontend
 import parsley.expr.Fixity
 import parsley.internal.deepembedding.ContOps
 import parsley.internal.deepembedding.ContOps.{ContAdapter}
+import parsley.expr.Ops
+import scala.annotation.unchecked.uncheckedVariance
 
-sealed trait LazyPrec[+Out] {
-  type In
+sealed abstract class LazyOps[-A, B] {
+  private [parsley] val f: Fixity
+  private [parsley] val ops: List[LazyParsley[f.Op[A @uncheckedVariance, B]]]
 }
 
-object LazyPrec {
-  final case class Atoms[A](atoms: List[LazyParsley[A]]) extends LazyPrec[A] {
-    type In = A
+object LazyOps {
+  private [parsley] def apply[A, B](fixity: Fixity)(operators: Seq[LazyParsley[fixity.Op[A, B]]]) = new LazyOps[A, B] {
+    val f: fixity.type = fixity
+    val ops = operators.toList
   }
+
+  private [parsley] def apply[A, B](ops: Ops[A,B]): LazyOps[A, B] = {
+    val o = ops
+    new LazyOps[A, B] {
+      val f: o.f.type = o.f
+      val ops = o.operators.toList.map(_.internal)
+    }
+  }
+}
+
+sealed trait LazyPrec[+Out]
+
+object LazyPrec {
+  final case class Atoms[A](atoms: List[LazyParsley[A]]) extends LazyPrec[A]
   
   final case class Level[A, B](
-    lower: LazyPrec[A],
-    fixity: Fixity,
-    operators: List[LazyParsley[Fixity#Op[A, B]]]
+    lvls: LazyPrec[A],
+    ops: LazyOps[A, B]
   ) extends LazyPrec[B] {
     type In = A
   }
@@ -26,7 +43,7 @@ object LazyPrec {
 
     table match {
       case PAtoms(atom0, atoms @ _*) => Atoms((atom0 +: atoms).toList.map(_.internal))
-      case PLevel(lower, ops) => Level(fromPrec(lower), ops.f, ops.operators.toList.map(_.internal))
+      case PLevel(lower, ops) => Level(fromPrec(lower), LazyOps(ops))
     }
   }
 
@@ -37,6 +54,6 @@ object LazyPrec {
     fOp: LazyParsley[_] => M[R, B]
   ): M[R, Unit] = table match {
     case Atoms(atoms) => TraverseHelper.traverse_[M, R, LazyParsley[_], B](atoms)(fAtom)
-    case Level(lower, _, ops) => traverse_[M, R, B](lower)(fAtom, fOp) >> TraverseHelper.traverse_[M, R, LazyParsley[_], B](ops)(fOp)
+    case Level(lower, lOps) => traverse_[M, R, B](lower)(fAtom, fOp) >> TraverseHelper.traverse_[M, R, LazyParsley[_], B](lOps.ops)(fOp)
   }
 }

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/PrecedenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/PrecedenceEmbedding.scala
@@ -3,32 +3,21 @@ package parsley.internal.deepembedding.frontend
 import parsley.internal.deepembedding.backend, backend.StrictParsley
 import parsley.internal.deepembedding.ContOps
 import parsley.internal.deepembedding.ContOps.{suspend, ContAdapter}
-import parsley.internal.deepembedding.Traverse.{traverse}
-import parsley.internal.deepembedding.frontend.LazyPrec.{Atoms, Level, traverse_ => traversePrec_}
+import parsley.internal.deepembedding.Traverse.{traverse_, traverse}
 
-private [parsley] final class Precedence[A](table: LazyPrec[A]) extends LazyParsley[A] {
-  override protected def findLetsAux[M[_, +_]: ContOps, R](seen: Set[LazyParsley[_]])(implicit state: LetFinderState): M[R,Unit] = {
-    traversePrec_(
-      table
-    )(
-      a => suspend[M, R, Unit](a.findLets(seen)),
-      op => suspend[M, R, Unit](op.findLets(seen))
-    )
-  }
+private [parsley] final class Precedence[A](table: LazyPrec) extends LazyParsley[A] {
+  override protected def findLetsAux[M[_, +_]: ContOps, R](seen: Set[LazyParsley[_]])(implicit state: LetFinderState): M[R,Unit] = 
+    traverse_(table.atoms)(a => suspend[M, R, Unit](a.findLets(seen))) >>
+    traverse_(table.ops)(op => suspend[M, R, Unit](op.op.findLets(seen)))
 
   override protected def preprocess[M[_, +_]: ContOps, R, A_ >: A](implicit lets: LetMap): M[R,StrictParsley[A_]] = for {
-    strictPrec <- buildStrictPrec[M, R, A](table)
-  } yield backend.Precedence(strictPrec)
-
-  private def buildStrictPrec[M[_, +_]: ContOps, R, X](lp: LazyPrec[X])(implicit lets: LetMap): M[R, backend.StrictPrec[X]] = lp match {
-    case Atoms(atoms) => traverse(atoms)(_.optimised[M, R, X]).map(backend.StrictPrec.Atoms(_))
-    case lvl @ Level(lower, lOps) => {
-      type Op = lOps.f.Op[lvl.In, X]
-      for {
-        strictLower <- buildStrictPrec(lower)
-        strictOps <- traverse(lOps.ops.asInstanceOf[List[LazyParsley[Op]]])(op => suspend(op.optimised[M, R, Op]))
-      } yield backend.StrictPrec.Level(strictLower, backend.StrictOps(lOps.f)(strictOps))
-    }
+    atoms <- traverse(table.atoms)(_.optimised[M, R, Any])
+    ops <- traverse(table.ops)(op => for {
+      strictOp <- suspend(op.op.optimised[M, R, Any])
+    } yield backend.StrictOp(op.fixity, strictOp, op.prec))
+  } yield {
+    val strictPrec = new backend.StrictPrec(atoms, ops, table.wraps)
+    backend.Precedence(strictPrec)
   }
 
   override def visit[T, U[+_]](visitor: LazyParsleyIVisitor[T,U], context: T): U[A] = visitor.visit(this, context)(table)

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/PrecedenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/PrecedenceEmbedding.scala
@@ -22,6 +22,6 @@ private [parsley] final class Precedence[A](table: LazyPrec) extends LazyParsley
 
   override def visit[T, U[+_]](visitor: LazyParsleyIVisitor[T,U], context: T): U[A] = visitor.visit(this, context)(table)
 
-  override private[parsley] var debugName: String = "precedence"
+  private [parsley] var debugName: String = "precedence"
 
 }

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/PrecedenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/PrecedenceEmbedding.scala
@@ -18,7 +18,7 @@ private [parsley] final class Precedence[A](table: LazyPrec[A]) extends LazyPars
 
   override protected def preprocess[M[_, +_]: ContOps, R, A_ >: A](implicit lets: LetMap): M[R,StrictParsley[A_]] = for {
     strictPrec <- buildStrictPrec[M, R, A](table)
-  } yield new backend.Precedence(strictPrec)
+  } yield backend.Precedence(strictPrec)
 
   private def buildStrictPrec[M[_, +_]: ContOps, R, X](lp: LazyPrec[X])(implicit lets: LetMap): M[R, backend.StrictPrec[X]] = lp match {
     case Atoms(atoms) => traverse(atoms)(_.optimised[M, R, X]).map(backend.StrictPrec.Atoms(_))

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/PrecedenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/PrecedenceEmbedding.scala
@@ -2,8 +2,8 @@ package parsley.internal.deepembedding.frontend
 
 import parsley.internal.deepembedding.backend, backend.StrictParsley
 import parsley.internal.deepembedding.ContOps
-import parsley.internal.deepembedding.ContOps.{result, suspend, ContAdapter}
-import parsley.internal.deepembedding.Traverse.{traverse, traverse_}
+import parsley.internal.deepembedding.ContOps.{suspend, ContAdapter}
+import parsley.internal.deepembedding.Traverse.{traverse}
 import parsley.internal.deepembedding.frontend.LazyPrec.{Atoms, Level, traverse_ => traversePrec_}
 
 private [parsley] final class Precedence[A](table: LazyPrec[A]) extends LazyParsley[A] {

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/PrecedenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/PrecedenceEmbedding.scala
@@ -16,7 +16,7 @@ private [parsley] final class Precedence[A](table: LazyPrec) extends LazyParsley
       strictOp <- suspend(op.op.optimised[M, R, Any])
     } yield backend.StrictOp(op.fixity, strictOp, op.prec))
   } yield {
-    val strictPrec = new backend.StrictPrec(atoms, ops, table.wraps)
+    val strictPrec = new backend.StrictPrec(atoms, ops, table.wraps.toArray)
     backend.Precedence(strictPrec)
   }
 

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/PrecedenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/PrecedenceEmbedding.scala
@@ -3,22 +3,8 @@ package parsley.internal.deepembedding.frontend
 import parsley.internal.deepembedding.backend, backend.StrictParsley
 import parsley.internal.deepembedding.ContOps
 import parsley.internal.deepembedding.ContOps.{result, suspend, ContAdapter}
+import parsley.internal.deepembedding.Traverse.{traverse, traverse_}
 import parsley.internal.deepembedding.frontend.LazyPrec.{Atoms, Level, traverse_ => traversePrec_}
-
-object TraverseHelper {
-  def traverse[M[_, +_]: ContOps, R, A, B](xs: List[A])(f: A => M[R, B]): M[R, List[B]] = xs match {
-    case Nil => result(Nil)
-    case x :: xs => for {
-        y <- f(x)
-        ys <- traverse(xs)(f)
-    } yield y :: ys
-  }
-
-  def traverse_[M[_, +_]: ContOps, R, A, B](xs: List[A])(f: A => M[R, B]): M[R, Unit] = xs match {
-    case Nil => result(())
-    case x :: xs => f(x) >> traverse_(xs)(f)
-  }
-}
 
 private [parsley] final class Precedence[A](table: LazyPrec[A]) extends LazyParsley[A] {
   override protected def findLetsAux[M[_, +_]: ContOps, R](seen: Set[LazyParsley[_]])(implicit state: LetFinderState): M[R,Unit] = {
@@ -35,12 +21,12 @@ private [parsley] final class Precedence[A](table: LazyPrec[A]) extends LazyPars
   } yield new backend.Precedence(strictPrec)
 
   private def buildStrictPrec[M[_, +_]: ContOps, R, X](lp: LazyPrec[X])(implicit lets: LetMap): M[R, backend.StrictPrec[X]] = lp match {
-    case Atoms(atoms) => TraverseHelper.traverse(atoms)(_.optimised[M, R, X]).map(backend.StrictPrec.Atoms(_))
+    case Atoms(atoms) => traverse(atoms)(_.optimised[M, R, X]).map(backend.StrictPrec.Atoms(_))
     case lvl @ Level(lower, lOps) => {
       type Op = lOps.f.Op[lvl.In, X]
       for {
         strictLower <- buildStrictPrec(lower)
-        strictOps <- TraverseHelper.traverse(lOps.ops.asInstanceOf[List[LazyParsley[Op]]])(op => suspend(op.optimised[M, R, Op]))
+        strictOps <- traverse(lOps.ops.asInstanceOf[List[LazyParsley[Op]]])(op => suspend(op.optimised[M, R, Op]))
       } yield backend.StrictPrec.Level(strictLower, backend.StrictOps(lOps.f)(strictOps))
     }
   }

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/PrecedenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/PrecedenceEmbedding.scala
@@ -16,7 +16,7 @@ private [parsley] final class Precedence[A](table: LazyPrec) extends LazyParsley
       strictOp <- suspend(op.op.optimised[M, R, Any])
     } yield backend.StrictOp(op.fixity, strictOp, op.prec))
   } yield {
-    val strictPrec = new backend.StrictPrec(atoms, ops, table.wraps.toArray)
+    val strictPrec = backend.StrictPrec(atoms, ops, table.wraps.toArray)
     backend.Precedence(strictPrec)
   }
 

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/PrecedenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/PrecedenceEmbedding.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2020 Parsley Contributors <https://github.com/j-mie6/Parsley/graphs/contributors>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 package parsley.internal.deepembedding.frontend
 
 import parsley.internal.deepembedding.backend, backend.StrictParsley

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/PrecedenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/PrecedenceEmbedding.scala
@@ -1,0 +1,125 @@
+package parsley.internal.deepembedding.frontend
+
+import parsley.internal.deepembedding.backend, backend.StrictParsley
+import parsley.internal.deepembedding.ContOps
+import parsley.internal.deepembedding.ContOps.{result, suspend, ContAdapter}
+import parsley.expr.Fixity
+import parsley.internal.deepembedding.frontend.LazyPrec.Atoms
+import parsley.internal.deepembedding.frontend.LazyPrec.Level
+
+// LazyPrec needs to include an operators table, containing operators (LazyParsleys), their fixity, and precedence
+// It also needs to include an atoms list, with LazyParsley parsers for the atoms
+// final case class LazyOperator[F <: Fixity, A, B](
+//   fixity: F,
+//   precedence: Int,
+//   parser: LazyParsley[F#Op[A, B]]
+// )
+
+// final case class LazyPrec(operators: List[LazyOperator[_, _, _]], atoms: List[LazyParsley[_]])
+
+sealed trait LazyPrec[+Out] {
+  type In
+}
+
+object LazyPrec {
+  final case class Atoms[A](atoms: List[LazyParsley[A]]) extends LazyPrec[A] {
+    type In = A
+  }
+  
+  final case class Level[A, B](
+    lower: LazyPrec[A],
+    fixity: Fixity,
+    operators: List[LazyParsley[Fixity#Op[A, B]]]
+  ) extends LazyPrec[B] {
+    type In = A
+  }
+
+  def fromPrec[A](table: parsley.expr.Prec[A]): LazyPrec[A] = {
+    import parsley.expr.{Atoms => PAtoms, Level => PLevel}
+
+    table match {
+      case PAtoms(atom0, atoms @ _*) => Atoms((atom0 +: atoms).toList.map(_.internal))
+      case PLevel(lower, ops) => Level(fromPrec(lower), ops.f, ops.operators.toList.map(_.internal))
+    }
+  }
+}
+
+
+object TraverseHelper {
+  def traverse[M[_, +_]: ContOps, R, A, B](xs: List[A])(f: A => M[R, B]): M[R, List[B]] = xs match {
+    case Nil => result(Nil)
+    case x :: xs => for {
+        y <- f(x)
+        ys <- traverse(xs)(f)
+    } yield y :: ys
+  }
+
+  def traverse_[M[_, +_]: ContOps, R, A, B](xs: List[A])(f: A => M[R, B]): M[R, Unit] = xs match {
+    case Nil => result(())
+    case x :: xs => f(x) >> traverse_(xs)(f)
+  }
+}
+
+object LazyPrecTraverseHelper {
+  def traverse_[M[_, +_]: ContOps, R, B](
+    table: LazyPrec[_]
+  )(
+    fAtom: LazyParsley[_] => M[R, B],
+    fOp: LazyParsley[_] => M[R, B]
+  ): M[R, Unit] = table match {
+    case Atoms(atoms) => TraverseHelper.traverse_[M, R, LazyParsley[_], B](atoms)(fAtom)
+    case Level(lower, _, ops) => traverse_[M, R, B](lower)(fAtom, fOp) >> TraverseHelper.traverse_[M, R, LazyParsley[_], B](ops)(fOp)
+  }
+}
+
+private [parsley] final class Precedence[A](table: LazyPrec[A]) extends LazyParsley[A] {
+
+  // override protected def findLetsAux[M[_, +_]: ContOps, R](seen: Set[LazyParsley[_]])(implicit state: LetFinderState): M[R,Unit] = {
+  //   TraverseHelper.traverse_(table.atoms)(a => suspend[M, R, Unit](a.findLets(seen))) >>
+  //   TraverseHelper.traverse_(table.operators)(op => suspend[M, R, Unit](op.parser.findLets(seen)))
+  // }
+
+  // override protected def preprocess[M[_, +_]: ContOps, R, A_ >: A](implicit lets: LetMap): M[R,StrictParsley[A_]] = {
+  //   for {
+  //     atoms <- TraverseHelper.traverse[M, R, LazyParsley[_], StrictParsley[_]](table.atoms)(_.optimised[M, R, Any])
+  //     ops <- TraverseHelper.traverse[M, R, LazyOperator[_, _], backend.StrictOperator[_, _]](table.operators) { op =>
+  //       for { 
+  //         p <- op.parser.optimised[M, R, op.fixity.Op[_, _]]
+  //       } yield new backend.StrictOperator[op.fixity.Op[_, _], op.fixity.Op[_, _]] {
+  //         val fixity = op.fixity
+  //         val precedence = op.precedence
+  //         val parser: StrictParsley[op.fixity.Op[_, _]] = p
+  //       }
+  //     }
+  //   } yield new backend.Precedence(new backend.StrictPrec(ops, atoms))
+  // }
+
+  override protected def findLetsAux[M[_, +_]: ContOps, R](seen: Set[LazyParsley[_]])(implicit state: LetFinderState): M[R,Unit] = {
+    LazyPrecTraverseHelper.traverse_(
+      table
+    )(
+      a => suspend[M, R, Unit](a.findLets(seen)),
+      op => suspend[M, R, Unit](op.findLets(seen))
+    )
+  }
+
+  override protected def preprocess[M[_, +_]: ContOps, R, A_ >: A](implicit lets: LetMap): M[R,StrictParsley[A_]] = for {
+    strictPrec <- buildStrictPrec[M, R, A](table)
+  } yield new backend.Precedence(strictPrec)
+
+  private def buildStrictPrec[M[_, +_]: ContOps, R, X](lp: LazyPrec[X])(implicit lets: LetMap): M[R, backend.StrictPrec[X]] = lp match {
+    case Atoms(atoms) => TraverseHelper.traverse(atoms)(_.optimised[M, R, X]).map(backend.StrictPrec.Atoms(_))
+    case lvl @ Level(lower, fixity, ops) => {
+      type Op = fixity.Op[lvl.In, X]
+      for {
+        strictLower <- buildStrictPrec(lower)
+        strictOps <- TraverseHelper.traverse(ops.asInstanceOf[List[LazyParsley[Op]]])(op => suspend(op.optimised[M, R, Op]))
+      } yield backend.StrictPrec.Level(strictLower, fixity, strictOps)
+    }
+  }
+
+  override def visit[T, U[+_]](visitor: LazyParsleyIVisitor[T,U], context: T): U[A] = visitor.visit(this, context)(table)
+
+  override private[parsley] var debugName: String = "precedence"
+
+}

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/PrecedenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/PrecedenceEmbedding.scala
@@ -21,27 +21,6 @@ object TraverseHelper {
 }
 
 private [parsley] final class Precedence[A](table: LazyPrec[A]) extends LazyParsley[A] {
-
-  // override protected def findLetsAux[M[_, +_]: ContOps, R](seen: Set[LazyParsley[_]])(implicit state: LetFinderState): M[R,Unit] = {
-  //   TraverseHelper.traverse_(table.atoms)(a => suspend[M, R, Unit](a.findLets(seen))) >>
-  //   TraverseHelper.traverse_(table.operators)(op => suspend[M, R, Unit](op.parser.findLets(seen)))
-  // }
-
-  // override protected def preprocess[M[_, +_]: ContOps, R, A_ >: A](implicit lets: LetMap): M[R,StrictParsley[A_]] = {
-  //   for {
-  //     atoms <- TraverseHelper.traverse[M, R, LazyParsley[_], StrictParsley[_]](table.atoms)(_.optimised[M, R, Any])
-  //     ops <- TraverseHelper.traverse[M, R, LazyOperator[_, _], backend.StrictOperator[_, _]](table.operators) { op =>
-  //       for { 
-  //         p <- op.parser.optimised[M, R, op.fixity.Op[_, _]]
-  //       } yield new backend.StrictOperator[op.fixity.Op[_, _], op.fixity.Op[_, _]] {
-  //         val fixity = op.fixity
-  //         val precedence = op.precedence
-  //         val parser: StrictParsley[op.fixity.Op[_, _]] = p
-  //       }
-  //     }
-  //   } yield new backend.Precedence(new backend.StrictPrec(ops, atoms))
-  // }
-
   override protected def findLetsAux[M[_, +_]: ContOps, R](seen: Set[LazyParsley[_]])(implicit state: LetFinderState): M[R,Unit] = {
     traversePrec_(
       table
@@ -57,12 +36,12 @@ private [parsley] final class Precedence[A](table: LazyPrec[A]) extends LazyPars
 
   private def buildStrictPrec[M[_, +_]: ContOps, R, X](lp: LazyPrec[X])(implicit lets: LetMap): M[R, backend.StrictPrec[X]] = lp match {
     case Atoms(atoms) => TraverseHelper.traverse(atoms)(_.optimised[M, R, X]).map(backend.StrictPrec.Atoms(_))
-    case lvl @ Level(lower, fixity, ops) => {
-      type Op = fixity.Op[lvl.In, X]
+    case lvl @ Level(lower, lOps) => {
+      type Op = lOps.f.Op[lvl.In, X]
       for {
         strictLower <- buildStrictPrec(lower)
-        strictOps <- TraverseHelper.traverse(ops.asInstanceOf[List[LazyParsley[Op]]])(op => suspend(op.optimised[M, R, Op]))
-      } yield backend.StrictPrec.Level(strictLower, fixity, strictOps)
+        strictOps <- TraverseHelper.traverse(lOps.ops.asInstanceOf[List[LazyParsley[Op]]])(op => suspend(op.optimised[M, R, Op]))
+      } yield backend.StrictPrec.Level(strictLower, backend.StrictOps(lOps.f)(strictOps))
     }
   }
 

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/PrecedenceEmbedding.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/PrecedenceEmbedding.scala
@@ -3,47 +3,7 @@ package parsley.internal.deepembedding.frontend
 import parsley.internal.deepembedding.backend, backend.StrictParsley
 import parsley.internal.deepembedding.ContOps
 import parsley.internal.deepembedding.ContOps.{result, suspend, ContAdapter}
-import parsley.expr.Fixity
-import parsley.internal.deepembedding.frontend.LazyPrec.Atoms
-import parsley.internal.deepembedding.frontend.LazyPrec.Level
-
-// LazyPrec needs to include an operators table, containing operators (LazyParsleys), their fixity, and precedence
-// It also needs to include an atoms list, with LazyParsley parsers for the atoms
-// final case class LazyOperator[F <: Fixity, A, B](
-//   fixity: F,
-//   precedence: Int,
-//   parser: LazyParsley[F#Op[A, B]]
-// )
-
-// final case class LazyPrec(operators: List[LazyOperator[_, _, _]], atoms: List[LazyParsley[_]])
-
-sealed trait LazyPrec[+Out] {
-  type In
-}
-
-object LazyPrec {
-  final case class Atoms[A](atoms: List[LazyParsley[A]]) extends LazyPrec[A] {
-    type In = A
-  }
-  
-  final case class Level[A, B](
-    lower: LazyPrec[A],
-    fixity: Fixity,
-    operators: List[LazyParsley[Fixity#Op[A, B]]]
-  ) extends LazyPrec[B] {
-    type In = A
-  }
-
-  def fromPrec[A](table: parsley.expr.Prec[A]): LazyPrec[A] = {
-    import parsley.expr.{Atoms => PAtoms, Level => PLevel}
-
-    table match {
-      case PAtoms(atom0, atoms @ _*) => Atoms((atom0 +: atoms).toList.map(_.internal))
-      case PLevel(lower, ops) => Level(fromPrec(lower), ops.f, ops.operators.toList.map(_.internal))
-    }
-  }
-}
-
+import parsley.internal.deepembedding.frontend.LazyPrec.{Atoms, Level, traverse_ => traversePrec_}
 
 object TraverseHelper {
   def traverse[M[_, +_]: ContOps, R, A, B](xs: List[A])(f: A => M[R, B]): M[R, List[B]] = xs match {
@@ -57,18 +17,6 @@ object TraverseHelper {
   def traverse_[M[_, +_]: ContOps, R, A, B](xs: List[A])(f: A => M[R, B]): M[R, Unit] = xs match {
     case Nil => result(())
     case x :: xs => f(x) >> traverse_(xs)(f)
-  }
-}
-
-object LazyPrecTraverseHelper {
-  def traverse_[M[_, +_]: ContOps, R, B](
-    table: LazyPrec[_]
-  )(
-    fAtom: LazyParsley[_] => M[R, B],
-    fOp: LazyParsley[_] => M[R, B]
-  ): M[R, Unit] = table match {
-    case Atoms(atoms) => TraverseHelper.traverse_[M, R, LazyParsley[_], B](atoms)(fAtom)
-    case Level(lower, _, ops) => traverse_[M, R, B](lower)(fAtom, fOp) >> TraverseHelper.traverse_[M, R, LazyParsley[_], B](ops)(fOp)
   }
 }
 
@@ -95,7 +43,7 @@ private [parsley] final class Precedence[A](table: LazyPrec[A]) extends LazyPars
   // }
 
   override protected def findLetsAux[M[_, +_]: ContOps, R](seen: Set[LazyParsley[_]])(implicit state: LetFinderState): M[R,Unit] = {
-    LazyPrecTraverseHelper.traverse_(
+    traversePrec_(
       table
     )(
       a => suspend[M, R, Unit](a.findLets(seen)),

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/Visitors.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/Visitors.scala
@@ -123,6 +123,9 @@ private [parsley] abstract class LazyParsleyIVisitor[-T, +U[+_]] { // scalastyle
     def visit[A, C](self: ManyTill[A, C], context: T)(init: LazyParsley[mutable.Builder[A, C]], body: LazyParsley[Any]): U[C]
     def visit(self: SkipManyUntil, context: T)(body: LazyParsley[Any]): U[Unit]
 
+    // Precedence parser visitor.
+    def visit[A](self: Precedence[A], context: T)(table: LazyPrec[A]): U[A]
+
     // Error parser visitors.
     def visit[A](self: ErrorLabel[A], context: T)(p: LazyParsley[A], label: String, labels: Seq[String]): U[A]
     def visit[A](self: ErrorHide[A], context: T)(p: LazyParsley[A]): U[A]

--- a/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/Visitors.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/deepembedding/frontend/Visitors.scala
@@ -124,7 +124,7 @@ private [parsley] abstract class LazyParsleyIVisitor[-T, +U[+_]] { // scalastyle
     def visit(self: SkipManyUntil, context: T)(body: LazyParsley[Any]): U[Unit]
 
     // Precedence parser visitor.
-    def visit[A](self: Precedence[A], context: T)(table: LazyPrec[A]): U[A]
+    def visit[A](self: Precedence[A], context: T)(table: LazyPrec): U[A]
 
     // Error parser visitors.
     def visit[A](self: ErrorLabel[A], context: T)(p: LazyParsley[A], label: String, labels: Seq[String]): U[A]

--- a/parsley/shared/src/main/scala/parsley/internal/machine/Context.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/Context.scala
@@ -35,7 +35,6 @@ private [parsley] final class Context(private [machine] var instrs: Array[Instr]
     private var calls: CallStack = Stack.empty
     /** State stack consisting of offsets and positions that can be rolled back */
     private [machine] var states: StateStack = Stack.empty
-    /** Stack consisting of offsets at previous checkpoints, which may query to test for consumed input */
     /** Current operational status of the machine */
     private [machine] var good: Boolean = true
     private [machine] var running: Boolean = true
@@ -126,7 +125,7 @@ private [parsley] final class Context(private [machine] var instrs: Array[Instr]
 
     private [parsley] def run[Err: ErrorBuilder, A](): Result[Err, A] = go[Err, A]()
     @tailrec private def go[Err: ErrorBuilder, A](): Result[Err, A] = {
-        //println(pretty)
+        // println(pretty)
         if (running) { // this is the likeliest branch, so should be executed with fewest comparisons
             instrs(pc)(this)
             go[Err, A]()

--- a/parsley/shared/src/main/scala/parsley/internal/machine/instructions/CoreInstrs.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/instructions/CoreInstrs.scala
@@ -181,7 +181,7 @@ private [internal] final class PushHandlerAndStateAndClearHints(var label: Int) 
         ctx.inc()
     }
     // $COVERAGE-OFF$
-    override def toString: String = s"PushHandlerAndStateAmdClearHints($label)"
+    override def toString: String = s"PushHandlerAndStateAndClearHints($label)"
     // $COVERAGE-ON$
 }
 

--- a/parsley/shared/src/main/scala/parsley/internal/machine/instructions/IntrinsicInstrs.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/instructions/IntrinsicInstrs.scala
@@ -152,7 +152,7 @@ private [internal] final class UniSat(f: Int => Boolean, expected: Iterable[Expe
         else ctx.expectedFail(expected, unexpectedWidth = 1)
     }
     // $COVERAGE-OFF$
-    override def toString: String = "UniSat(?)"
+    override def toString: String = "UniSat(?(_))"
     // $COVERAGE-ON$
 }
 

--- a/parsley/shared/src/main/scala/parsley/internal/machine/instructions/OptInstrs.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/instructions/OptInstrs.scala
@@ -136,7 +136,10 @@ private [internal] final class JumpTable(jumpTable: List[Either[mutable.Map[Char
         defaultPreamble = default - 1
         jumpTableFuncs = jumpTable.map {
             case Left(map) => map.toMap
-            case Right(predDef) => { case c if predDef.pred(c) => predDef.labelErrors }
+            case Right(predDef) => {
+                val pf: PartialFunction[Char, (Int, Iterable[ExpectItem])] = { case c: Char if predDef.pred(c) => predDef.labelErrors }
+                pf
+            }
         }
         this
     }

--- a/parsley/shared/src/main/scala/parsley/internal/machine/instructions/OptInstrs.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/instructions/OptInstrs.scala
@@ -144,7 +144,7 @@ private [parsley] final class JumpTable(jumpTable: List[Either[mutable.Map[Char,
 
     private def tableToString: String = jumpTable.map(group => group match {
         case Left(map) => s"${map.toList.sortBy{case (_, (l, _)) => l}.map{case (k, v) => s"${k.toChar} -> ${v._1}"}.mkString(", ")}"
-        case Right(predDef) => s"?(c) -> ${predDef.labelErrors._1}"
+        case Right(predDef) => s"?(_) -> ${predDef.labelErrors._1}"
     }).mkString(", ")
     // $COVERAGE-OFF$
     override def toString: String = s"JumpTable(${tableToString}, _ -> $default, $merge)"

--- a/parsley/shared/src/main/scala/parsley/internal/machine/instructions/PrimitiveInstrs.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/instructions/PrimitiveInstrs.scala
@@ -19,7 +19,7 @@ private [internal] final class Satisfies(f: Char => Boolean, expected: Iterable[
         else ctx.expectedFail(expected, unexpectedWidth = 1)
     }
     // $COVERAGE-OFF$
-    override def toString: String = "Sat(?)"
+    override def toString: String = "Sat(?(_))"
     // $COVERAGE-ON$
 }
 

--- a/parsley/shared/src/main/scala/parsley/internal/machine/instructions/ShuntInstrs.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/instructions/ShuntInstrs.scala
@@ -4,7 +4,6 @@ import scala.collection.mutable
 
 import parsley.internal.machine.Context
 import parsley.expr.{Fixity, Prefix, InfixL, InfixR, InfixN, Postfix}
-import parsley.internal.errors.FlexibleCaret
 
 private [internal] sealed trait ShuntInput
 
@@ -60,7 +59,7 @@ private [internal] final class Shunt(var prefixAtomLabel: Int, var postfixInfixL
               val currentOffset = ctx.offset
               ctx.restoreState()
               ctx.handlers = ctx.handlers.tail
-              ctx.failWithMessage(new FlexibleCaret(currentOffset-ctx.offset) , "Non-associative operator cannot be chained") // needs to be token length
+              ctx.expectedFailWithReason(Nil, "Operator cannot be applied in sequence as it is non-associative", currentOffset-ctx.offset)
               return
             }
             state.operators.push(o)

--- a/parsley/shared/src/main/scala/parsley/internal/machine/instructions/ShuntInstrs.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/instructions/ShuntInstrs.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2020 Parsley Contributors <https://github.com/j-mie6/Parsley/graphs/contributors>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 package parsley.internal.machine.instructions
 
 import parsley.XAssert._

--- a/parsley/shared/src/main/scala/parsley/internal/machine/instructions/ShuntInstrs.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/instructions/ShuntInstrs.scala
@@ -2,14 +2,25 @@ package parsley.internal.machine.instructions
 
 import parsley.XAssert._
 import parsley.internal.machine.Context
-import parsley.expr.Fixity.{PR, PO, IL, IR, IN}
+import parsley.expr.Fixity.{PrefixTag, PostfixTag, InfixLTag, InfixRTag, InfixNTag}
 import scala.annotation.switch
 import parsley.internal.machine.stacks.ArrayStack
 
-private [internal] sealed trait ShuntInput
+private [internal] sealed trait ShuntInput {
+  val tag: Int
+}
 
-private [internal] case class Atom(v: Any, lvl: Int) extends ShuntInput
-private [internal] case class Operator(f: Any, fix: Int, prec: Int) extends ShuntInput
+private [internal] case class Atom(v: Any, lvl: Int) extends ShuntInput {
+  override val tag: Int = ShuntInput.AtomTag
+}
+private [internal] case class Operator(f: Any, fix: Int, prec: Int) extends ShuntInput {
+  override val tag: Int = ShuntInput.OperatorTag
+}
+
+object ShuntInput {
+  val AtomTag = 0
+  val OperatorTag = 1
+}
 
 private [internal] case class ShuntingYardState(
   atoms: ArrayStack[Atom],
@@ -26,84 +37,95 @@ private [internal] final class Shunt(var prefixAtomLabel: Int, var postfixInfixL
     if (ctx.good) {
       val input = ctx.stack.pop[ShuntInput]()
       val state = ctx.stack.peek[ShuntingYardState]
-      
       // println("State: " + state)
-
       ctx.updateCheckOffset()
-      
-      input match {
-        case a@Atom(_, _) =>
-          state.atoms.push(a)
-          gotoPostInfix(ctx, state)
-        case o@Operator(_, fix, prec) => (fix: @switch) match {
-          case PR => {
-            if (!state.operators.isEmpty && prec < state.operators.peek.prec) {
-              // This is a malformed expression
-              val currentOffset = ctx.offset
-              ctx.restoreState()
-              ctx.handlers = ctx.handlers.tail
-              ctx.expectedFail(Nil, currentOffset-ctx.offset)
-              return
-            }
-            state.operators.push(o)
-            gotoPreAtom(ctx, state)
-          }
-          case PO => {
-            if (!state.operators.isEmpty && state.operators.peek.fix == PO && prec > state.operators.peek.prec) {
-              // This was an unexpected postfix operator
-              ctx.restoreState()
-              produceResult(ctx)
-              return
-            }
-            while (!state.operators.isEmpty && state.operators.peek.prec >= prec) {
-              reduce(state)
-            }
-            state.operators.push(o)
-            gotoPostInfix(ctx, state)
-          }
-          case IL => {
-            while (!state.operators.isEmpty && state.operators.peek.prec >= prec) {
-              reduce(state)
-            }
-            state.operators.push(o)
-            gotoPreAtom(ctx, state)
-          }
-          case IR | IN => {
-            while (!state.operators.isEmpty && state.operators.peek.prec > prec) {
-              reduce(state)
-            }
-            if (fix == IN && !state.operators.isEmpty && state.operators.peek.fix == IN && state.operators.peek.prec == prec) {
-              // This is a special case in which non-associative operators are chained
-              val currentOffset = ctx.offset
-              ctx.restoreState()
-              ctx.handlers = ctx.handlers.tail
-              ctx.expectedFailWithReason(Nil, "operator cannot be applied in sequence as it is non-associative", currentOffset-ctx.offset)
-              return
-            }
-            state.operators.push(o)
-            gotoPreAtom(ctx, state)
-          }
+
+      if (input.tag == ShuntInput.AtomTag) handleAtom(ctx, input.asInstanceOf[Atom], state)
+      else {
+        val o@Operator(_, fix, prec) = input.asInstanceOf[Operator]
+        (fix: @switch) match {
+          case PrefixTag => handlePrefixOperator(ctx, o, prec, state)
+          case PostfixTag => handlePostfixOperator(ctx, o, prec, state)
+          case InfixLTag => handleInfixLOperator(ctx, o, prec, state)
+          case InfixRTag | InfixNTag => handleInfixRNOperator(ctx, fix, o, prec, state)
         }
       }
-      updateState(ctx)
+    } else handleBadContext(ctx)
+  }
+
+  def handleAtom(ctx: Context, atom: Atom, state: ShuntingYardState): Unit = {
+    state.atoms.push(atom)
+    gotoPostInfix(ctx, state)
+    updateState(ctx)
+  }
+  
+  def handlePrefixOperator(ctx: Context, o: Operator, prec: Int, state: ShuntingYardState): Unit =
+    if (!state.operators.isEmpty && prec < state.operators.peek.prec) {
+      // This is a malformed expression
+      val currentOffset = ctx.offset
+      ctx.restoreState()
+      ctx.handlers = ctx.handlers.tail
+      ctx.expectedFail(Nil, currentOffset-ctx.offset)
     } else {
-      if (ctx.offset != ctx.handlers.check || ctx.stack.peek[ShuntingYardState].failOnNoConsumed) {
-        // consumed input and/or prefix/atom choice did not match, hard failure
-        ctx.handlers = ctx.handlers.tail
-        popState(ctx)
-        ctx.fail()
-        return
+      state.operators.push(o)
+      gotoPreAtom(ctx, state)
+      updateState(ctx)
+    }
+
+  def handlePostfixOperator(ctx: Context, o: Operator, prec: Int, state: ShuntingYardState): Unit =
+    if (!state.operators.isEmpty && state.operators.peek.fix == PostfixTag && prec > state.operators.peek.prec) {
+      // This was an unexpected postfix operator
+      ctx.restoreState()
+      produceResult(ctx)
+    } else {
+      while (!state.operators.isEmpty && state.operators.peek.prec >= prec) {
+        reduce(state)
       }
+      state.operators.push(o)
+      gotoPostInfix(ctx, state)
+      updateState(ctx)
+    }
+
+  def handleInfixLOperator(ctx: Context, o: Operator, prec: Int, state: ShuntingYardState): Unit = {
+    while (!state.operators.isEmpty && state.operators.peek.prec >= prec) {
+      reduce(state)
+    }
+    state.operators.push(o)
+    gotoPreAtom(ctx, state)
+    updateState(ctx)
+  }
+  def handleInfixRNOperator(ctx: Context, fix: Int, o: Operator, prec: Int, state: ShuntingYardState): Unit = {
+    while (!state.operators.isEmpty && state.operators.peek.prec > prec) {
+      reduce(state)
+    }
+    if (fix == InfixNTag && !state.operators.isEmpty && state.operators.peek.fix == InfixNTag && state.operators.peek.prec == prec) {
+      // This is a special case in which non-associative operators are chained
+      val currentOffset = ctx.offset
+      ctx.restoreState()
+      ctx.handlers = ctx.handlers.tail
+      ctx.expectedFailWithReason(Nil, "operator cannot be applied in sequence as it is non-associative", currentOffset-ctx.offset)
+    } else {
+      state.operators.push(o)
+      gotoPreAtom(ctx, state)
+      updateState(ctx)
+    }
+  }
+  def handleBadContext(ctx: Context): Unit =
+    if (ctx.offset != ctx.handlers.check || ctx.stack.peek[ShuntingYardState].failOnNoConsumed) {
+      // consumed input and/or prefix/atom choice did not match, hard failure
+      ctx.handlers = ctx.handlers.tail
+      popState(ctx)
+      ctx.fail()
+    } else {
       // In this case, there was an error in Choice
       // It is a soft error in which nothing was consumed and we were looking for an infix/postfix
       // we are at the end of the expression
-      
+
       ctx.good = true
       produceResult(ctx)
       popState(ctx)
       ctx.addErrorToHintsAndPop()
     }
-  }
 
   private def gotoPreAtom(ctx: Context, state: ShuntingYardState): Unit = {
     state.failOnNoConsumed = true
@@ -132,25 +154,25 @@ private [internal] final class Shunt(var prefixAtomLabel: Int, var postfixInfixL
   private def reduce(state: ShuntingYardState): Unit = {
     val op = state.operators.pop[Operator]()
     (op.fix: @switch) match {
-      case IL => {
+      case InfixLTag => {
         val right = state.atoms.pop[Atom]()
         val left = state.atoms.pop[Atom]()
         val result = op.f.asInstanceOf[(Any, Any) => Any](wrap(left.lvl, op.prec, left.v), wrap(right.lvl, op.prec + 1, right.v))
         state.atoms.push(Atom(result, op.prec))
       }
-      case IR => {
+      case InfixRTag => {
         val right = state.atoms.pop[Atom]()
         val left = state.atoms.pop[Atom]()
         val result = op.f.asInstanceOf[(Any, Any) => Any](wrap(left.lvl, op.prec + 1, left.v), wrap(right.lvl, op.prec, right.v))
         state.atoms.push(Atom(result, op.prec))
       }
-      case IN => {
+      case InfixNTag => {
         val right = state.atoms.pop[Atom]()
         val left = state.atoms.pop[Atom]()
         val result = op.f.asInstanceOf[(Any, Any) => Any](wrap(left.lvl, op.prec + 1, left.v), wrap(right.lvl, op.prec + 1, right.v))
         state.atoms.push(Atom(result, op.prec))
       }
-      case PO | PR => {
+      case PostfixTag | PrefixTag => {
         val right = state.atoms.pop[Atom]()
         val result = op.f.asInstanceOf[Any => Any](wrap(right.lvl, op.prec, right.v))
         state.atoms.push(Atom(result, op.prec))

--- a/parsley/shared/src/main/scala/parsley/internal/machine/instructions/ShuntInstrs.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/instructions/ShuntInstrs.scala
@@ -59,7 +59,7 @@ private [internal] final class Shunt(var prefixAtomLabel: Int, var postfixInfixL
               val currentOffset = ctx.offset
               ctx.restoreState()
               ctx.handlers = ctx.handlers.tail
-              ctx.expectedFailWithReason(Nil, "Operator cannot be applied in sequence as it is non-associative", currentOffset-ctx.offset)
+              ctx.expectedFailWithReason(Nil, "operator cannot be applied in sequence as it is non-associative", currentOffset-ctx.offset)
               return
             }
             state.operators.push(o)

--- a/parsley/shared/src/main/scala/parsley/internal/machine/instructions/ShuntInstrs.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/instructions/ShuntInstrs.scala
@@ -1,11 +1,10 @@
 package parsley.internal.machine.instructions
 
-import scala.collection.mutable
-
 import parsley.XAssert._
 import parsley.internal.machine.Context
 import parsley.expr.Fixity.{PR, PO, IL, IR, IN}
 import scala.annotation.switch
+import parsley.internal.machine.stacks.ArrayStack
 
 private [internal] sealed trait ShuntInput
 
@@ -13,13 +12,13 @@ private [internal] case class Atom(v: Any, lvl: Int) extends ShuntInput
 private [internal] case class Operator(f: Any, fix: Int, prec: Int) extends ShuntInput
 
 private [internal] case class ShuntingYardState(
-  atoms: mutable.Stack[Atom],
-  operators: mutable.Stack[Operator],
+  atoms: ArrayStack[Atom],
+  operators: ArrayStack[Operator],
   var failOnNoConsumed: Boolean
 )
 
 object ShuntingYardState {
-  def empty = new ShuntingYardState(mutable.Stack.empty, mutable.Stack.empty, true)
+  def empty = new ShuntingYardState(new ArrayStack(), new ArrayStack(), true)
 }
 
 private [internal] final class Shunt(var prefixAtomLabel: Int, var postfixInfixLabel: Int, wraps: Array[Any => Any]) extends Instr {
@@ -35,11 +34,10 @@ private [internal] final class Shunt(var prefixAtomLabel: Int, var postfixInfixL
       input match {
         case a@Atom(_, _) =>
           state.atoms.push(a)
-          state.failOnNoConsumed = false
-          ctx.pc = postfixInfixLabel
+          gotoPostInfix(ctx, state)
         case o@Operator(_, fix, prec) => (fix: @switch) match {
           case PR => {
-            if (state.operators.nonEmpty && prec < state.operators.top.prec) {
+            if (!state.operators.isEmpty && prec < state.operators.peek.prec) {
               // This is a malformed expression
               val currentOffset = ctx.offset
               ctx.restoreState()
@@ -48,36 +46,33 @@ private [internal] final class Shunt(var prefixAtomLabel: Int, var postfixInfixL
               return
             }
             state.operators.push(o)
-            state.failOnNoConsumed = true
-            ctx.pc = prefixAtomLabel
+            gotoPreAtom(ctx, state)
           }
           case PO => {
-            if (state.operators.nonEmpty && state.operators.top.fix == PO && prec > state.operators.top.prec) {
+            if (!state.operators.isEmpty && state.operators.peek.fix == PO && prec > state.operators.peek.prec) {
               // This was an unexpected postfix operator
               ctx.restoreState()
               produceResult(ctx)
               return
             }
-            while (state.operators.nonEmpty && state.operators.top.prec >= prec) {
+            while (!state.operators.isEmpty && state.operators.peek.prec >= prec) {
               reduce(state)
             }
             state.operators.push(o)
-            state.failOnNoConsumed = false
-            ctx.pc = postfixInfixLabel
+            gotoPostInfix(ctx, state)
           }
           case IL => {
-            while (state.operators.nonEmpty && state.operators.top.prec >= prec) {
+            while (!state.operators.isEmpty && state.operators.peek.prec >= prec) {
               reduce(state)
             }
             state.operators.push(o)
-            state.failOnNoConsumed = true
-            ctx.pc = prefixAtomLabel
+            gotoPreAtom(ctx, state)
           }
           case IR | IN => {
-            while (state.operators.nonEmpty && state.operators.top.prec > prec) {
+            while (!state.operators.isEmpty && state.operators.peek.prec > prec) {
               reduce(state)
             }
-            if (fix == IN && state.operators.nonEmpty && state.operators.top.fix == IN && state.operators.top.prec == prec) {
+            if (fix == IN && !state.operators.isEmpty && state.operators.peek.fix == IN && state.operators.peek.prec == prec) {
               // This is a special case in which non-associative operators are chained
               val currentOffset = ctx.offset
               ctx.restoreState()
@@ -86,8 +81,7 @@ private [internal] final class Shunt(var prefixAtomLabel: Int, var postfixInfixL
               return
             }
             state.operators.push(o)
-            state.failOnNoConsumed = true
-            ctx.pc = prefixAtomLabel
+            gotoPreAtom(ctx, state)
           }
         }
       }
@@ -111,43 +105,53 @@ private [internal] final class Shunt(var prefixAtomLabel: Int, var postfixInfixL
     }
   }
 
+  private def gotoPreAtom(ctx: Context, state: ShuntingYardState): Unit = {
+    state.failOnNoConsumed = true
+    ctx.pc = prefixAtomLabel
+  }
+
+  private def gotoPostInfix(ctx: Context, state: ShuntingYardState): Unit = {
+    state.failOnNoConsumed = false
+    ctx.pc = postfixInfixLabel
+  }
+
   private def produceResult(ctx: Context): Unit = {
     val state = ctx.stack.pop[ShuntingYardState]()
     // println("State: " + state)
 
-    while (state.operators.nonEmpty) reduce(state)
+    while (!state.operators.isEmpty) reduce(state)
 
     assume(state.atoms.size == 1, "Expected exactly one atom at the end of reduction")
     
-    val Atom(v, lvl) = state.atoms.pop()
+    val Atom(v, lvl) = state.atoms.pop[Atom]()
     ctx.stack.push(wrap(lvl, 0)(v))
     ctx.handlers = ctx.handlers.tail
     ctx.inc()
   }
 
   private def reduce(state: ShuntingYardState): Unit = {
-    val op = state.operators.pop()
+    val op = state.operators.pop[Operator]()
     (op.fix: @switch) match {
       case IL => {
-        val right = state.atoms.pop()
-        val left = state.atoms.pop()
+        val right = state.atoms.pop[Atom]()
+        val left = state.atoms.pop[Atom]()
         val result = op.f.asInstanceOf[(Any, Any) => Any](wrap(left.lvl, op.prec)(left.v), wrap(right.lvl, op.prec + 1)(right.v))
         state.atoms.push(Atom(result, op.prec))
       }
       case IR => {
-        val right = state.atoms.pop()
-        val left = state.atoms.pop()
+        val right = state.atoms.pop[Atom]()
+        val left = state.atoms.pop[Atom]()
         val result = op.f.asInstanceOf[(Any, Any) => Any](wrap(left.lvl, op.prec + 1)(left.v), wrap(right.lvl, op.prec)(right.v))
         state.atoms.push(Atom(result, op.prec))
       }
       case IN => {
-        val right = state.atoms.pop()
-        val left = state.atoms.pop()
+        val right = state.atoms.pop[Atom]()
+        val left = state.atoms.pop[Atom]()
         val result = op.f.asInstanceOf[(Any, Any) => Any](wrap(left.lvl, op.prec + 1)(left.v), wrap(right.lvl, op.prec + 1)(right.v))
         state.atoms.push(Atom(result, op.prec))
       }
       case PO | PR => {
-        val right = state.atoms.pop()
+        val right = state.atoms.pop[Atom]()
         val result = op.f.asInstanceOf[Any => Any](wrap(right.lvl, op.prec)(right.v))
         state.atoms.push(Atom(result, op.prec))
       }

--- a/parsley/shared/src/main/scala/parsley/internal/machine/instructions/ShuntInstrs.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/instructions/ShuntInstrs.scala
@@ -1,0 +1,127 @@
+package parsley.internal.machine.instructions
+
+import scala.collection.mutable
+
+import parsley.internal.machine.Context
+import parsley.expr.{Fixity, Prefix, InfixL, InfixR, InfixN, Postfix}
+
+private [internal] sealed trait ShuntInput
+
+private [internal] case class Atom(v: Any) extends ShuntInput
+private [internal] case class Operator(f: Any, fix: Fixity, prec: Int) extends ShuntInput
+
+private [internal] case class ShuntingYardState(
+  atoms: mutable.Stack[Either[Operator, Atom]],
+  operators: mutable.Stack[Operator]
+)
+
+object ShuntingYardState {
+  def empty = new ShuntingYardState(mutable.Stack.empty, mutable.Stack.empty)
+}
+
+private [internal] final class Shunt(var label: Int) extends InstrWithLabel {
+  override def apply(ctx: Context): Unit = {
+    if (ctx.good) {
+      // A choice was made and a new "token" is at the top of the stack
+      // This is the body of the for loop in the standard algorithm
+      val input = ctx.stack.pop[ShuntInput]()
+      val state = ctx.stack.peek[ShuntingYardState]
+
+      input match {
+        case a@Atom(_) =>
+          state.atoms.push(Right(a))
+          ctx.inc()
+        case o@Operator(_, fix, prec) => fix match {
+          case Prefix => state.atoms.push(Left(o))
+          case InfixL => {
+            maybeReducePrefixes(prec, state)
+            while (state.operators.nonEmpty && state.operators.top.prec >= prec) {
+              reduce(state)
+            }
+            state.operators.push(o)
+          }
+          case InfixR | InfixN | Postfix => {
+            maybeReducePrefixes(prec, state)
+            while (state.operators.nonEmpty && state.operators.top.prec > prec) {
+              reduce(state)
+            }
+            state.operators.push(o)
+          }
+        }
+      }
+      ctx.updateCheckOffset()
+      ctx.pc = label
+    } else ctx.catchNoConsumed(ctx.handlers.check) {
+      // In this case, there was an error in Choice
+      // It is a soft error in which nothing was consumed so we are at the end of the input
+      val state = ctx.stack.peek[ShuntingYardState]
+      
+      while (state.operators.nonEmpty) reduce(state)
+      forceReducePrefixes(state)
+      
+      if (state.atoms.size != 1) {
+        throw new IllegalStateException("Expected a single result, but got multiple")
+      }
+      popAST(state.atoms) match {
+        case Atom(v) => ctx.stack.exchange(v) // pops the state to clean up, replace with result
+        case _ => throw new IllegalStateException("Expected an atom, but got an operator as the final result")
+      }
+      ctx.handlers = ctx.handlers.tail
+      ctx.addErrorToHintsAndPop()
+      ctx.inc()
+    }
+  }
+
+  private def popAST(atoms: mutable.Stack[Either[Operator, Atom]]): Atom = atoms.pop() match {
+    case Left(_) => throw new IllegalStateException("Expected an atom, but got an operator")
+    case Right(a) => a 
+  }
+
+  private def popPrefix(atoms: mutable.Stack[Either[Operator, Atom]]): Operator = atoms.pop() match {
+    case Left(op) => op.fix match {
+      case Prefix => op
+      case _ => throw new IllegalStateException("Expected a prefix operator, but got an atom")
+    }
+    case Right(_) => throw new IllegalStateException("Expected a prefix operator, but got an atom")
+  }
+
+  private def reduce(state: ShuntingYardState): Unit = {
+    val op = state.operators.pop()
+    op.fix match {
+      case InfixR | InfixL | InfixN => {
+        if (state.atoms.size < 2) throw new IllegalStateException("Not enough operands for infix operator")
+        val right = popAST(state.atoms)
+        val left = popAST(state.atoms)
+        val result = op.f.asInstanceOf[(Any, Any) => Any](left.v, right.v)
+        state.atoms.push(Right(Atom(result)))
+      }
+      case Postfix => {
+        if (state.atoms.isEmpty) throw new IllegalStateException("Not enough operands for postfix operator")
+        val right = popAST(state.atoms)
+        val result = op.f.asInstanceOf[Any => Any](right.v)
+        state.atoms.push(Right(Atom(result)))
+      }
+      case _ => throw new IllegalStateException("Unexpected Prefix in operator stack")
+    }
+  }
+
+  private def maybeReducePrefixes(nextOpPrec: Int, state: ShuntingYardState): Unit = {
+    while (state.atoms.size >= 2 && state.atoms(1).isLeft && state.atoms(1).swap.getOrElse(throw new IllegalStateException("Expected a prefix operator")).prec > nextOpPrec) {
+      val operand = popAST(state.atoms)
+      val prefixOp = popPrefix(state.atoms)
+      val result = prefixOp.f.asInstanceOf[Any => Any](operand.v)
+      state.atoms.push(Right(Atom(result)))
+    }
+  }
+
+  private def forceReducePrefixes(state: ShuntingYardState): Unit = {
+    while (state.atoms.size >= 2 && state.atoms(1).isLeft) {
+        val operand = popAST(state.atoms)
+        val prefixOp = popPrefix(state.atoms)
+        val result = prefixOp.f.asInstanceOf[Any => Any](operand.v)
+        state.atoms.push(Right(Atom(result)))
+      }
+  }
+
+  override def toString(): String = s"Shunt($label)"
+}

--- a/parsley/shared/src/main/scala/parsley/internal/machine/instructions/ShuntInstrs.scala
+++ b/parsley/shared/src/main/scala/parsley/internal/machine/instructions/ShuntInstrs.scala
@@ -20,7 +20,7 @@ object ShuntingYardState {
   def empty = new ShuntingYardState(mutable.Stack.empty, mutable.Stack.empty, true)
 }
 
-private [internal] final class Shunt(var prefixAtomLabel: Int, var postfixInfixLabel: Int, wraps: List[Any => Any]) extends Instr {
+private [internal] final class Shunt(var prefixAtomLabel: Int, var postfixInfixLabel: Int, wraps: Array[Any => Any]) extends Instr {
   override def apply(ctx: Context): Unit = {
     if (ctx.good) {
       val input = ctx.stack.pop[ShuntInput]()

--- a/parsley/shared/src/test/scala/parsley/expr/ExprGen.scala
+++ b/parsley/shared/src/test/scala/parsley/expr/ExprGen.scala
@@ -105,15 +105,15 @@ object ExprGen {
                 fixityGen.flatMap {
                     case fixity@(InfixL | InfixN | InfixR) if infixPool.nonEmpty =>
                         infixOpsDefGen(fixity, infixPool).flatMap {
-                            case (opsDef, remaining) => loop(remaining, prefixPool, postfixPool.empty, acc.appended(opsDef))
+                            case (opsDef, remaining) => loop(remaining, prefixPool, postfixPool.empty, acc :+ opsDef)
                         }
                     case Prefix if prefixPool.nonEmpty =>
                         prefixOpsDefGen(prefixPool).flatMap {
-                            case (opsDef, remaining) => loop(infixPool, remaining, postfixPool, acc.appended(opsDef))
+                            case (opsDef, remaining) => loop(infixPool, remaining, postfixPool, acc :+ opsDef)
                         }
                     case Postfix if postfixPool.nonEmpty =>
                         postfixOpsDefGen(postfixPool).flatMap {
-                            case (opsDef, remaining) => loop(infixPool, prefixPool, remaining, acc.appended(opsDef))
+                            case (opsDef, remaining) => loop(infixPool, prefixPool, remaining, acc :+ opsDef)
                         }
                     case _ => loop(infixPool, prefixPool, postfixPool, acc)
                 }

--- a/parsley/shared/src/test/scala/parsley/expr/ExprGen.scala
+++ b/parsley/shared/src/test/scala/parsley/expr/ExprGen.scala
@@ -4,12 +4,15 @@ import parsley.syntax.character.{stringLift, charLift}
 import parsley.character
 import org.scalacheck.Gen
 import parsley.Parsley
+import parsley.Parsley.atomic
+import parsley.generic.ParserBridge1
+import parsley.generic.ParserBridge2
 
 object ExprGen {
-    private type UnaryOp = (String, Int => Int)
-    private type BinaryOp = (String, (Int, Int) => Int)
+    private type UnaryOp = (Parsley[_], TestExpr => TestExpr)
+    private type BinaryOp = (Parsley[_], (TestExpr, TestExpr) => TestExpr)
 
-    case class OpsDef(fixity: Fixity, ops: List[(String, Any)])
+    case class OpsDef(fixity: Fixity, ops: List[(Parsley[_], Any)])
 
     private val fixityGen: Gen[Fixity] = Gen.oneOf(
         InfixL,
@@ -19,43 +22,76 @@ object ExprGen {
         Postfix
     )
 
+    sealed trait TestExpr
+
+    case class Num(value: Int) extends TestExpr
+
+    case class InfixPlus(x: TestExpr, y: TestExpr) extends TestExpr
+    case class InfixMinus(x: TestExpr, y: TestExpr) extends TestExpr
+    case class InfixMult(x: TestExpr, y: TestExpr) extends TestExpr
+    case class InfixDiv(x: TestExpr, y: TestExpr) extends TestExpr
+    case class InfixEq(x: TestExpr, y: TestExpr) extends TestExpr
+
+    case class PrefixPlus(x: TestExpr) extends TestExpr
+    case class PrefixMinus(x: TestExpr) extends TestExpr
+
+    case class PostfixFactorial(x: TestExpr) extends TestExpr
+    case class PostfixIncrement(x: TestExpr) extends TestExpr
+
+    object Num extends ParserBridge1[Int, TestExpr]
+
+    object InfixPlus extends ParserBridge2[TestExpr, TestExpr, TestExpr]
+    object InfixMinus extends ParserBridge2[TestExpr, TestExpr, TestExpr]
+    object InfixMult extends ParserBridge2[TestExpr, TestExpr, TestExpr]
+    object InfixDiv extends ParserBridge2[TestExpr, TestExpr, TestExpr]
+    object InfixEq extends ParserBridge2[TestExpr, TestExpr, TestExpr]
+
+    object PrefixPlus extends ParserBridge1[TestExpr, TestExpr]
+    object PrefixMinus extends ParserBridge1[TestExpr, TestExpr]
+
+    object PostfixFactorial extends ParserBridge1[TestExpr, TestExpr]
+    object PostfixIncrement extends ParserBridge1[TestExpr, TestExpr]
+
     private val infixOps: Set[BinaryOp] = Set(
-        ("+", (a: Int, b: Int) => a + b),
-        ("-", (a: Int, b: Int) => a - b),
-        ("*", (a: Int, b: Int) => a * b),
-        ("/", (a: Int, b: Int) => if (b == 0) 1 else a / b),
-        ("==", (a: Int, b: Int) => if (a == b) 1 else 0)
+        ("+", InfixPlus(_, _)),
+        ("-", InfixMinus(_, _)),
+        ("*", InfixMult(_, _)),
+        ("/", InfixDiv(_, _)),
+        (atomic("=="), InfixEq(_, _))
     )
 
     private val prefixOps: Set[UnaryOp] = Set(
-        ("+", (a: Int) => a + 1),
-        ("-", (a: Int) => -a)
+        ("+", PrefixPlus(_)),
+        ("-", PrefixMinus(_))
     )
 
     private val postfixOps: Set[UnaryOp] = Set(
-        ("!", (a: Int) => (1 to a).product),
-        ("++", (a: Int) => a + 1) // This will cause ambiguity with infix +
+        ("!", PostfixFactorial(_)),
+        ("$", PostfixIncrement(_))
     )
 
     private def prefixOpsDefGen(availableOps: Set[UnaryOp]): Gen[(OpsDef, Set[UnaryOp])] = for {
-        ops <- Gen.pick(1, availableOps)
+        numOps <- Gen.choose(1, availableOps.size)
+        ops <- Gen.pick(numOps, availableOps)
     } yield {
         (OpsDef(Prefix, ops.toList), availableOps -- ops)
     }
 
     private def postfixOpsDefGen(availableOps: Set[UnaryOp]): Gen[(OpsDef, Set[UnaryOp])] = for {
-        ops <- Gen.pick(1, availableOps)
+        numOps <- Gen.choose(1, availableOps.size)
+        ops <- Gen.pick(numOps, availableOps)
     } yield {
         (OpsDef(Postfix, ops.toList), availableOps -- ops)
     }
 
     private def infixOpsDefGen(fixity: Fixity, availableOps: Set[BinaryOp]): Gen[(OpsDef, Set[BinaryOp])] = for {
-        ops <- Gen.pick(1, availableOps)
+        numOps <- Gen.choose(1, availableOps.size)
+        ops <- Gen.pick(numOps, availableOps)
     } yield {
         (OpsDef(fixity, ops.toList), availableOps -- ops)
     }
 
-    val exprPairGen: Gen[(Parsley[Int], Parsley[Int], List[OpsDef])] = {
+    val exprPairGen: Gen[(Parsley[TestExpr], Parsley[TestExpr], List[OpsDef])] = {
         def loop(infixPool: Set[BinaryOp], prefixPool: Set[UnaryOp], postfixPool: Set[UnaryOp], acc: List[OpsDef]): Gen[List[OpsDef]] = {
             if (infixPool.isEmpty && prefixPool.isEmpty && postfixPool.isEmpty) {
                 Gen.const(acc)
@@ -63,15 +99,15 @@ object ExprGen {
                 fixityGen.flatMap {
                     case fixity@(InfixL | InfixN | InfixR) if infixPool.nonEmpty =>
                         infixOpsDefGen(fixity, infixPool).flatMap {
-                            case (opsDef, remaining) => loop(remaining, prefixPool, postfixPool, opsDef :: acc)
+                            case (opsDef, remaining) => loop(remaining, prefixPool, postfixPool.empty, acc.appended(opsDef))
                         }
                     case Prefix if prefixPool.nonEmpty =>
                         prefixOpsDefGen(prefixPool).flatMap {
-                            case (opsDef, remaining) => loop(infixPool, remaining, postfixPool, opsDef :: acc)
+                            case (opsDef, remaining) => loop(infixPool, remaining, postfixPool, acc.appended(opsDef))
                         }
                     case Postfix if postfixPool.nonEmpty =>
                         postfixOpsDefGen(postfixPool).flatMap {
-                            case (opsDef, remaining) => loop(infixPool, prefixPool, remaining, opsDef :: acc)
+                            case (opsDef, remaining) => loop(infixPool, prefixPool, remaining, acc.appended(opsDef))
                         }
                     case _ => loop(infixPool, prefixPool, postfixPool, acc)
                 }
@@ -82,24 +118,24 @@ object ExprGen {
             opsDefs <- loop(infixOps, prefixOps, postfixOps, Nil)
         } yield {
             val int = character.digit.foldLeft1(0)((n, d) => n * 10 + d.asDigit)
-            lazy val originalAtoms: OriginalPrec[Int] = OriginalAtoms[Int](int, '(' ~> originalExpr <~ ')')
+            lazy val originalAtoms: OriginalPrec[TestExpr] = OriginalAtoms[TestExpr](Num(int), '(' ~> originalExpr <~ ')')
 
-            lazy val originalExpr = originalPrecedence[Int](
+            lazy val originalExpr = originalPrecedence[TestExpr](
                 opsDefs.foldLeft(originalAtoms) {
                     case (acc, OpsDef(fixity, ops)) => {
-                        val opsWithFixity = ops.map { case (s, f) => s as f.asInstanceOf[fixity.Op[Int, Int]] }
+                        val opsWithFixity = ops.map { case (s, f) => s as f.asInstanceOf[fixity.Op[TestExpr, TestExpr]] }
                         val originalOps = OriginalOps(fixity)(opsWithFixity(0), opsWithFixity.tail: _*)
                         acc :+ originalOps
                     }
                 }
             )
 
-            lazy val newAtoms: Prec[Int] = Atoms[Int](int, '(' ~> newExpr <~ ')')
+            lazy val newAtoms: Prec[TestExpr] = Atoms[TestExpr](Num(int), '(' ~> newExpr <~ ')')
 
-            lazy val newExpr = precedence[Int](
+            lazy val newExpr = precedence[TestExpr](
                 opsDefs.foldLeft(newAtoms) {
                     case (acc, OpsDef(fixity, ops)) => {
-                        val opsWithFixity = ops.map { case (s, f) => s as f.asInstanceOf[fixity.Op[Int, Int]] }
+                        val opsWithFixity = ops.map { case (s, f) => s as f.asInstanceOf[fixity.Op[TestExpr, TestExpr]] }
                         val newOps = Ops(fixity)(opsWithFixity(0), opsWithFixity.tail: _*)
                         acc :+ newOps
                     }
@@ -110,43 +146,114 @@ object ExprGen {
         }
     }
 
-    def successInputsGen(opsDefs: List[OpsDef]): Gen[List[String]] = {
-        // currently ignores InfixN possible error case
-        // PRE: opsDefs is not empty
-        if (opsDefs.isEmpty) Gen.fail
+    def inputsGen(
+        opsDefs: List[OpsDef],
+        numInputs: Int,
+        failureRate: Int = 20,
+        invalidCharacters: List[String] = List("@", "#", "$", "%", "^", "~", "`", "\\", "|", ",", "<", ">", "?")
+    ): Gen[List[String]] = {
+        require(opsDefs.nonEmpty, "OpsDefs cannot be empty")
+        require(numInputs > 0, "Number of inputs must be positive")
+        require(failureRate >= 0 && failureRate <= 100, "Failure rate must be between 0 and 100")
         
         val ops = opsDefs.flatMap(opsDef => opsDef.ops.map(op => (op._1, opsDef.fixity)))
         val digits = (0 to 99).map(_.toString)
 
-        def loop(depth: Int): Gen[String] = {
-            if (depth > 4) Gen.oneOf(digits)
-            else {
-                val exprGen = for {
+        def generateValidExpr(depth: Int): Gen[String] = {
+            if (depth > 4) {
+                Gen.oneOf(digits)
+            } else {
+                // Create different types of expressions based on depth
+                val terminalExpr = Gen.oneOf(digits)
+                val operatorExpr = for {
                     op <- Gen.oneOf(ops)
                     expr <- op._2 match {
                         case InfixL | InfixN | InfixR =>
                             for {
-                                left <- loop(depth + 1)
-                                right <- loop(depth + 1)
+                                left <- generateValidExpr(depth + 1)
+                                right <- generateValidExpr(depth + 1)
                             } yield s"$left${op._1}$right"
                         case Prefix =>
                             for {
-                                inner <- loop(depth + 1)
+                                inner <- generateValidExpr(depth + 1)
                             } yield s"${op._1}$inner"
                         case Postfix =>
                             for {
-                                inner <- loop(depth + 1)
+                                inner <- generateValidExpr(depth + 1)
                             } yield s"$inner${op._1}"
                     }
                 } yield expr
-                // val bracketGen = for {
-                //     inner <- loop(depth + 1)
-                // } yield s"($inner)"
-                return Gen.oneOf(exprGen, Gen.oneOf(digits))
+                val bracketedExpr = for {
+                    inner <- generateValidExpr(depth + 1)
+                } yield s"($inner)"
+              
+                Gen.frequency(
+                    (3, operatorExpr),
+                    (2, terminalExpr),
+                    (1, bracketedExpr)
+                )
             }
         }
 
-        // Generate the expression by either choosing an operator (and recursively generating the inputs) or a digit / bracketed sub expression
-        Gen.listOfN(100, loop(0))
+        val mutations: List[String => Gen[String]] = List(
+            // Remove a sequence of characters
+            (s: String) => if (s.isEmpty) Gen.const("") else for {
+                startIdx <- Gen.choose(0, s.length - 1)
+                len <- Gen.choose(1, Math.min(3, s.length - startIdx))
+            } yield s.substring(0, startIdx) + s.substring(startIdx + len),
+
+            // Add invalid characters
+            (s: String) => for {
+                idx <- Gen.choose(0, s.length)
+                numChars <- Gen.choose(1, 3)
+                chars <- Gen.listOfN(numChars, Gen.oneOf(invalidCharacters))
+            } yield s.substring(0, idx) + chars.mkString + s.substring(idx),
+
+            // Replace characters with invalid ones
+            (s: String) => if (s.isEmpty()) Gen.oneOf(invalidCharacters) else for {
+                idx <- Gen.choose(0, s.length - 1)
+                replacementChar <- Gen.oneOf(invalidCharacters)
+            } yield s.substring(0, idx) + replacementChar + s.substring(idx + 1),
+
+            // Add unbalanced parentheses
+            (s: String) => for {
+                idx <- Gen.choose(0, s.length)
+                paren <- Gen.oneOf("(", ")")
+            } yield s.substring(0, idx) + paren + s.substring(idx)
+        )
+
+        def applyRandomMutation(s: String): Gen[String] = Gen.oneOf(mutations).flatMap(mutation => mutation(s))
+
+        def applyMutations(s: String, count: Int): Gen[String] = {
+            if (count <= 0) Gen.const(s)
+            else for {
+                mutated <- applyRandomMutation(s)
+                result <- applyMutations(mutated, count - 1)
+            } yield result
+        }
+
+        def corruptExpression(expr: String): Gen[String] = for {
+            numMutations <- Gen.frequency(
+                (50, Gen.const(1)),
+                (30, Gen.const(2)),
+                (15, Gen.const(3)),
+                (5, Gen.const(4))
+            )
+            result <- applyMutations(expr, numMutations)
+        } yield result
+
+        for {
+            validExprs <- Gen.listOfN(numInputs, generateValidExpr(0))
+
+            result <- Gen.sequence(validExprs.map { expr =>
+                for {
+                    shouldCorrupt <- Gen.frequency(
+                        (100 - failureRate, Gen.const(false)),
+                        (failureRate, Gen.const(true))
+                    )
+                    finalExpr <- if (shouldCorrupt) corruptExpression(expr) else Gen.const(expr)
+                } yield finalExpr
+            })
+        } yield result.toArray.toList.asInstanceOf[List[String]]
     }
 }

--- a/parsley/shared/src/test/scala/parsley/expr/ExprGen.scala
+++ b/parsley/shared/src/test/scala/parsley/expr/ExprGen.scala
@@ -33,8 +33,8 @@ object ExprGen {
     )
 
     private val postfixOps: Set[UnaryOp] = Set(
-        // ("!", (a: Int) => (1 to a).product),
-        // ("++", (a: Int) => a + 1) // This will cause ambiguity with infix +
+        ("!", (a: Int) => (1 to a).product),
+        ("++", (a: Int) => a + 1) // This will cause ambiguity with infix +
     )
 
     private def prefixOpsDefGen(availableOps: Set[UnaryOp]): Gen[(OpsDef, Set[UnaryOp])] = for {

--- a/parsley/shared/src/test/scala/parsley/expr/ExprGen.scala
+++ b/parsley/shared/src/test/scala/parsley/expr/ExprGen.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2020 Parsley Contributors <https://github.com/j-mie6/Parsley/graphs/contributors>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 package parsley.expr
 
 import parsley.syntax.character.{stringLift, charLift}

--- a/parsley/shared/src/test/scala/parsley/expr/ExprGen.scala
+++ b/parsley/shared/src/test/scala/parsley/expr/ExprGen.scala
@@ -9,10 +9,10 @@ import parsley.generic.ParserBridge1
 import parsley.generic.ParserBridge2
 
 object ExprGen {
-    private type UnaryOp = (Parsley[_], TestExpr => TestExpr)
-    private type BinaryOp = (Parsley[_], (TestExpr, TestExpr) => TestExpr)
+    private type UnaryOp = (String, TestExpr => TestExpr)
+    private type BinaryOp = (String, (TestExpr, TestExpr) => TestExpr)
 
-    case class OpsDef(fixity: Fixity, ops: List[(Parsley[_], Any)])
+    case class OpsDef(fixity: Fixity, ops: List[(String, Any)])
 
     private val fixityGen: Gen[Fixity] = Gen.oneOf(
         InfixL,
@@ -57,7 +57,7 @@ object ExprGen {
         ("-", InfixMinus(_, _)),
         ("*", InfixMult(_, _)),
         ("/", InfixDiv(_, _)),
-        (atomic("=="), InfixEq(_, _))
+        ("==", InfixEq(_, _))
     )
 
     private val prefixOps: Set[UnaryOp] = Set(
@@ -132,7 +132,7 @@ object ExprGen {
             lazy val originalExpr = originalPrecedence[TestExpr](
                 opsDefs.foldLeft(originalAtoms) {
                     case (acc, OpsDef(fixity, ops)) => {
-                        val opsWithFixity = ops.map { case (s, f) => s as f.asInstanceOf[fixity.Op[TestExpr, TestExpr]] }
+                        val opsWithFixity = ops.map { case (s, f) => atomic(s) as f.asInstanceOf[fixity.Op[TestExpr, TestExpr]] }
                         val originalOps = OriginalOps(fixity)(opsWithFixity(0), opsWithFixity.tail: _*)
                         acc :+ originalOps
                     }
@@ -144,7 +144,7 @@ object ExprGen {
             lazy val newExpr = precedence[TestExpr](
                 opsDefs.foldLeft(newAtoms) {
                     case (acc, OpsDef(fixity, ops)) => {
-                        val opsWithFixity = ops.map { case (s, f) => s as f.asInstanceOf[fixity.Op[TestExpr, TestExpr]] }
+                        val opsWithFixity = ops.map { case (s, f) => atomic(s) as f.asInstanceOf[fixity.Op[TestExpr, TestExpr]] }
                         val newOps = Ops(fixity)(opsWithFixity(0), opsWithFixity.tail: _*)
                         acc :+ newOps
                     }

--- a/parsley/shared/src/test/scala/parsley/expr/ExprGen.scala
+++ b/parsley/shared/src/test/scala/parsley/expr/ExprGen.scala
@@ -93,7 +93,7 @@ object ExprGen {
 
     val exprPairGen: Gen[(Parsley[TestExpr], Parsley[TestExpr], List[OpsDef])] = {
         def loop(infixPool: Set[BinaryOp], prefixPool: Set[UnaryOp], postfixPool: Set[UnaryOp], acc: List[OpsDef]): Gen[List[OpsDef]] = {
-            if (infixPool.isEmpty && prefixPool.isEmpty && postfixPool.isEmpty) {
+            def continue(): Gen[List[OpsDef]] = if (infixPool.isEmpty && prefixPool.isEmpty && postfixPool.isEmpty) {
                 Gen.const(acc)
             } else {
                 fixityGen.flatMap {
@@ -111,6 +111,15 @@ object ExprGen {
                         }
                     case _ => loop(infixPool, prefixPool, postfixPool, acc)
                 }
+            }
+            
+            if (acc.nonEmpty) {
+                Gen.frequency(
+                    2 -> Gen.const(acc),
+                    3 -> continue()
+                )
+            } else {
+                continue()
             }
         }
 

--- a/parsley/shared/src/test/scala/parsley/expr/ExprGen.scala
+++ b/parsley/shared/src/test/scala/parsley/expr/ExprGen.scala
@@ -1,0 +1,152 @@
+package parsley.expr
+
+import parsley.syntax.character.{stringLift, charLift}
+import parsley.character
+import org.scalacheck.Gen
+import parsley.Parsley
+
+object ExprGen {
+    private type UnaryOp = (String, Int => Int)
+    private type BinaryOp = (String, (Int, Int) => Int)
+
+    case class OpsDef(fixity: Fixity, ops: List[(String, Any)])
+
+    private val fixityGen: Gen[Fixity] = Gen.oneOf(
+        InfixL,
+        InfixN,
+        InfixR,
+        Prefix,
+        Postfix
+    )
+
+    private val infixOps: Set[BinaryOp] = Set(
+        ("+", (a: Int, b: Int) => a + b),
+        ("-", (a: Int, b: Int) => a - b),
+        ("*", (a: Int, b: Int) => a * b),
+        ("/", (a: Int, b: Int) => if (b == 0) 1 else a / b),
+        ("==", (a: Int, b: Int) => if (a == b) 1 else 0)
+    )
+
+    private val prefixOps: Set[UnaryOp] = Set(
+        ("+", (a: Int) => a + 1),
+        ("-", (a: Int) => -a)
+    )
+
+    private val postfixOps: Set[UnaryOp] = Set(
+        // ("!", (a: Int) => (1 to a).product),
+        // ("++", (a: Int) => a + 1) // This will cause ambiguity with infix +
+    )
+
+    private def prefixOpsDefGen(availableOps: Set[UnaryOp]): Gen[(OpsDef, Set[UnaryOp])] = for {
+        ops <- Gen.pick(1, availableOps)
+    } yield {
+        (OpsDef(Prefix, ops.toList), availableOps -- ops)
+    }
+
+    private def postfixOpsDefGen(availableOps: Set[UnaryOp]): Gen[(OpsDef, Set[UnaryOp])] = for {
+        ops <- Gen.pick(1, availableOps)
+    } yield {
+        (OpsDef(Postfix, ops.toList), availableOps -- ops)
+    }
+
+    private def infixOpsDefGen(fixity: Fixity, availableOps: Set[BinaryOp]): Gen[(OpsDef, Set[BinaryOp])] = for {
+        ops <- Gen.pick(1, availableOps)
+    } yield {
+        (OpsDef(fixity, ops.toList), availableOps -- ops)
+    }
+
+    val exprPairGen: Gen[(Parsley[Int], Parsley[Int], List[OpsDef])] = {
+        def loop(infixPool: Set[BinaryOp], prefixPool: Set[UnaryOp], postfixPool: Set[UnaryOp], acc: List[OpsDef]): Gen[List[OpsDef]] = {
+            if (infixPool.isEmpty && prefixPool.isEmpty && postfixPool.isEmpty) {
+                Gen.const(acc)
+            } else {
+                fixityGen.flatMap {
+                    case fixity@(InfixL | InfixN | InfixR) if infixPool.nonEmpty =>
+                        infixOpsDefGen(fixity, infixPool).flatMap {
+                            case (opsDef, remaining) => loop(remaining, prefixPool, postfixPool, opsDef :: acc)
+                        }
+                    case Prefix if prefixPool.nonEmpty =>
+                        prefixOpsDefGen(prefixPool).flatMap {
+                            case (opsDef, remaining) => loop(infixPool, remaining, postfixPool, opsDef :: acc)
+                        }
+                    case Postfix if postfixPool.nonEmpty =>
+                        postfixOpsDefGen(postfixPool).flatMap {
+                            case (opsDef, remaining) => loop(infixPool, prefixPool, remaining, opsDef :: acc)
+                        }
+                    case _ => loop(infixPool, prefixPool, postfixPool, acc)
+                }
+            }
+        }
+
+        for {
+            opsDefs <- loop(infixOps, prefixOps, postfixOps, Nil)
+        } yield {
+            val int = character.digit.foldLeft1(0)((n, d) => n * 10 + d.asDigit)
+            lazy val originalAtoms: OriginalPrec[Int] = OriginalAtoms[Int](int, '(' ~> originalExpr <~ ')')
+
+            lazy val originalExpr = originalPrecedence[Int](
+                opsDefs.foldLeft(originalAtoms) {
+                    case (acc, OpsDef(fixity, ops)) => {
+                        val opsWithFixity = ops.map { case (s, f) => s as f.asInstanceOf[fixity.Op[Int, Int]] }
+                        val originalOps = OriginalOps(fixity)(opsWithFixity(0), opsWithFixity.tail: _*)
+                        acc :+ originalOps
+                    }
+                }
+            )
+
+            lazy val newAtoms: Prec[Int] = Atoms[Int](int, '(' ~> newExpr <~ ')')
+
+            lazy val newExpr = precedence[Int](
+                opsDefs.foldLeft(newAtoms) {
+                    case (acc, OpsDef(fixity, ops)) => {
+                        val opsWithFixity = ops.map { case (s, f) => s as f.asInstanceOf[fixity.Op[Int, Int]] }
+                        val newOps = Ops(fixity)(opsWithFixity(0), opsWithFixity.tail: _*)
+                        acc :+ newOps
+                    }
+                }
+            )
+
+            (originalExpr, newExpr, opsDefs)
+        }
+    }
+
+    def successInputsGen(opsDefs: List[OpsDef]): Gen[List[String]] = {
+        // currently ignores InfixN possible error case
+        // PRE: opsDefs is not empty
+        if (opsDefs.isEmpty) Gen.fail
+        
+        val ops = opsDefs.flatMap(opsDef => opsDef.ops.map(op => (op._1, opsDef.fixity)))
+        val digits = (0 to 99).map(_.toString)
+
+        def loop(depth: Int): Gen[String] = {
+            if (depth > 4) Gen.oneOf(digits)
+            else {
+                val exprGen = for {
+                    op <- Gen.oneOf(ops)
+                    expr <- op._2 match {
+                        case InfixL | InfixN | InfixR =>
+                            for {
+                                left <- loop(depth + 1)
+                                right <- loop(depth + 1)
+                            } yield s"$left${op._1}$right"
+                        case Prefix =>
+                            for {
+                                inner <- loop(depth + 1)
+                            } yield s"${op._1}$inner"
+                        case Postfix =>
+                            for {
+                                inner <- loop(depth + 1)
+                            } yield s"$inner${op._1}"
+                    }
+                } yield expr
+                // val bracketGen = for {
+                //     inner <- loop(depth + 1)
+                // } yield s"($inner)"
+                return Gen.oneOf(exprGen, Gen.oneOf(digits))
+            }
+        }
+
+        // Generate the expression by either choosing an operator (and recursively generating the inputs) or a digit / bracketed sub expression
+        Gen.listOfN(100, loop(0))
+    }
+}

--- a/parsley/shared/src/test/scala/parsley/expr/ExpressionParserTests.scala
+++ b/parsley/shared/src/test/scala/parsley/expr/ExpressionParserTests.scala
@@ -11,8 +11,6 @@ import parsley._
 import parsley.token.{descriptions => desc}
 import parsley.character.digit
 import parsley.syntax.character.{charLift, stringLift}
-import parsley.expr.{chain, infix, mixed}
-import parsley.expr.{precedence, Ops, GOps, SOps, InfixL, InfixR, Prefix, Postfix, InfixN, Atoms}
 import parsley.position._
 import parsley.generic._
 

--- a/parsley/shared/src/test/scala/parsley/expr/ExpressionParserTests.scala
+++ b/parsley/shared/src/test/scala/parsley/expr/ExpressionParserTests.scala
@@ -3,11 +3,12 @@
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
-package parsley
+package parsley.expr
 
 import Predef.{ArrowAssoc => _, _}
 
-import token.{descriptions => desc}
+import parsley._
+import parsley.token.{descriptions => desc}
 import parsley.character.digit
 import parsley.syntax.character.{charLift, stringLift}
 import parsley.expr.{chain, infix, mixed}

--- a/parsley/shared/src/test/scala/parsley/expr/ExpressionSemanticPreservationSpec.scala
+++ b/parsley/shared/src/test/scala/parsley/expr/ExpressionSemanticPreservationSpec.scala
@@ -1,0 +1,38 @@
+package parsley.expr
+
+
+import org.scalatest.matchers._
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
+
+import parsley.syntax.character.charLift
+import parsley.character
+
+class ExpressionSemanticPreservationSpec extends AnyPropSpec with ScalaCheckPropertyChecks with should.Matchers {
+    implicit val config: PropertyCheckConfiguration = new PropertyCheckConfiguration(minSuccessful = 50)
+
+    def compositeAndShuntAreTheSame[A](originalPrec: OriginalPrec[A], newPrec: Prec[A])(input: String) = {
+        val original = originalPrecedence(originalPrec)
+        val shunt = precedence(newPrec)
+        shunt.parse(input) shouldBe original.parse(input)
+    }
+
+    property("successfully parsing basic expressions should not vary based on optimisations") {
+        val originalPrec = OriginalOps[Int](InfixL)('+' #> (_ + _)) +:
+            OriginalOps[Int](InfixL)('*' #> (_ * _)) +:
+            OriginalAtoms[Int](character.digit.map(_.asDigit))
+        val prec = Ops[Int](InfixL)('+' #> (_ + _)) +:
+            Ops[Int](InfixL)('*' #> (_ * _)) +:
+            Atoms[Int](character.digit.map(_.asDigit))
+        
+        val cases: List[String] = List(
+            "1+1",
+            "1*1",
+            "1+2*3",
+        )
+
+        for (input <- cases) {
+            compositeAndShuntAreTheSame(originalPrec, prec)(input)
+        }
+    }
+}

--- a/parsley/shared/src/test/scala/parsley/expr/ExpressionSemanticPreservationSpec.scala
+++ b/parsley/shared/src/test/scala/parsley/expr/ExpressionSemanticPreservationSpec.scala
@@ -4,14 +4,13 @@ import parsley.syntax.character.{charLift, stringLift}
 import parsley.character
 import parsley.Parsley
 import ExprGen._
-import parsley.errors.ErrorBuilder
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
 import parsley.Success
 import parsley.Failure
+import parsley.ParsleyTest
+import parsley.VanillaError
+import parsley.SpecializedError
 
-class ExpressionSemanticPreservationSpec extends AnyFlatSpec with Matchers {
-    implicit val eb: ErrorBuilder[String] = ErrorBuilder.stringError
+class ExpressionSemanticPreservationSpec extends ParsleyTest {
     val originalExpr: Parsley[Int] = originalPrecedence(
         OriginalOps[Int](InfixN)("==" #> ((a, b) => if (a == b) 1 else 0)) +:
         OriginalOps[Int](InfixL)('+' #> (_ + _), '-' #> (_ - _)) +:
@@ -102,6 +101,40 @@ class ExpressionSemanticPreservationSpec extends AnyFlatSpec with Matchers {
                     case Success(_) => originalResult shouldBe newResult
                     case Failure(_) => newResult shouldBe a [Failure[_]]
                 }
+
+                // originalResult match {
+                //     case Success(_) => originalResult shouldBe newResult
+                //     case Failure(originalError) => newResult match {
+                //         case Failure(newError) => {
+                //             originalError.pos shouldBe newError.pos
+                //             originalError.lines match {
+                //                 case VanillaError(unexpected, expecteds, reasons, width) => newError.lines match {
+                //                     case VanillaError(newUnexpected, newExpecteds, newReasons, newWidth) => {
+                //                         if (unexpected != newUnexpected) {
+                //                             println(opsDefs)
+                //                             println(input)
+                //                             println(originalResult)
+                //                             println(newResult)
+                //                         }
+                //                         unexpected shouldBe newUnexpected
+                //                         // expecteds shouldBe newExpecteds
+                //                         reasons shouldBe newReasons
+                //                         width shouldBe newWidth
+                //                     }
+                //                     case _ => fail("Expected VanillaError but got something else")
+                //                 }
+                //                 case SpecializedError(msgs, width) => newError.lines match {
+                //                     case SpecializedError(newMsgs, newWidth) => {
+                //                         msgs shouldBe newMsgs
+                //                         width shouldBe newWidth
+                //                     }
+                //                     case _ => fail("Expected SpecializedError but got something else")
+                //                 }
+                //             }
+                //         }
+                //         case Success(_) => fail("Expected failure but got success")
+                //     }
+                // }
             }
         }
     }

--- a/parsley/shared/src/test/scala/parsley/expr/ExpressionSemanticPreservationSpec.scala
+++ b/parsley/shared/src/test/scala/parsley/expr/ExpressionSemanticPreservationSpec.scala
@@ -91,14 +91,10 @@ class ExpressionSemanticPreservationSpec extends AnyFlatSpec with Matchers {
     }
 
     it should "parse random expressions and not vary based on optimisations" in {
-        for (_ <- 0 until 500) {
+        for (_ <- 0 until 1000) {
             val (originalExpr, newExpr, opsDefs) = exprPairGen.sample.get
-            val successInputs = successInputsGen(opsDefs).sample.get
-            for (input <- successInputs) {
-                println(opsDefs)
-                println(input)
-                println(originalExpr.parse(input))
-                println(newExpr.parse(input))
+            val inputs = inputsGen(opsDefs, 100).sample.get
+            for (input <- inputs) {
                 val originalResult = originalExpr.parse(input)
                 val newResult = newExpr.parse(input)
 
@@ -106,7 +102,6 @@ class ExpressionSemanticPreservationSpec extends AnyFlatSpec with Matchers {
                     case Success(_) => originalResult shouldBe newResult
                     case Failure(_) => newResult shouldBe a [Failure[_]]
                 }
-                // originalExpr.parse(input) shouldBe newExpr.parse(input)
             }
         }
     }

--- a/parsley/shared/src/test/scala/parsley/expr/ExpressionSemanticPreservationSpec.scala
+++ b/parsley/shared/src/test/scala/parsley/expr/ExpressionSemanticPreservationSpec.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2020 Parsley Contributors <https://github.com/j-mie6/Parsley/graphs/contributors>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 package parsley.expr
 
 import parsley.syntax.character.{charLift, stringLift}
@@ -88,6 +93,29 @@ class ExpressionSemanticPreservationSpec extends ParsleyTest {
     }
 
     it should "parse random expressions and not vary based on optimisations" in {
+        // val opsDefsMedium = List(
+        //     OpsDef(InfixL, List(("+", Nil), ("-", Nil))),
+        //     OpsDef(InfixL, List(("*", Nil), ("/", Nil), ("%", Nil))),
+        //     OpsDef(InfixN, List(("==", Nil), ("!=", Nil))),
+        //     OpsDef(Prefix, List(("-", Nil), ("len", Nil), ("ord", Nil)))
+        // )
+
+        // val opsDefsLarge = List(
+        //     OpsDef(InfixR, List(("|", Nil))),
+        //     OpsDef(InfixR, List(("&&", Nil))),
+        //     OpsDef(InfixN, List(("==", Nil), ("!=", Nil))),
+        //     OpsDef(InfixN, List(("<", Nil), (">", Nil), ("<=", Nil), (">=", Nil))),
+        //     OpsDef(InfixL, List(("+", Nil), ("-", Nil))),
+        //     OpsDef(InfixL, List(("*", Nil), ("/", Nil), ("%", Nil))),
+        //     OpsDef(Prefix, List(("!", Nil), ("-", Nil), ("len", Nil), ("ord", Nil), ("chr", Nil)))
+        // )
+
+        // val inputsMedium = inputsGen(opsDefsMedium, 1300, failureRate = 0).sample.get
+        // println(inputsMedium)
+
+        // val inputsLarge = inputsGen(opsDefsLarge, 1400, failureRate = 0).sample.get
+        // println(inputsLarge)
+
         for (_ <- 0 until 5000) {
             val (originalExpr, newExpr, opsDefs) = exprPairGen.sample.get
             val inputs = inputsGen(opsDefs, 500).sample.get

--- a/parsley/shared/src/test/scala/parsley/expr/ExpressionSemanticPreservationSpec.scala
+++ b/parsley/shared/src/test/scala/parsley/expr/ExpressionSemanticPreservationSpec.scala
@@ -93,7 +93,7 @@ class ExpressionSemanticPreservationSpec extends AnyFlatSpec with Matchers {
     it should "parse random expressions and not vary based on optimisations" in {
         for (_ <- 0 until 1000) {
             val (originalExpr, newExpr, opsDefs) = exprPairGen.sample.get
-            val inputs = inputsGen(opsDefs, 100).sample.get
+            val inputs = inputsGen(opsDefs, 500).sample.get
             for (input <- inputs) {
                 val originalResult = originalExpr.parse(input)
                 val newResult = newExpr.parse(input)

--- a/parsley/shared/src/test/scala/parsley/expr/ExpressionSemanticPreservationSpec.scala
+++ b/parsley/shared/src/test/scala/parsley/expr/ExpressionSemanticPreservationSpec.scala
@@ -5,34 +5,88 @@ import org.scalatest.matchers._
 import org.scalatest.propspec.AnyPropSpec
 import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-import parsley.syntax.character.charLift
+import parsley.syntax.character.{charLift, stringLift}
 import parsley.character
+import parsley.Parsley
 
 class ExpressionSemanticPreservationSpec extends AnyPropSpec with ScalaCheckPropertyChecks with should.Matchers {
     implicit val config: PropertyCheckConfiguration = new PropertyCheckConfiguration(minSuccessful = 50)
 
-    def compositeAndShuntAreTheSame[A](originalPrec: OriginalPrec[A], newPrec: Prec[A])(input: String) = {
-        val original = originalPrecedence(originalPrec)
-        val shunt = precedence(newPrec)
-        shunt.parse(input) shouldBe original.parse(input)
+    val originalExpr: Parsley[Int] = originalPrecedence(
+        OriginalOps[Int](InfixN)("==" #> ((a, b) => if (a == b) 1 else 0)) +:
+        OriginalOps[Int](InfixL)('+' #> (_ + _), '-' #> (_ - _)) +:
+        OriginalOps[Int](InfixL)('*' #> (_ * _)) +:
+        OriginalOps[Int](Prefix)('-' #> (-_)) +:
+        OriginalAtoms[Int](character.digit.map(_.asDigit), '(' ~> originalExpr <~ ')')
+    )
+
+    val newExpr: Parsley[Int] = precedence[Int](
+        Ops[Int](InfixN)("==" #> ((a, b) => if (a == b) 1 else 0)) +:
+        Ops[Int](InfixL)('+' #> (_ + _), '-' #> (_ - _)) +:
+        Ops[Int](InfixL)('*' #> (_ * _)) +:
+        Ops[Int](Prefix)('-' #> (-_)) +:
+        Atoms[Int](character.digit.map(_.asDigit), '(' ~> newExpr <~ ')')
+    )
+
+    def compositeAndShuntAreTheSame[A](input: String) = {
+        newExpr.parse(input) shouldBe originalExpr.parse(input)
     }
 
     property("successfully parsing basic expressions should not vary based on optimisations") {
-        val originalPrec = OriginalOps[Int](InfixL)('+' #> (_ + _)) +:
-            OriginalOps[Int](InfixL)('*' #> (_ * _)) +:
-            OriginalAtoms[Int](character.digit.map(_.asDigit))
-        val prec = Ops[Int](InfixL)('+' #> (_ + _)) +:
-            Ops[Int](InfixL)('*' #> (_ * _)) +:
-            Atoms[Int](character.digit.map(_.asDigit))
-        
         val cases: List[String] = List(
             "1+1",
             "1*1",
             "1+2*3",
+            "1+-2"
         )
 
         for (input <- cases) {
-            compositeAndShuntAreTheSame(originalPrec, prec)(input)
+            compositeAndShuntAreTheSame(input)
+        }
+    }
+
+    property("failing to parse basic expressions should not vary based on optimisations") {
+        val cases: List[String] = List(
+            "1+",
+            "1*",
+            "1+2*",
+            "1+2*3+",
+            "1+2*3*",
+            "",
+            "1++2",
+            "+1"
+        )
+
+        for (input <- cases) {
+            compositeAndShuntAreTheSame(input)
+        }
+    }
+
+    property("parsing expressions with parentheses should not vary based on optimisations") {
+        val cases: List[String] = List(
+            "(1+1)",
+            "(1*1)",
+            "(1+2*3)",
+            "(1+-2)",
+            "((1+1))",
+            "((1*1))",
+            "((1+2*3))",
+            "((1+-2))"
+        )
+
+        for (input <- cases) {
+            compositeAndShuntAreTheSame(input)
+        }
+    }
+
+    property("parsing chained non-associative operators should not vary based on optimisations") {
+        val cases: List[String] = List(
+            "1==2==3",
+            "1==2*3==4+5",
+        )
+
+        for (input <- cases) {
+            compositeAndShuntAreTheSame(input)
         }
     }
 }

--- a/parsley/shared/src/test/scala/parsley/expr/ExpressionSemanticPreservationSpec.scala
+++ b/parsley/shared/src/test/scala/parsley/expr/ExpressionSemanticPreservationSpec.scala
@@ -3,7 +3,6 @@ package parsley.expr
 import parsley.syntax.character.{charLift, stringLift}
 import parsley.character
 import parsley.Parsley
-import parsley.ParsleyTest
 import ExprGen._
 import parsley.errors.ErrorBuilder
 import org.scalatest.flatspec.AnyFlatSpec
@@ -92,21 +91,23 @@ class ExpressionSemanticPreservationSpec extends AnyFlatSpec with Matchers {
     }
 
     it should "parse random expressions and not vary based on optimisations" in {
-        val (originalExpr, newExpr, opsDefs) = exprPairGen.sample.get
-        val successInputs = successInputsGen(opsDefs).sample.get
-        for (input <- successInputs) {
-            println(opsDefs)
-            println(input)
-            println(originalExpr.parse(input))
-            println(newExpr.parse(input))
-            val originalResult = originalExpr.parse(input)
-            val newResult = newExpr.parse(input)
+        for (_ <- 0 until 500) {
+            val (originalExpr, newExpr, opsDefs) = exprPairGen.sample.get
+            val successInputs = successInputsGen(opsDefs).sample.get
+            for (input <- successInputs) {
+                println(opsDefs)
+                println(input)
+                println(originalExpr.parse(input))
+                println(newExpr.parse(input))
+                val originalResult = originalExpr.parse(input)
+                val newResult = newExpr.parse(input)
 
-            originalResult match {
-                case Success(_) => originalResult shouldBe newResult
-                case Failure(_) => newResult shouldBe a [Failure[_]]
+                originalResult match {
+                    case Success(_) => originalResult shouldBe newResult
+                    case Failure(_) => newResult shouldBe a [Failure[_]]
+                }
+                // originalExpr.parse(input) shouldBe newExpr.parse(input)
             }
-            // originalExpr.parse(input) shouldBe newExpr.parse(input)
         }
     }
 }

--- a/parsley/shared/src/test/scala/parsley/expr/OriginalLevels.scala
+++ b/parsley/shared/src/test/scala/parsley/expr/OriginalLevels.scala
@@ -1,0 +1,11 @@
+package parsley.expr
+
+import parsley.Parsley
+
+sealed abstract class OriginalPrec[+A] private [expr] {
+    final def :+[Aʹ >: A, B](ops: OriginalOps[Aʹ, B]): OriginalPrec[B] = new OriginalLevel(this, ops)
+    final def +:[Aʹ >: A, B](ops: OriginalOps[Aʹ, B]): OriginalPrec[B] = new OriginalLevel(this, ops)
+}
+private [expr] case class OriginalLevel[A, B](lvls: OriginalPrec[A], ops: OriginalOps[A, B]) extends OriginalPrec[B]
+
+case class OriginalAtoms[+A](atom0: Parsley[A], atoms: Parsley[A]*) extends OriginalPrec[A]

--- a/parsley/shared/src/test/scala/parsley/expr/OriginalLevels.scala
+++ b/parsley/shared/src/test/scala/parsley/expr/OriginalLevels.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2020 Parsley Contributors <https://github.com/j-mie6/Parsley/graphs/contributors>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 package parsley.expr
 
 import parsley.Parsley

--- a/parsley/shared/src/test/scala/parsley/expr/OriginalOps.scala
+++ b/parsley/shared/src/test/scala/parsley/expr/OriginalOps.scala
@@ -1,0 +1,11 @@
+package parsley.expr
+
+import parsley.Parsley
+
+abstract class OriginalOps[-A, B] {
+    private [expr] def chain(p: Parsley[A]): Parsley[B]
+}
+
+object OriginalOps {
+    def apply[A](fixity: Fixity)(op0: Parsley[fixity.Op[A, A]], ops: Parsley[fixity.Op[A, A]]*): OriginalOps[A, A] = OriginalGOps[A, A](fixity)(op0, ops: _*)
+}

--- a/parsley/shared/src/test/scala/parsley/expr/OriginalOps.scala
+++ b/parsley/shared/src/test/scala/parsley/expr/OriginalOps.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2020 Parsley Contributors <https://github.com/j-mie6/Parsley/graphs/contributors>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 package parsley.expr
 
 import parsley.Parsley

--- a/parsley/shared/src/test/scala/parsley/expr/OriginalSmartOps.scala
+++ b/parsley/shared/src/test/scala/parsley/expr/OriginalSmartOps.scala
@@ -1,0 +1,14 @@
+package parsley.expr
+
+import parsley.Parsley
+import parsley.combinator.choice
+
+object OriginalGOps {
+    def apply[A, B](fixity: Fixity)(op0: Parsley[fixity.Op[A, B]], ops: Parsley[fixity.Op[A, B]]*)(implicit wrap: A => B): OriginalOps[A, B] = new OriginalOps[A, B] {
+        private [expr] def chain(p: Parsley[A]): Parsley[B] = fixity.chain(p, choice((op0 +: ops): _*))
+    }
+}
+
+object OriginalSOps {
+    def apply[B, A <: B](fixity: Fixity)(op0: Parsley[fixity.Op[A, B]], ops: Parsley[fixity.Op[A, B]]*): OriginalOps[A, B] = OriginalGOps(fixity)(op0, ops: _*)
+}

--- a/parsley/shared/src/test/scala/parsley/expr/OriginalSmartOps.scala
+++ b/parsley/shared/src/test/scala/parsley/expr/OriginalSmartOps.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2020 Parsley Contributors <https://github.com/j-mie6/Parsley/graphs/contributors>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 package parsley.expr
 
 import parsley.Parsley

--- a/parsley/shared/src/test/scala/parsley/expr/originalPrecedence.scala
+++ b/parsley/shared/src/test/scala/parsley/expr/originalPrecedence.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2020 Parsley Contributors <https://github.com/j-mie6/Parsley/graphs/contributors>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 package parsley.expr
 
 import parsley.Parsley

--- a/parsley/shared/src/test/scala/parsley/expr/originalPrecedence.scala
+++ b/parsley/shared/src/test/scala/parsley/expr/originalPrecedence.scala
@@ -1,0 +1,22 @@
+package parsley.expr
+
+import parsley.Parsley
+import parsley.combinator.choice
+
+object originalPrecedence {
+    def apply[A](atom0: Parsley[A], atoms: Parsley[A]*)(lvlTightest: OriginalOps[A, A], lvls: OriginalOps[A, A]*): Parsley[A] = {
+        apply(lvls.foldLeft[OriginalPrec[A]](new OriginalLevel(OriginalAtoms(atom0, atoms: _*), lvlTightest))(new OriginalLevel(_, _)))
+    }
+
+    def apply[A](lvlWeakest: OriginalOps[A, A], lvls: OriginalOps[A, A]*)(atom0: Parsley[A], atoms: Parsley[A]*): Parsley[A] = {
+        val (lvlTightest +: lvls_) = (lvlWeakest +: lvls).reverse: @unchecked
+        apply(atom0, atoms: _*)(lvlTightest, lvls_ : _*)
+    }
+
+    def apply[A](table: OriginalPrec[A]): Parsley[A] = crushLevels(table)
+
+    private def crushLevels[A](lvls: OriginalPrec[A]): Parsley[A] = lvls match {
+        case OriginalAtoms(atom0, atoms @ _*) => choice((atom0 +: atoms): _*)
+        case OriginalLevel(lvls, ops) => ops.chain(crushLevels(lvls))
+    }
+}

--- a/parsley/shared/src/test/scala/parsley/internal/InternalTests.scala
+++ b/parsley/shared/src/test/scala/parsley/internal/InternalTests.scala
@@ -53,18 +53,18 @@ class InternalTests extends ParsleyTest {
     }
     they should "contain the default in case of no input" in {
         val p = atomicChoice(string("abc"), string("a"), stringOfSome(digit), string("dead"))
-        assume(p.internal.instrs.count(_.isInstanceOf[instructions.JumpTable]) == 1)
+        // assume(p.internal.instrs.count(_.isInstanceOf[instructions.JumpTable]) == 1)
         val q = atomicChoice(string("abc").impure, string("a").impure,
                              stringOfSome(digit).impure, string("dead").impure)
-        assume(q.internal.instrs.count(_.isInstanceOf[instructions.JumpTable]) == 0)
+        // assume(q.internal.instrs.count(_.isInstanceOf[instructions.JumpTable]) == 0)
         p.parse("") shouldBe q.parse("")
     }
     they should "contain the default for mid-points without backtracking" in {
         val p = choice(string("abc"), string("cee"), stringOfSome(digit), string("dead"))
-        assume(p.internal.instrs.count(_.isInstanceOf[instructions.JumpTable]) == 1)
+        // assume(p.internal.instrs.count(_.isInstanceOf[instructions.JumpTable]) == 1)
         val q = choice(string("abc").impure, string("cee").impure,
                        stringOfSome(digit).impure, string("dead").impure)
-        assume(q.internal.instrs.count(_.isInstanceOf[instructions.JumpTable]) == 0)
+        // assume(q.internal.instrs.count(_.isInstanceOf[instructions.JumpTable]) == 0)
         info("parsing 'c'")
         p.parse("c") shouldBe q.parse("c")
         info("parsing 'd'")
@@ -73,9 +73,9 @@ class InternalTests extends ParsleyTest {
     they should "be complete when backtracking is disabled" in {
         val strs = Seq("hello", "hi", "abc", "good", "g")
         val p = choice(strs.map(string): _*)
-        assume(p.internal.instrs.count(_.isInstanceOf[instructions.JumpTable]) == 1)
+        // assume(p.internal.instrs.count(_.isInstanceOf[instructions.JumpTable]) == 1)
         val q = choice(strs.map(s => string(s).impure): _*)
-        assume(q.internal.instrs.count(_.isInstanceOf[instructions.JumpTable]) == 0)
+        // assume(q.internal.instrs.count(_.isInstanceOf[instructions.JumpTable]) == 0)
         info("parsing 'h'")
         p.parse("h") shouldBe q.parse("h")
         info("parsing 'g'")
@@ -85,9 +85,9 @@ class InternalTests extends ParsleyTest {
     }
     they should "merge properly when more input is consumed in a non-backtracking branch" in {
         val p = choice(string("abc"), char('b') *> stringOfSome(digit), string("cde"))
-        assume(p.internal.instrs.count(_.isInstanceOf[instructions.JumpTable]) == 1)
+        // assume(p.internal.instrs.count(_.isInstanceOf[instructions.JumpTable]) == 1)
         val q = choice(string("abc").impure, char('b').impure *> stringOfSome(digit), string("cde").impure)
-        assume(q.internal.instrs.count(_.isInstanceOf[instructions.JumpTable]) == 0)
+        // assume(q.internal.instrs.count(_.isInstanceOf[instructions.JumpTable]) == 0)
         info("parsing nothing")
         p.parse("") shouldBe q.parse("")
         info("parsing 'a'")

--- a/parsley/shared/src/test/scala/parsley/internal/InternalTests.scala
+++ b/parsley/shared/src/test/scala/parsley/internal/InternalTests.scala
@@ -9,7 +9,6 @@ import parsley.{ParsleyTest, Success, Failure, TestError, VanillaError}
 import parsley.Parsley, Parsley._
 import parsley.character.{char, satisfy, digit, string, stringOfSome}
 import parsley.combinator.{atomicChoice, choice, optional}
-import parsley.expr._
 import parsley.syntax.character.charLift
 import parsley.errors.combinator.ErrorMethods
 
@@ -36,22 +35,6 @@ class InternalTests extends ParsleyTest {
         val q = 'a' *> p.label("err1") <* 'b' <* p.label("err1") <* 'c'
         q.internal.instrs.count(_ == instructions.Return) shouldBe 2 //one is in dropped position
         q.parse("a123b123c") should be (Success('3'))
-    }
-
-    they should "work in the precedence parser with one op" in {
-        val atom = some(digit).map(_.mkString.toInt)
-        val expr = precedence[Int](atom)(
-            Ops(InfixL)('+'.as(_ + _)))
-        expr.internal.instrs.count(_ == instructions.Return) shouldBe 1
-    }
-
-    they should "appear frequently inside expression parsers" in {
-        val atom = some(digit).map(_.mkString.toInt)
-        val expr = precedence[Int](atom)(
-            Ops(InfixL)('+'.as(_ + _)),
-            Ops(InfixL)('*'.as(_ * _)),
-            Ops(InfixL)('%'.as(_ % _)))
-        expr.internal.instrs.count(_ == instructions.Return) shouldBe 3
     }
 
     // Issue 118

--- a/parsley/shared/src/test/scala/parsley/internal/deepembedding/frontend/VisitorTests.scala
+++ b/parsley/shared/src/test/scala/parsley/internal/deepembedding/frontend/VisitorTests.scala
@@ -43,6 +43,8 @@ class VisitorTests extends ParsleyTest {
 
             override def visit[A](self: ChainPre[A], context: Unit)(p: LazyParsley[A], op: => LazyParsley[A => A]): ConstUnit[A] = CUnit
 
+            override def visit[A](self: Precedence[A], context: Unit)(table: LazyPrec[A]): ConstUnit[A] = CUnit
+
             override def visitUnknown[A](self: LazyParsley[A], context: Unit): ConstUnit[A] = CUnit
         }
 

--- a/parsley/shared/src/test/scala/parsley/internal/deepembedding/frontend/VisitorTests.scala
+++ b/parsley/shared/src/test/scala/parsley/internal/deepembedding/frontend/VisitorTests.scala
@@ -43,7 +43,7 @@ class VisitorTests extends ParsleyTest {
 
             override def visit[A](self: ChainPre[A], context: Unit)(p: LazyParsley[A], op: => LazyParsley[A => A]): ConstUnit[A] = CUnit
 
-            override def visit[A](self: Precedence[A], context: Unit)(table: LazyPrec[A]): ConstUnit[A] = CUnit
+            override def visit[A](self: Precedence[A], context: Unit)(table: LazyPrec): ConstUnit[A] = CUnit
 
             override def visitUnknown[A](self: LazyParsley[A], context: Unit): ConstUnit[A] = CUnit
         }


### PR DESCRIPTION
- Reimplemented `precedence` to use an adapted shunting yard algorithm implementation. Instead of compiling to a nested chain of choices for each precedence level, it compiles to a frontend and backend `PrecedenceEmbedding`. The code generation relies on `choice` nodes and a new `Shunt` instruction.
- Expanded the existing `JumpTable` generation optimisations for `choice` to make `Satisfy` nodes "tablable" with the `JumpTable` instruction altered to check any `Char` predicate. Also allowed for more than a single jump table to be generated.