### PR TITLE
Synthesise bridges up to 22 arguments

### DIFF
--- a/parsley/shared/src/main/scala-3/parsley/Main.scala
+++ b/parsley/shared/src/main/scala-3/parsley/Main.scala
@@ -15,13 +15,17 @@ object Pos {
 }
 
 case class Foo[A](arg1: A, arg2: Int = 6)(@isPosition val y: Pos)
+case class Bar(arg1: Int, arg2: Int)
 
 def foo[B] = bridge[Foo[B]]
+def bar = bridge[Bar]
 
 @main
 def bridgeTest() = {
     val b = foo[Int]
     println((character.char('a') ~> b(Parsley.pure(7), Parsley.pure(4))).parse("a").map(_.arg2))
+
+    println(bar(character.digit.map(_.asDigit), Parsley.pure(2)).parse("4"))
 }
 
 /*abstract class Bar {

--- a/parsley/shared/src/main/scala-3/parsley/Main.scala
+++ b/parsley/shared/src/main/scala-3/parsley/Main.scala
@@ -6,8 +6,6 @@
 package parsley
 import parsley.experimental.generic.*
 
-import scala.annotation.experimental
-
 case class Pos(line: Int, col: Int, offset: Int)
 object Pos {
     import parsley.position.{line, col, offset}
@@ -20,11 +18,16 @@ case class Foo[A](arg1: A, arg2: Int = 6)(@isPosition val y: Pos)
 case class Bar(arg1: Int, arg2: Int)
 case class Baz[A](arg1: Char, arg2: Int, arg3: String, arg4: A)(@isPosition val pos: Pos)
 
-@experimental def foo[B] = bridge[Foo[B]]
-@experimental def bar = bridge[Bar]
-@experimental def baz = bridge[Baz[Int]]
+case class A22[A](x1: A, x2: A, x3: A, x4: A, x5: A, x6: A, x7: A, x8: A, x9: A, x10: A, x11: A, x12: A, x13: A, x14: A, x15: A, x16: A, x17: A, x18: A, x19: A, x20: A, x21: A, x22: A)
+case class A23[A](x1: A, x2: A, x3: A, x4: A, x5: A, x6: A, x7: A, x8: A, x9: A, x10: A, x11: A, x12: A, x13: A, x14: A, x15: A, x16: A, x17: A, x18: A, x19: A, x20: A, x21: A, x22: A, x23: A)
 
-@main @experimental
+def foo[B] = bridge[Foo[B]]
+def bar = bridge[Bar]
+def baz = bridge[Baz[Int]]
+def a22 = bridge[A22[String]]
+// def a23 = bridge[A23[Int]] // error: bridges cannot have more than 22 arguments
+
+@main
 def bridgeTest() = {
     val b = foo[Int]
     println((character.char('a') ~> b(Parsley.pure(7), Parsley.pure(4))).parse("a").map(_.arg2))

--- a/parsley/shared/src/main/scala-3/parsley/Main.scala
+++ b/parsley/shared/src/main/scala-3/parsley/Main.scala
@@ -6,6 +6,8 @@
 package parsley
 import parsley.experimental.generic.*
 
+import scala.annotation.experimental
+
 case class Pos(line: Int, col: Int, offset: Int)
 object Pos {
     import parsley.position.{line, col, offset}
@@ -16,16 +18,20 @@ object Pos {
 
 case class Foo[A](arg1: A, arg2: Int = 6)(@isPosition val y: Pos)
 case class Bar(arg1: Int, arg2: Int)
+case class Baz[A](arg1: Char, arg2: Int, arg3: String, arg4: A)(@isPosition val pos: Pos)
 
-def foo[B] = bridge[Foo[B]]
-def bar = bridge[Bar]
+@experimental def foo[B] = bridge[Foo[B]]
+@experimental def bar = bridge[Bar]
+@experimental def baz = bridge[Baz[Int]]
 
-@main
+@main @experimental
 def bridgeTest() = {
     val b = foo[Int]
     println((character.char('a') ~> b(Parsley.pure(7), Parsley.pure(4))).parse("a").map(_.arg2))
 
     println(bar(character.digit.map(_.asDigit), Parsley.pure(2)).parse("4"))
+
+    println((character.string("a ") ~> baz(character.item, character.digit.map(_.asDigit), character.string("d2"), Parsley.pure(0))).parse("a r2d2").map(b => s"$b @ ${b.pos}"))
 }
 
 /*abstract class Bar {

--- a/parsley/shared/src/main/scala-3/parsley/experimental/generic/ParserBridge.scala
+++ b/parsley/shared/src/main/scala-3/parsley/experimental/generic/ParserBridge.scala
@@ -173,7 +173,7 @@ private class BridgeImpl(using Quotes) {
     private def synthesiseLift[R: Type](existsUniquePosition: Option[PosImpl[?]], argTys: List[TypeRepr], con: Term, args: List[Term]): Expr[Parsley[R]] = {
         val tys = argTys :+ TypeRepr.of[R]
         val arity = argTys.size + existsUniquePosition.size
-        TypeRepr.of[parsley.lift$].typeSymbol.methodMember(s"lift$arity").headOption.map('{parsley.lift}.asTerm.select(_)) match {
+        TypeRepr.of[parsley.lift.type].typeSymbol.methodMember(s"lift$arity").headOption.map('{parsley.lift}.asTerm.select(_)) match {
             case Some(lift) => existsUniquePosition match {
                 case Some(impl@PosImpl(_, given Type[posTy])) =>
                     val posTyRepr = TypeRepr.of[posTy]

--- a/parsley/shared/src/main/scala-3/parsley/experimental/generic/ParserBridge.scala
+++ b/parsley/shared/src/main/scala-3/parsley/experimental/generic/ParserBridge.scala
@@ -6,26 +6,14 @@
 package parsley
 package experimental.generic
 
-import scala.annotation.tailrec
+import scala.annotation.{experimental, tailrec}
 import scala.collection.mutable
 import scala.quoted.*
-import generic.*
+import generic.ErrorBridge
 
-/*
-Problem space:
-    * How are error bridges incorporated in (annotation?)
-*/
-
-abstract class Bridge1[T, R] extends ErrorBridge {
-    def apply(p1: Parsley[T]): Parsley[R]
-}
-abstract class Bridge2[T1, T2, R] extends ErrorBridge {
-    def apply(p1: Parsley[T1], p2: Parsley[T2]): Parsley[R]
-}
-
-inline transparent def bridge[T]: ErrorBridge = bridge[T, T]
-inline transparent def bridge[T, S >: T]: ErrorBridge = ${bridgeImpl[T, S]}
-private def bridgeImpl[T: Type, S >: T: Type](using Quotes): Expr[ErrorBridge] = BridgeImpl().synthesise[T, S]
+@experimental inline transparent def bridge[T]: ErrorBridge = bridge[T, T]
+@experimental inline transparent def bridge[T, S >: T]: ErrorBridge = ${bridgeImpl[T, S]}
+@experimental private def bridgeImpl[T: Type, S >: T: Type](using Quotes): Expr[ErrorBridge] = BridgeImpl().synthesise[T, S]
 // having a class here simplifies the importing of quotes.reflect.* for the enum
 // (FIXME: it is considered bad practice, so I will probably just make a parametric enum later)
 private class BridgeImpl(using Quotes) {
@@ -37,6 +25,7 @@ private class BridgeImpl(using Quotes) {
         case Err(name: String, pos: Option[Position])
     }
 
+    @experimental
     def synthesise[T: Type, S >: T: Type] = {
         val tyRepr = TypeRepr.of[T]
         val tyArgs = tyRepr.typeArgs
@@ -55,21 +44,26 @@ private class BridgeImpl(using Quotes) {
                 }
                 val con = constructor[T](cls, bridgePrimaryArgs, tyArgs, categorisedArgs, existsUniquePosition.map(_.tyRepr))
                 val body = synthesiseLift[S](existsUniquePosition, bridgePrimaryArgs.map(_._2), con, _)
+                val bridge = synthesiseBridge[S](bridgePrimaryArgs.map(_._2), body)
+
                 // TODO: ensure validation if Err is encountered (report separately, but then abort if failed (Option))
-                bridgePrimaryArgs.map(_._2.asType) match {
-                    case List('[t1]) => '{
-                        new Bridge1[t1, S] {
-                            def apply(p1: Parsley[t1]): Parsley[S] = ${body(List('p1.asTerm))}
-                        }
-                    }
-                    case List('[t1], '[t2]) => '{
-                        new Bridge2[t1, t2, S] {
-                            def apply(p1: Parsley[t1], p2: Parsley[t2]): Parsley[S] = ${body(List('p1.asTerm, 'p2.asTerm))}
-                        }
-                    }
-                    // TODO: 19 more of these
-                    case _ => '{???}
-                }
+                // bridgePrimaryArgs.map(_._2.asType) match {
+                //     case List('[t1]) => '{
+                //         new bridges.Bridge1[t1, S] {
+                //             def apply(p1: Parsley[t1]): Parsley[S] = ${body(List('p1.asTerm))}
+                //         }
+                //     }
+                //     case List('[t1], '[t2]) => '{
+                //         new bridges.Bridge2[t1, t2, S] {
+
+                //             def apply(p1: Parsley[t1], p2: Parsley[t2]): Parsley[S] = ${body(List('p1.asTerm, 'p2.asTerm))}
+                //         }
+                //     }
+                //     // TODO: 19 more of these
+                //     case _ => '{???}
+                // }
+
+                bridge
             case _ => report.errorAndAbort("can only make bridges for constructible classes or objects")
         }
     }
@@ -187,6 +181,44 @@ private class BridgeImpl(using Quotes) {
             }
             case None => report.errorAndAbort(s"No `lift` available for arity $arity")
         }
+    }
+
+    @experimental
+    private def synthesiseBridge[R: Type](argTys: List[TypeRepr], body: List[Term] => Expr[Parsley[R]]): Expr[ErrorBridge] = {
+        val arity = argTys.size
+        // TODO: is there a better way to retrieve the bridge with desired arity?
+        val bridgeTy = TypeTree.ref(TypeRepr.of[bridges.type].typeSymbol.typeMember(s"Bridge$arity"))
+
+        // BridgeN[T1, ..., TN, R]       
+        val parents = List(Applied(bridgeTy, argTys.map(Inferred(_)) :+ TypeTree.of[R]))
+
+        // def apply(p1: Parsley[T1], ..., pN: parsley[TN]): Parsley[R]
+        def decls(cls: Symbol): List[Symbol] =
+            List(Symbol.newMethod(cls, "apply", MethodType(
+                paramNames = (1 to arity).map(i => s"p$i").toList
+            )(
+                paramInfosExp = _ => argTys.map(TypeRepr.of[Parsley].appliedTo(_)),
+                resultTypeExp = _ => TypeRepr.of[Parsley].appliedTo(TypeRepr.of[R])
+            )))
+
+        val bridgeCls = Symbol.newClass(Symbol.spliceOwner, "$anon", parents.map(_.tpe), decls, selfType = None)
+
+        // def apply(...) = ${ body(List('p1.asTerm, ..., 'pN.asTerm)) }
+        val applySym = bridgeCls.declaredMethod("apply").head
+        val applyDef = DefDef(applySym, argss => {
+            val args = argss.head.map {
+                case t: Term => t
+                case tree    => report.errorAndAbort(s"Expected term while synthesising arguments for the apply method, got ${tree.show} instead")
+            }
+            Some(body(args).asTerm.changeOwner(applySym))
+        })
+
+        // class $anon extends BridgeN[T1, ..., TN, R] { def apply(...) = ... }
+        val bridgeClsDef = ClassDef(bridgeCls, parents, body = List(applyDef))
+        // new $anon(): BridgeN[T1, ..., TN, R]
+        val newBridgeCls = Typed(Apply(Select(New(TypeIdent(bridgeCls)), bridgeCls.primaryConstructor), Nil), parents.head)
+
+        Block(List(bridgeClsDef), newBridgeCls).asExprOf[ErrorBridge]
     }
 
     private object Bridgeable {

--- a/parsley/shared/src/main/scala-3/parsley/experimental/generic/ParserBridge.scala
+++ b/parsley/shared/src/main/scala-3/parsley/experimental/generic/ParserBridge.scala
@@ -134,7 +134,7 @@ private class BridgeImpl(using Quotes) {
 
     private def appliedCon(cls: Symbol, owner: Symbol, lamParams: IndexedSeq[Term], clsTyArgs: List[TypeRepr], otherArgs: List[List[BridgeArg]], posParam: Option[Term]): Term = {
         val tys: List[TypeTree] = clsTyArgs.map(tyRep => TypeTree.of(using tyRep.asType))
-        val objTy = New(Applied(TypeTree.ref(cls), tys))
+        val objTy = if (tys.isEmpty) New(TypeTree.ref(cls)) else New(Applied(TypeTree.ref(cls), tys))
         val con = objTy.select(cls.primaryConstructor).appliedToTypes(clsTyArgs)
         val kaboom: Term = '{???}.asTerm
         // at this point, we have applied the constructor to the bridge args (except for positions)

--- a/parsley/shared/src/main/scala-3/parsley/experimental/generic/ParserBridge.scala
+++ b/parsley/shared/src/main/scala-3/parsley/experimental/generic/ParserBridge.scala
@@ -6,14 +6,14 @@
 package parsley
 package experimental.generic
 
-import scala.annotation.{experimental, tailrec}
+import scala.annotation.{switch, tailrec}
 import scala.collection.mutable
 import scala.quoted.*
 import generic.ErrorBridge
 
-@experimental inline transparent def bridge[T]: ErrorBridge = bridge[T, T]
-@experimental inline transparent def bridge[T, S >: T]: ErrorBridge = ${bridgeImpl[T, S]}
-@experimental private def bridgeImpl[T: Type, S >: T: Type](using Quotes): Expr[ErrorBridge] = BridgeImpl().synthesise[T, S]
+inline transparent def bridge[T]: ErrorBridge = bridge[T, T]
+inline transparent def bridge[T, S >: T]: ErrorBridge = ${bridgeImpl[T, S]}
+private def bridgeImpl[T: Type, S >: T: Type](using Quotes): Expr[ErrorBridge] = BridgeImpl().synthesise[T, S]
 // having a class here simplifies the importing of quotes.reflect.* for the enum
 // (FIXME: it is considered bad practice, so I will probably just make a parametric enum later)
 private class BridgeImpl(using Quotes) {
@@ -25,7 +25,6 @@ private class BridgeImpl(using Quotes) {
         case Err(name: String, pos: Option[Position])
     }
 
-    @experimental
     def synthesise[T: Type, S >: T: Type] = {
         val tyRepr = TypeRepr.of[T]
         val tyArgs = tyRepr.typeArgs
@@ -44,26 +43,9 @@ private class BridgeImpl(using Quotes) {
                 }
                 val con = constructor[T](cls, bridgePrimaryArgs, tyArgs, categorisedArgs, existsUniquePosition.map(_.tyRepr))
                 val body = synthesiseLift[S](existsUniquePosition, bridgePrimaryArgs.map(_._2), con, _)
-                val bridge = synthesiseBridge[S](bridgePrimaryArgs.map(_._2), body)
 
                 // TODO: ensure validation if Err is encountered (report separately, but then abort if failed (Option))
-                // bridgePrimaryArgs.map(_._2.asType) match {
-                //     case List('[t1]) => '{
-                //         new bridges.Bridge1[t1, S] {
-                //             def apply(p1: Parsley[t1]): Parsley[S] = ${body(List('p1.asTerm))}
-                //         }
-                //     }
-                //     case List('[t1], '[t2]) => '{
-                //         new bridges.Bridge2[t1, t2, S] {
-
-                //             def apply(p1: Parsley[t1], p2: Parsley[t2]): Parsley[S] = ${body(List('p1.asTerm, 'p2.asTerm))}
-                //         }
-                //     }
-                //     // TODO: 19 more of these
-                //     case _ => '{???}
-                // }
-
-                bridge
+                synthesiseBridge[S](bridgePrimaryArgs.map(_._2.asType), body)
             case _ => report.errorAndAbort("can only make bridges for constructible classes or objects")
         }
     }
@@ -183,6 +165,262 @@ private class BridgeImpl(using Quotes) {
         }
     }
 
+    private def synthesiseBridge[R: Type](argTys: List[Type[?]], body: List[Term] => Expr[Parsley[R]]): Expr[ErrorBridge] = (argTys.size: @switch) match {
+        case 1 => (argTys: @unchecked) match {
+            case List('[t1]) => '{
+                new bridges.Bridge1[t1, R] {
+                    def apply(p1: Parsley[t1]): Parsley[R] = ${ body(List('p1.asTerm)) }
+                }
+            }
+        }
+        case 2 => (argTys: @unchecked) match {
+            case List('[t1], '[t2]) => '{
+                new bridges.Bridge2[t1, t2, R] {
+                    def apply(p1: Parsley[t1], p2: Parsley[t2]): Parsley[R] = ${ body(List('p1.asTerm, 'p2.asTerm)) }
+                }
+            }
+        }
+        case 3 => (argTys: @unchecked) match {
+            case List('[t1], '[t2], '[t3]) => '{
+                new bridges.Bridge3[t1, t2, t3, R] {
+                    def apply(p1: Parsley[t1], p2: Parsley[t2], p3: Parsley[t3]): Parsley[R] =
+                        ${ body(List('p1.asTerm, 'p2.asTerm, 'p3.asTerm)) }
+                }
+            }
+        }
+        case 4 => (argTys: @unchecked) match {
+            case List('[t1], '[t2], '[t3], '[t4]) => '{
+                new bridges.Bridge4[t1, t2, t3, t4, R] {
+                    def apply(p1: Parsley[t1], p2: Parsley[t2], p3: Parsley[t3], p4: Parsley[t4]): Parsley[R] =
+                        ${ body(List('p1.asTerm, 'p2.asTerm, 'p3.asTerm, 'p4.asTerm)) }
+                }
+            }
+        }
+        case 5 => (argTys: @unchecked) match {
+            case List('[t1], '[t2], '[t3], '[t4], '[t5]) => '{
+                new bridges.Bridge5[t1, t2, t3, t4, t5, R] {
+                    def apply(p1: Parsley[t1], p2: Parsley[t2], p3: Parsley[t3], p4: Parsley[t4], p5: Parsley[t5]): Parsley[R] =
+                        ${ body(List('p1.asTerm, 'p2.asTerm, 'p3.asTerm, 'p4.asTerm, 'p5.asTerm)) }
+                }
+            }
+        }
+        case 6 => (argTys: @unchecked) match {
+            case List('[t1], '[t2], '[t3], '[t4], '[t5], '[t6]) => '{
+                new bridges.Bridge6[t1, t2, t3, t4, t5, t6, R] {
+                    def apply(p1: Parsley[t1], p2: Parsley[t2], p3: Parsley[t3], p4: Parsley[t4], p5: Parsley[t5],
+                              p6: Parsley[t6]): Parsley[R] =
+                        ${ body(List('p1.asTerm, 'p2.asTerm, 'p3.asTerm, 'p4.asTerm, 'p5.asTerm,
+                                     'p6.asTerm)) }
+                }
+            }
+        }
+        case 7 => (argTys: @unchecked) match {
+            case List('[t1], '[t2], '[t3], '[t4], '[t5], '[t6], '[t7]) => '{
+                new bridges.Bridge7[t1, t2, t3, t4, t5, t6, t7, R] {
+                    def apply(p1: Parsley[t1], p2: Parsley[t2], p3: Parsley[t3], p4: Parsley[t4], p5: Parsley[t5],
+                              p6: Parsley[t6], p7: Parsley[t7]): Parsley[R] =
+                        ${ body(List('p1.asTerm, 'p2.asTerm, 'p3.asTerm, 'p4.asTerm, 'p5.asTerm,
+                                     'p6.asTerm, 'p7.asTerm)) }
+                }
+            }
+        }
+        case 8 => (argTys: @unchecked) match {
+            case List('[t1], '[t2], '[t3], '[t4], '[t5], '[t6], '[t7], '[t8]) => '{
+                new bridges.Bridge8[t1, t2, t3, t4, t5, t6, t7, t8, R] {
+                    def apply(p1: Parsley[t1], p2: Parsley[t2], p3: Parsley[t3], p4: Parsley[t4], p5: Parsley[t5],
+                              p6: Parsley[t6], p7: Parsley[t7], p8: Parsley[t8]): Parsley[R] =
+                        ${ body(List('p1.asTerm, 'p2.asTerm, 'p3.asTerm, 'p4.asTerm, 'p5.asTerm,
+                                     'p6.asTerm, 'p7.asTerm, 'p8.asTerm)) }
+                }
+            }
+        }
+        case 9 => (argTys: @unchecked) match {
+            case List('[t1], '[t2], '[t3], '[t4], '[t5], '[t6], '[t7], '[t8], '[t9]) => '{
+                new bridges.Bridge9[t1, t2, t3, t4, t5, t6, t7, t8, t9, R] {
+                    def apply(p1: Parsley[t1], p2: Parsley[t2], p3: Parsley[t3], p4: Parsley[t4], p5: Parsley[t5],
+                              p6: Parsley[t6], p7: Parsley[t7], p8: Parsley[t8], p9: Parsley[t9]): Parsley[R] =
+                        ${ body(List('p1.asTerm, 'p2.asTerm, 'p3.asTerm, 'p4.asTerm, 'p5.asTerm,
+                                     'p6.asTerm, 'p7.asTerm, 'p8.asTerm, 'p9.asTerm)) }
+                }
+            }
+        }
+        case 10 => (argTys: @unchecked) match {
+            case List('[t1], '[t2], '[t3], '[t4], '[t5], '[t6], '[t7], '[t8], '[t9], '[t10]) => '{
+                new bridges.Bridge10[t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, R] {
+                    def apply(p1: Parsley[t1], p2: Parsley[t2], p3: Parsley[t3], p4: Parsley[t4], p5: Parsley[t5],
+                              p6: Parsley[t6], p7: Parsley[t7], p8: Parsley[t8], p9: Parsley[t9], p10: Parsley[t10]): Parsley[R] =
+                        ${ body(List('p1.asTerm, 'p2.asTerm, 'p3.asTerm, 'p4.asTerm, 'p5.asTerm,
+                                     'p6.asTerm, 'p7.asTerm, 'p8.asTerm, 'p9.asTerm, 'p10.asTerm)) }
+                }
+            }
+        }
+        case 11 => (argTys: @unchecked) match {
+            case List('[t1], '[t2], '[t3], '[t4], '[t5], '[t6], '[t7], '[t8], '[t9], '[t10], '[t11]) => '{
+                new bridges.Bridge11[t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, R] {
+                    def apply(p1: Parsley[t1], p2: Parsley[t2], p3: Parsley[t3], p4: Parsley[t4], p5: Parsley[t5],
+                              p6: Parsley[t6], p7: Parsley[t7], p8: Parsley[t8], p9: Parsley[t9], p10: Parsley[t10],
+                              p11: Parsley[t11]): Parsley[R] =
+                        ${ body(List('p1.asTerm, 'p2.asTerm, 'p3.asTerm, 'p4.asTerm, 'p5.asTerm,
+                                     'p6.asTerm, 'p7.asTerm, 'p8.asTerm, 'p9.asTerm, 'p10.asTerm,
+                                     'p11.asTerm)) }
+                }
+            }
+        }
+        case 12 => (argTys: @unchecked) match {
+            case List('[t1], '[t2], '[t3], '[t4], '[t5], '[t6], '[t7], '[t8], '[t9], '[t10], '[t11], '[t12]) => '{
+                new bridges.Bridge12[t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, R] {
+                    def apply(p1: Parsley[t1], p2: Parsley[t2], p3: Parsley[t3], p4: Parsley[t4], p5: Parsley[t5],
+                              p6: Parsley[t6], p7: Parsley[t7], p8: Parsley[t8], p9: Parsley[t9], p10: Parsley[t10],
+                              p11: Parsley[t11], p12: Parsley[t12]): Parsley[R] =
+                        ${ body(List('p1.asTerm, 'p2.asTerm, 'p3.asTerm, 'p4.asTerm, 'p5.asTerm,
+                                     'p6.asTerm, 'p7.asTerm, 'p8.asTerm, 'p9.asTerm, 'p10.asTerm,
+                                     'p11.asTerm, 'p12.asTerm)) }
+                }
+            }
+        }
+        case 13 => (argTys: @unchecked) match {
+            case List('[t1], '[t2], '[t3], '[t4], '[t5], '[t6], '[t7], '[t8], '[t9], '[t10], '[t11], '[t12], '[t13]) => '{
+                new bridges.Bridge13[t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, R] {
+                    def apply(p1: Parsley[t1], p2: Parsley[t2], p3: Parsley[t3], p4: Parsley[t4], p5: Parsley[t5],
+                              p6: Parsley[t6], p7: Parsley[t7], p8: Parsley[t8], p9: Parsley[t9], p10: Parsley[t10],
+                              p11: Parsley[t11], p12: Parsley[t12], p13: Parsley[t13]): Parsley[R] =
+                        ${ body(List('p1.asTerm, 'p2.asTerm, 'p3.asTerm, 'p4.asTerm, 'p5.asTerm,
+                                     'p6.asTerm, 'p7.asTerm, 'p8.asTerm, 'p9.asTerm, 'p10.asTerm,
+                                     'p11.asTerm, 'p12.asTerm, 'p13.asTerm)) }
+                }
+            }
+        }
+        case 14 => (argTys: @unchecked) match {
+            case List('[t1], '[t2], '[t3], '[t4], '[t5], '[t6], '[t7], '[t8], '[t9], '[t10], '[t11], '[t12], '[t13], '[t14]) => '{
+                new bridges.Bridge14[t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, R] {
+                    def apply(p1: Parsley[t1], p2: Parsley[t2], p3: Parsley[t3], p4: Parsley[t4], p5: Parsley[t5],
+                              p6: Parsley[t6], p7: Parsley[t7], p8: Parsley[t8], p9: Parsley[t9], p10: Parsley[t10],
+                              p11: Parsley[t11], p12: Parsley[t12], p13: Parsley[t13], p14: Parsley[t14]): Parsley[R] =
+                        ${ body(List('p1.asTerm, 'p2.asTerm, 'p3.asTerm, 'p4.asTerm, 'p5.asTerm,
+                                     'p6.asTerm, 'p7.asTerm, 'p8.asTerm, 'p9.asTerm, 'p10.asTerm,
+                                     'p11.asTerm, 'p12.asTerm, 'p13.asTerm, 'p14.asTerm)) }
+                }
+            }
+        }
+        case 15 => (argTys: @unchecked) match {
+            case List('[t1], '[t2], '[t3], '[t4], '[t5], '[t6], '[t7], '[t8], '[t9], '[t10], '[t11], '[t12], '[t13], '[t14], '[t15]) => '{
+                new bridges.Bridge15[t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, R] {
+                    def apply(p1: Parsley[t1], p2: Parsley[t2], p3: Parsley[t3], p4: Parsley[t4], p5: Parsley[t5],
+                              p6: Parsley[t6], p7: Parsley[t7], p8: Parsley[t8], p9: Parsley[t9], p10: Parsley[t10],
+                              p11: Parsley[t11], p12: Parsley[t12], p13: Parsley[t13], p14: Parsley[t14], p15: Parsley[t15]): Parsley[R] =
+                        ${ body(List('p1.asTerm, 'p2.asTerm, 'p3.asTerm, 'p4.asTerm, 'p5.asTerm,
+                                     'p6.asTerm, 'p7.asTerm, 'p8.asTerm, 'p9.asTerm, 'p10.asTerm,
+                                     'p11.asTerm, 'p12.asTerm, 'p13.asTerm, 'p14.asTerm, 'p15.asTerm)) }
+                }
+            }
+        }
+        case 16 => (argTys: @unchecked) match {
+            case List('[t1], '[t2], '[t3], '[t4], '[t5], '[t6], '[t7], '[t8], '[t9], '[t10], '[t11], '[t12], '[t13], '[t14], '[t15], '[t16]) => '{
+                new bridges.Bridge16[t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, R] {
+                    def apply(p1: Parsley[t1], p2: Parsley[t2], p3: Parsley[t3], p4: Parsley[t4], p5: Parsley[t5],
+                              p6: Parsley[t6], p7: Parsley[t7], p8: Parsley[t8], p9: Parsley[t9], p10: Parsley[t10],
+                              p11: Parsley[t11], p12: Parsley[t12], p13: Parsley[t13], p14: Parsley[t14], p15: Parsley[t15],
+                              p16: Parsley[t16]): Parsley[R] =
+                        ${ body(List('p1.asTerm, 'p2.asTerm, 'p3.asTerm, 'p4.asTerm, 'p5.asTerm,
+                                     'p6.asTerm, 'p7.asTerm, 'p8.asTerm, 'p9.asTerm, 'p10.asTerm,
+                                     'p11.asTerm, 'p12.asTerm, 'p13.asTerm, 'p14.asTerm, 'p15.asTerm,
+                                     'p16.asTerm)) }
+                }
+            }
+        }
+        case 17 => (argTys: @unchecked) match {
+            case List('[t1], '[t2], '[t3], '[t4], '[t5], '[t6], '[t7], '[t8], '[t9], '[t10], '[t11], '[t12], '[t13], '[t14], '[t15], '[t16], '[t17]) => '{
+                new bridges.Bridge17[t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, R] {
+                    def apply(p1: Parsley[t1], p2: Parsley[t2], p3: Parsley[t3], p4: Parsley[t4], p5: Parsley[t5],
+                              p6: Parsley[t6], p7: Parsley[t7], p8: Parsley[t8], p9: Parsley[t9], p10: Parsley[t10],
+                              p11: Parsley[t11], p12: Parsley[t12], p13: Parsley[t13], p14: Parsley[t14], p15: Parsley[t15],
+                              p16: Parsley[t16], p17: Parsley[t17]): Parsley[R] =
+                        ${ body(List('p1.asTerm, 'p2.asTerm, 'p3.asTerm, 'p4.asTerm, 'p5.asTerm,
+                                     'p6.asTerm, 'p7.asTerm, 'p8.asTerm, 'p9.asTerm, 'p10.asTerm,
+                                     'p11.asTerm, 'p12.asTerm, 'p13.asTerm, 'p14.asTerm, 'p15.asTerm,
+                                     'p16.asTerm, 'p17.asTerm)) }
+                }
+            }
+        }
+        case 18 => (argTys: @unchecked) match {
+            case List('[t1], '[t2], '[t3], '[t4], '[t5], '[t6], '[t7], '[t8], '[t9], '[t10], '[t11], '[t12], '[t13], '[t14], '[t15], '[t16], '[t17], '[t18]) => '{
+                new bridges.Bridge18[t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, R] {
+                    def apply(p1: Parsley[t1], p2: Parsley[t2], p3: Parsley[t3], p4: Parsley[t4], p5: Parsley[t5],
+                              p6: Parsley[t6], p7: Parsley[t7], p8: Parsley[t8], p9: Parsley[t9], p10: Parsley[t10],
+                              p11: Parsley[t11], p12: Parsley[t12], p13: Parsley[t13], p14: Parsley[t14], p15: Parsley[t15],
+                              p16: Parsley[t16], p17: Parsley[t17], p18: Parsley[t18]): Parsley[R] =
+                        ${ body(List('p1.asTerm, 'p2.asTerm, 'p3.asTerm, 'p4.asTerm, 'p5.asTerm,
+                                     'p6.asTerm, 'p7.asTerm, 'p8.asTerm, 'p9.asTerm, 'p10.asTerm,
+                                     'p11.asTerm, 'p12.asTerm, 'p13.asTerm, 'p14.asTerm, 'p15.asTerm,
+                                     'p16.asTerm, 'p17.asTerm, 'p18.asTerm)) }
+                }
+            }
+        }
+        case 19 => (argTys: @unchecked) match {
+            case List('[t1], '[t2], '[t3], '[t4], '[t5], '[t6], '[t7], '[t8], '[t9], '[t10], '[t11], '[t12], '[t13], '[t14], '[t15], '[t16], '[t17], '[t18], '[t19]) => '{
+                new bridges.Bridge19[t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, R] {
+                    def apply(p1: Parsley[t1], p2: Parsley[t2], p3: Parsley[t3], p4: Parsley[t4], p5: Parsley[t5],
+                              p6: Parsley[t6], p7: Parsley[t7], p8: Parsley[t8], p9: Parsley[t9], p10: Parsley[t10],
+                              p11: Parsley[t11], p12: Parsley[t12], p13: Parsley[t13], p14: Parsley[t14], p15: Parsley[t15],
+                              p16: Parsley[t16], p17: Parsley[t17], p18: Parsley[t18], p19: Parsley[t19]): Parsley[R] =
+                        ${ body(List('p1.asTerm, 'p2.asTerm, 'p3.asTerm, 'p4.asTerm, 'p5.asTerm,
+                                     'p6.asTerm, 'p7.asTerm, 'p8.asTerm, 'p9.asTerm, 'p10.asTerm,
+                                     'p11.asTerm, 'p12.asTerm, 'p13.asTerm, 'p14.asTerm, 'p15.asTerm,
+                                     'p16.asTerm, 'p17.asTerm, 'p18.asTerm, 'p19.asTerm)) }
+                }
+            }
+        }
+        case 20 => (argTys: @unchecked) match {
+            case List('[t1], '[t2], '[t3], '[t4], '[t5], '[t6], '[t7], '[t8], '[t9], '[t10], '[t11], '[t12], '[t13], '[t14], '[t15], '[t16], '[t17], '[t18], '[t19], '[t20]) => '{
+                new bridges.Bridge20[t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, t20, R] {
+                    def apply(p1: Parsley[t1], p2: Parsley[t2], p3: Parsley[t3], p4: Parsley[t4], p5: Parsley[t5],
+                              p6: Parsley[t6], p7: Parsley[t7], p8: Parsley[t8], p9: Parsley[t9], p10: Parsley[t10],
+                              p11: Parsley[t11], p12: Parsley[t12], p13: Parsley[t13], p14: Parsley[t14], p15: Parsley[t15],
+                              p16: Parsley[t16], p17: Parsley[t17], p18: Parsley[t18], p19: Parsley[t19], p20: Parsley[t20]): Parsley[R] =
+                        ${ body(List('p1.asTerm, 'p2.asTerm, 'p3.asTerm, 'p4.asTerm, 'p5.asTerm,
+                                     'p6.asTerm, 'p7.asTerm, 'p8.asTerm, 'p9.asTerm, 'p10.asTerm,
+                                     'p11.asTerm, 'p12.asTerm, 'p13.asTerm, 'p14.asTerm, 'p15.asTerm,
+                                     'p16.asTerm, 'p17.asTerm, 'p18.asTerm, 'p19.asTerm, 'p20.asTerm)) }
+                }
+            }
+        }
+        case 21 => (argTys: @unchecked) match {
+            case List('[t1], '[t2], '[t3], '[t4], '[t5], '[t6], '[t7], '[t8], '[t9], '[t10], '[t11], '[t12], '[t13], '[t14], '[t15], '[t16], '[t17], '[t18], '[t19], '[t20], '[t21]) => '{
+                new bridges.Bridge21[t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, t20, t21, R] {
+                    def apply(p1: Parsley[t1], p2: Parsley[t2], p3: Parsley[t3], p4: Parsley[t4], p5: Parsley[t5],
+                              p6: Parsley[t6], p7: Parsley[t7], p8: Parsley[t8], p9: Parsley[t9], p10: Parsley[t10],
+                              p11: Parsley[t11], p12: Parsley[t12], p13: Parsley[t13], p14: Parsley[t14], p15: Parsley[t15],
+                              p16: Parsley[t16], p17: Parsley[t17], p18: Parsley[t18], p19: Parsley[t19], p20: Parsley[t20],
+                              p21: Parsley[t21]): Parsley[R] =
+                        ${ body(List('p1.asTerm, 'p2.asTerm, 'p3.asTerm, 'p4.asTerm, 'p5.asTerm,
+                                     'p6.asTerm, 'p7.asTerm, 'p8.asTerm, 'p9.asTerm, 'p10.asTerm,
+                                     'p11.asTerm, 'p12.asTerm, 'p13.asTerm, 'p14.asTerm, 'p15.asTerm,
+                                     'p16.asTerm, 'p17.asTerm, 'p18.asTerm, 'p19.asTerm, 'p20.asTerm,
+                                     'p21.asTerm)) }
+                }
+            }
+        }
+        case 22 => (argTys: @unchecked) match {
+            case List('[t1], '[t2], '[t3], '[t4], '[t5], '[t6], '[t7], '[t8], '[t9], '[t10], '[t11], '[t12], '[t13], '[t14], '[t15], '[t16], '[t17], '[t18], '[t19], '[t20], '[t21], '[t22]) => '{
+                new bridges.Bridge22[t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, t11, t12, t13, t14, t15, t16, t17, t18, t19, t20, t21, t22, R] {
+                    def apply(p1: Parsley[t1], p2: Parsley[t2], p3: Parsley[t3], p4: Parsley[t4], p5: Parsley[t5],
+                              p6: Parsley[t6], p7: Parsley[t7], p8: Parsley[t8], p9: Parsley[t9], p10: Parsley[t10],
+                              p11: Parsley[t11], p12: Parsley[t12], p13: Parsley[t13], p14: Parsley[t14], p15: Parsley[t15],
+                              p16: Parsley[t16], p17: Parsley[t17], p18: Parsley[t18], p19: Parsley[t19], p20: Parsley[t20],
+                              p21: Parsley[t21], p22: Parsley[t22]): Parsley[R] =
+                        ${ body(List('p1.asTerm, 'p2.asTerm, 'p3.asTerm, 'p4.asTerm, 'p5.asTerm,
+                                     'p6.asTerm, 'p7.asTerm, 'p8.asTerm, 'p9.asTerm, 'p10.asTerm,
+                                     'p11.asTerm, 'p12.asTerm, 'p13.asTerm, 'p14.asTerm, 'p15.asTerm,
+                                     'p16.asTerm, 'p17.asTerm, 'p18.asTerm, 'p19.asTerm, 'p20.asTerm,
+                                     'p21.asTerm, 'p22.asTerm)) }
+                }
+            }
+        }
+        case _ => report.errorAndAbort("Bridges cannot have more than 22 arguments")
+    }
+
+    // TODO: use this generalised synthesis method once Symbol.newClass and ClassDef are no longer marked experimental
+    /*
     @experimental
     private def synthesiseBridge[R: Type](argTys: List[TypeRepr], body: List[Term] => Expr[Parsley[R]]): Expr[ErrorBridge] = {
         val arity = argTys.size
@@ -220,6 +458,7 @@ private class BridgeImpl(using Quotes) {
 
         Block(List(bridgeClsDef), newBridgeCls).asExprOf[ErrorBridge]
     }
+    */
 
     private object Bridgeable {
         def unapply(ty: TypeRepr): Option[(Symbol, List[Symbol], List[Symbol], List[List[Symbol]])] = {

--- a/parsley/shared/src/main/scala-3/parsley/experimental/generic/bridges.scala
+++ b/parsley/shared/src/main/scala-3/parsley/experimental/generic/bridges.scala
@@ -1,3 +1,8 @@
+/*
+ * Copyright 2020 Parsley Contributors <https://github.com/j-mie6/Parsley/graphs/contributors>
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
 package parsley
 package experimental.generic
 

--- a/parsley/shared/src/main/scala-3/parsley/experimental/generic/bridges.scala
+++ b/parsley/shared/src/main/scala-3/parsley/experimental/generic/bridges.scala
@@ -1,0 +1,137 @@
+package parsley
+package experimental.generic
+
+import generic.ErrorBridge
+
+/*
+Problem space:
+    * How are error bridges incorporated in (annotation?)
+*/
+
+object bridges {
+    abstract class Bridge1[T, R] extends ErrorBridge {
+        def apply(p1: Parsley[T]): Parsley[R]
+    }
+
+    abstract class Bridge2[T1, T2, R] extends ErrorBridge {
+        def apply(p1: Parsley[T1], p2: Parsley[T2]): Parsley[R]
+    }
+
+    abstract class Bridge3[T1, T2, T3, R] extends ErrorBridge {
+        def apply(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3]): Parsley[R]
+    }
+
+    abstract class Bridge4[T1, T2, T3, T4, R] extends ErrorBridge {
+        def apply(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4]): Parsley[R]
+    }
+
+    abstract class Bridge5[T1, T2, T3, T4, T5, R] extends ErrorBridge {
+        def apply(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5]): Parsley[R]
+    }
+
+    abstract class Bridge6[T1, T2, T3, T4, T5, T6, R] extends ErrorBridge {
+        def apply(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5],
+                  p6: Parsley[T6]): Parsley[R]
+    }
+
+    abstract class Bridge7[T1, T2, T3, T4, T5, T6, T7, R] extends ErrorBridge {
+        def apply(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5],
+                  p6: Parsley[T6], p7: Parsley[T7]): Parsley[R]
+    }
+
+    abstract class Bridge8[T1, T2, T3, T4, T5, T6, T7, T8, R] extends ErrorBridge {
+        def apply(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5],
+                  p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8]): Parsley[R]
+    }
+
+    abstract class Bridge9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R] extends ErrorBridge {
+        def apply(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5],
+                  p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8], p9: Parsley[T9]): Parsley[R]
+    }
+
+    abstract class Bridge10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R] extends ErrorBridge {
+        def apply(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5],
+                  p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8], p9: Parsley[T9], p10: Parsley[T10]): Parsley[R]
+    }
+
+    abstract class Bridge11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R] extends ErrorBridge {
+        def apply(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5],
+                  p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8], p9: Parsley[T9], p10: Parsley[T10],
+                  p11: Parsley[T11]): Parsley[R]
+    }
+
+    abstract class Bridge12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R] extends ErrorBridge {
+        def apply(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5],
+                  p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8], p9: Parsley[T9], p10: Parsley[T10],
+                  p11: Parsley[T11], p12: Parsley[T12]): Parsley[R]
+    }
+
+    abstract class Bridge13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R] extends ErrorBridge {
+        def apply(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5],
+                  p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8], p9: Parsley[T9], p10: Parsley[T10],
+                  p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13]): Parsley[R]
+    }
+
+    abstract class Bridge14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R] extends ErrorBridge {
+        def apply(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5],
+                  p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8], p9: Parsley[T9], p10: Parsley[T10],
+                  p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13], p14: Parsley[T14]): Parsley[R]
+    }
+
+    abstract class Bridge15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R] extends ErrorBridge {
+        def apply(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5],
+                  p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8], p9: Parsley[T9], p10: Parsley[T10],
+                  p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15]): Parsley[R]
+    }
+
+    abstract class Bridge16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R] extends ErrorBridge {
+        def apply(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5],
+                  p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8], p9: Parsley[T9], p10: Parsley[T10],
+                  p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15],
+                  p16: Parsley[T16]): Parsley[R]
+    }
+
+    abstract class Bridge17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R] extends ErrorBridge {
+        def apply(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5],
+                  p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8], p9: Parsley[T9], p10: Parsley[T10],
+                  p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15],
+                  p16: Parsley[T16], p17: Parsley[T17]): Parsley[R]
+    }
+
+    abstract class Bridge18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R] extends ErrorBridge {
+        def apply(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5],
+                  p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8], p9: Parsley[T9], p10: Parsley[T10],
+                  p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15],
+                  p16: Parsley[T16], p17: Parsley[T17], p18: Parsley[T18]): Parsley[R]
+    }
+
+    abstract class Bridge19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R] extends ErrorBridge {
+        def apply(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5],
+                  p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8], p9: Parsley[T9], p10: Parsley[T10],
+                  p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15],
+                  p16: Parsley[T16], p17: Parsley[T17], p18: Parsley[T18], p19: Parsley[T19]): Parsley[R]
+    }
+
+    abstract class Bridge20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R] extends ErrorBridge {
+        def apply(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5],
+                  p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8], p9: Parsley[T9], p10: Parsley[T10],
+                  p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15],
+                  p16: Parsley[T16], p17: Parsley[T17], p18: Parsley[T18], p19: Parsley[T19], p20: Parsley[T20]): Parsley[R]
+    }
+
+    abstract class Bridge21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R] extends ErrorBridge {
+        def apply(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5],
+                  p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8], p9: Parsley[T9], p10: Parsley[T10],
+                  p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15],
+                  p16: Parsley[T16], p17: Parsley[T17], p18: Parsley[T18], p19: Parsley[T19], p20: Parsley[T20],
+                  p21: Parsley[T21]): Parsley[R]
+    }
+
+    abstract class Bridge22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R] extends ErrorBridge {
+        def apply(p1: Parsley[T1], p2: Parsley[T2], p3: Parsley[T3], p4: Parsley[T4], p5: Parsley[T5],
+                  p6: Parsley[T6], p7: Parsley[T7], p8: Parsley[T8], p9: Parsley[T9], p10: Parsley[T10],
+                  p11: Parsley[T11], p12: Parsley[T12], p13: Parsley[T13], p14: Parsley[T14], p15: Parsley[T15],
+                  p16: Parsley[T16], p17: Parsley[T17], p18: Parsley[T18], p19: Parsley[T19], p20: Parsley[T20],
+                  p21: Parsley[T21], p22: Parsley[T22]): Parsley[R]
+    }
+}


### PR DESCRIPTION
This PR completes the bridge synthesis macro with cases up to 22 arguments. Additionally, it adds a generalised synthesis approach based on experimental methods in the reflection API, but this will not be used until it is no longer experimental on the Scala 3 LTS series.