### PR TITLE
Combined String Parsers

### DIFF
--- a/parsley/shared/src/main/scala/parsley/character.scala
+++ b/parsley/shared/src/main/scala/parsley/character.scala
@@ -543,15 +543,18 @@ private [parsley] trait character {
       * @since 4.0.0
       * @group string
       */
-    final def strings[A](kv0: (String, Parsley[A]), kvs: (String, Parsley[A])*): Parsley[A] = {
+    final def strings[A](kv0: (String, Parsley[A]), kvs: (String, Parsley[A])*): Parsley[A] = strings(string(_).ut(), kv0, kvs*)
+
+    // requires that the given combinator is transparent
+    private [parsley] final def strings[A](comb: String => Parsley[String], kv0: (String, Parsley[A]), kvs: (String, Parsley[A])*): Parsley[A] = {
         // this isn't the best we could do: it's possible to eliminate backtracking with a Trie...
         // can this be done in a semantic preserving way without resorting to a new instruction?
         // I don't think it's worth it. Down the line a general Trie-backed optimisation would be
         // more effective.
         val ss = kv0 +: kvs
-        choice(ss.groupBy(_._1.head).toList.sortBy(_._1).view.map(_._2).flatMap { s =>
+        choice(ss.groupBy(_._1.charAt(0)).toList.sortBy(_._1).view.map(_._2).flatMap { s =>
             val (sLast, pLast) :: rest = s.toList.sortBy(_._1.length): @unchecked
-            ((string(sLast).ut() ~> pLast.ut()).ut() :: rest.map { case (s, p) => (atomic(string(s).ut()).ut() ~> p).ut() }).reverse
+            ((comb(sLast) ~> pLast).ut() :: rest.map { case (s, p) => (atomic(comb(s)).ut() ~> p).ut() }).reverse
         }.toSeq*).uo((kv0._1 +: kvs.map(_._1)).mkString("strings(", ", ", ")"))
     }
 

--- a/parsley/shared/src/main/scala/parsley/token/Lexer.scala
+++ b/parsley/shared/src/main/scala/parsley/token/Lexer.scala
@@ -20,7 +20,7 @@ import parsley.token.numeric.{CombinedParsers, IntegerParsers,
 import parsley.token.symbol.{ConcreteSymbol, LexemeSymbol}
 import parsley.token.text.{CharacterParsers, ConcreteCharacter, ConcreteString,
                            EscapableCharacter, Escape, LexemeCharacter, LexemeString,
-                           RawCharacter, StringParsers}
+                           RawCharacter, StringParsers, CombinedStrings}
 import parsley.unicode.satisfy
 
 import parsley.internal.deepembedding.singletons
@@ -197,8 +197,7 @@ private [token] abstract class Lexeme {
   *
   *     String literals are described generally as follows:
   *       - '''`desc.textDesc.stringEnds`''':  the sequence of characters that can begin or
-  *         end a string literal. Regardless of which of these is used for a specific literal,
-  *         the end of the literal ''must'' use the same sequence
+  *         end a string literal.
   *       - '''`desc.textDesc.graphicCharacter`''': describes the legal characters that may appear
   *         in the literal directly. Usually, this excludes control characters and newlines,
   *         but permits most other things. Escape sequences can represent non-graphic
@@ -210,8 +209,19 @@ private [token] abstract class Lexeme {
   *
   *     String literals are described generally as follows:
   *       - '''`desc.textDesc.multiStringEnds`''':  the sequence of characters that can begin or
-  *         end a multi-line string literal. Regardless of which of these is used for a specific literal,
-  *         the end of the literal ''must'' use the same sequence
+  *         end a multi-line string literal.
+  *       - '''`desc.textDesc.graphicCharacter`''': describes the legal characters that may appear
+  *         in the literal directly. Usually, this excludes control characters and newlines,
+  *         but permits most other things. Escape sequences can represent non-graphic
+  *         characters for non-raw strings
+  *       - '''`desc.textDesc.escapeSequences`''': describes the legal escape sequences that
+  *         that can appear in a string literal (for example `\n` or `\u000a`)
+  * @define combinedString
+  *    This is a collection of parsers concerned with handling both single-line and multi-line string literals.
+  *
+  *     String literals are described generally as follows:
+  *       - '''`desc.textDesc.stringEnds`'''/'''`desc.textDesc.multiStringEnds`''':  the sequence of characters that can begin or
+  *         end a string literal.
   *       - '''`desc.textDesc.graphicCharacter`''': describes the legal characters that may appear
   *         in the literal directly. Usually, this excludes control characters and newlines,
   *         but permits most other things. Escape sequences can represent non-graphic
@@ -374,33 +384,46 @@ final class Lexer(desc: descriptions.LexicalDesc, errConfig: errors.ErrorConfig)
           * @since 4.5.0
           * @group textg
           */
-        def character: CharacterParsers = new LexemeCharacter(nonlexeme.character, this)
+        val character: CharacterParsers = new LexemeCharacter(nonlexeme.character, this)
         /** $string
           *
           * @since 4.5.0
           * @group textg
           */
-        def string: StringParsers = new LexemeString(nonlexeme.string, this)
+        val string: StringParsers = new LexemeString(nonlexeme.string, this)
         /** $string
           *
           * @note $raw
           * @since 4.5.0
           * @group textg
           */
-        def rawString: StringParsers = new LexemeString(nonlexeme.rawString, this)
+        val rawString: StringParsers = new LexemeString(nonlexeme.rawString, this)
         /** $multiString
           *
           * @since 4.5.0
           * @group textg
           */
-        def multiString: StringParsers = new LexemeString(nonlexeme.multiString, this)
+        val multiString: StringParsers = new LexemeString(nonlexeme.multiString, this)
         /** $multiString
           *
           * @note $raw
           * @since 4.5.0
           * @group textg
           */
-        def rawMultiString: StringParsers = new LexemeString(nonlexeme.rawMultiString, this)
+        val rawMultiString: StringParsers = new LexemeString(nonlexeme.rawMultiString, this)
+        /** $combinedString
+          *
+          * @since 5.0.0
+          * @group textg
+          */
+        val combinedString: StringParsers =  new LexemeString(nonlexeme.combinedString, this)
+        /** $combinedString
+          *
+          * @note $raw
+          * @since 5.0.0
+          * @group textg
+          */
+        val rawCombinedString: StringParsers = new LexemeString(nonlexeme.rawCombinedString, this)
 
         /** $symbol
           *
@@ -810,39 +833,59 @@ final class Lexer(desc: descriptions.LexicalDesc, errConfig: errors.ErrorConfig)
         private val escapes = new Escape(desc.textDesc.escapeSequences, errConfig, generic)
         private val escapeChar = new EscapableCharacter(desc.textDesc.escapeSequences, escapes, space.space, errConfig)
         private val rawChar = new RawCharacter(errConfig)
+        private val _character = new ConcreteCharacter(desc.textDesc, escapes, errConfig)
+        private val _string = new ConcreteString(desc.textDesc.stringEnds, escapeChar, desc.textDesc.graphicCharacter, false, errConfig)
+        private val _rawString = new ConcreteString(desc.textDesc.stringEnds, rawChar, desc.textDesc.graphicCharacter, false, errConfig)
+        private val _multiString = new ConcreteString(desc.textDesc.multiStringEnds, escapeChar, desc.textDesc.graphicCharacter, true, errConfig)
+        private val _rawMultiString = new ConcreteString(desc.textDesc.multiStringEnds, rawChar, desc.textDesc.graphicCharacter, true, errConfig)
+        private val _combinedString = new CombinedStrings(desc.textDesc.stringEnds, desc.textDesc.multiStringEnds, _string, _multiString, escapeChar, errConfig)
+        private val _rawCombinedString = new CombinedStrings(desc.textDesc.stringEnds, desc.textDesc.multiStringEnds, _rawString, _rawMultiString, rawChar, errConfig)
 
         /** $character
           *
           * @since 4.5.0
           * @group textg
           */
-        val character: CharacterParsers = new ConcreteCharacter(desc.textDesc, escapes, errConfig)
+        def character: CharacterParsers = _character
         /** $string
           *
           * @since 4.5.0
           * @group textg
           */
-        val string: StringParsers = new ConcreteString(desc.textDesc.stringEnds, escapeChar, desc.textDesc.graphicCharacter, false, errConfig)
+        def string: StringParsers = _string
         /** $string
           *
           * @note $raw
           * @since 4.5.0
           * @group textg
           */
-        val rawString: StringParsers = new ConcreteString(desc.textDesc.stringEnds, rawChar, desc.textDesc.graphicCharacter, false, errConfig)
+        val rawString: StringParsers = _rawString
         /** $multiString
           *
           * @since 4.5.0
           * @group textg
           */
-        val multiString: StringParsers = new ConcreteString(desc.textDesc.multiStringEnds, escapeChar, desc.textDesc.graphicCharacter, true, errConfig)
+        val multiString: StringParsers = _multiString
         /** $multiString
           *
           * @note $raw
           * @since 4.5.0
           * @group textg
           */
-        val rawMultiString: StringParsers = new ConcreteString(desc.textDesc.multiStringEnds, rawChar, desc.textDesc.graphicCharacter, true, errConfig)
+        val rawMultiString: StringParsers = _rawMultiString
+        /** $combinedString
+          *
+          * @since 5.0.0
+          * @group textg
+          */
+        val combinedString: StringParsers = _combinedString
+        /** $combinedString
+          *
+          * @note $raw
+          * @since 5.0.0
+          * @group textg
+          */
+        val rawCombinedString: StringParsers = _rawCombinedString
 
         /** $symbol
           *

--- a/parsley/shared/src/main/scala/parsley/token/errors/ConfigImplUntyped.scala
+++ b/parsley/shared/src/main/scala/parsley/token/errors/ConfigImplUntyped.scala
@@ -62,13 +62,13 @@ private [parsley] sealed trait Labeller {
   */
 final class Label(val label: String, val labels: String*) extends LabelConfig {
     require(label.nonEmpty && labels.forall(_.nonEmpty), "labels cannot be empty strings")
-    private [parsley] final override def apply[A](p: Parsley[A]) = p.label(label, labels: _*)
+    private [parsley] final override def apply[A](p: Parsley[A]) = p.label(label, labels*)
     private [parsley] final override def asExpectDescs: Iterable[ExpectDesc] = (label +: labels).map(new ExpectDesc(_))
     private [parsley] final override def asExpectDescs(@unused otherwise: String) = asExpectDescs
     private [parsley] final override def asExpectItems(@unused raw: String) = asExpectDescs
     private [parsley] final override def orElse(config: LabelWithExplainConfig) = config match {
-        case r: Reason => new LabelAndReason(r.reason, label, labels: _*)
-        case lr: LabelAndReason => new LabelAndReason(lr.reason, label, labels: _*)
+        case r: Reason => new LabelAndReason(r.reason, label, labels*)
+        case lr: LabelAndReason => new LabelAndReason(lr.reason, label, labels*)
         case _ => this
     }
     private [parsley] final override def orElse(config: LabelConfig) = this
@@ -78,7 +78,7 @@ final class Label(val label: String, val labels: String*) extends LabelConfig {
   * @group labels
   */
 object Label extends Labeller {
-    def apply(label: String, labels: String*): LabelConfig = new Label(label, labels: _*)
+    def apply(label: String, labels: String*): LabelConfig = new Label(label, labels*)
     private [parsley] final def config(name: String) = new Label(name)
 }
 
@@ -107,8 +107,8 @@ final class Reason(val reason: String) extends ExplainConfig {
     private [parsley] final override def asExpectDescs(otherwise: String) = Some(new ExpectDesc(otherwise))
     private [parsley] final override def asExpectItems(raw: String) = Some(new ExpectRaw(raw))
     private [parsley] final override def orElse(config: LabelWithExplainConfig) = config match {
-        case l: Label => new LabelAndReason(reason, l.label, l.labels: _*)
-        case lr: LabelAndReason => new LabelAndReason(reason, lr.label, lr.labels: _*)
+        case l: Label => new LabelAndReason(reason, l.label, l.labels*)
+        case lr: LabelAndReason => new LabelAndReason(reason, lr.label, lr.labels*)
         case _ => this
     }
     private [parsley] final override def asReason: Option[String] = Some(reason)
@@ -127,7 +127,7 @@ object Reason {
 final class LabelAndReason(val reason: String, val label: String, val labels: String*) extends LabelWithExplainConfig {
     require(reason.nonEmpty, "reason cannot be empty strings, use `Label` instead")
     require(label.nonEmpty && labels.forall(_.nonEmpty), "labels cannot be empty strings")
-    private [parsley] final override def apply[A](p: Parsley[A]) = p.label(label, labels: _*).explain(reason)
+    private [parsley] final override def apply[A](p: Parsley[A]) = p.label(label, labels*).explain(reason)
     private [parsley] final override def asExpectDescs = (label +: labels).map(new ExpectDesc(_))
     private [parsley] final override def asExpectDescs(@unused otherwise: String) = asExpectDescs
     private [parsley] final override def asExpectItems(@unused raw: String) = asExpectDescs
@@ -138,7 +138,7 @@ final class LabelAndReason(val reason: String, val label: String, val labels: St
   * @group labels
   */
 object LabelAndReason {
-    def apply(reason: String, label: String, labels: String*): LabelWithExplainConfig = new LabelAndReason(reason, label, labels: _*)
+    def apply(reason: String, label: String, labels: String*): LabelWithExplainConfig = new LabelAndReason(reason, label, labels*)
 }
 
 /** This object specifies that no special labels or reasons should be generated, and default errors should be used instead.

--- a/parsley/shared/src/main/scala/parsley/token/errors/ErrorConfig.scala
+++ b/parsley/shared/src/main/scala/parsley/token/errors/ErrorConfig.scala
@@ -519,7 +519,7 @@ class ErrorConfig {
 
     /** How a ASCII-only string literal should be referred to or explained in error messages.
       * @since 4.1.0
-      * @param multi whether this is for multi-line strings
+      * @param multi whether this is for multi-line strings (false could indicate both, if combined)
       * @param raw whether this is for raw strings
       * @note defaults to [[NotConfigured `NotConfigured`]]
       * @group text
@@ -527,7 +527,7 @@ class ErrorConfig {
     def labelStringAscii(@unused multi: Boolean, @unused raw: Boolean): LabelWithExplainConfig = NotConfigured
     /** How a Latin1-only string literal should be referred to or explained in error messages.
       * @since 4.1.0
-      * @param multi whether this is for multi-line strings
+      * @param multi whether this is for multi-line strings (false could indicate both, if combined)
       * @param raw whether this is for raw strings
       * @note defaults to [[NotConfigured `NotConfigured`]]
       * @group text
@@ -535,7 +535,7 @@ class ErrorConfig {
     def labelStringLatin1(@unused multi: Boolean, @unused raw: Boolean): LabelWithExplainConfig = NotConfigured
     /** How a UTF-16-only string should literal be referred to or explained in error messages.
       * @since 4.1.0
-      * @param multi whether this is for multi-line strings
+      * @param multi whether this is for multi-line strings (false could indicate both, if combined)
       * @param raw whether this is for raw strings
       * @note defaults to [[NotConfigured `NotConfigured`]]
       * @group text

--- a/parsley/shared/src/main/scala/parsley/token/text/ConcreteString.scala
+++ b/parsley/shared/src/main/scala/parsley/token/text/ConcreteString.scala
@@ -5,30 +5,42 @@
  */
 package parsley.token.text
 
-import parsley.Parsley, Parsley.{atomic, fresh, pure}
-import parsley.character.{char, string}
-import parsley.combinator.{choice, skipManyUntil}
+import parsley.Parsley, Parsley.{atomic, empty, fresh, pure}
+import parsley.character.{char, string, strings}
+import parsley.combinator.skipManyUntil
 import parsley.errors.combinator.ErrorMethods
-import parsley.syntax.zipped._
+import parsley.state.Ref
+import parsley.syntax.zipped.*
 import parsley.token.errors.{ErrorConfig, LabelConfig, LabelWithExplainConfig}
 import parsley.token.CharPred
 
 private [token] final class ConcreteString(ends: Set[(String, String)], stringChar: StringCharacter, isGraphic: CharPred,
                                            allowsAllSpace: Boolean, err: ErrorConfig) extends StringParsers {
+    private lazy val sbRef = Ref.make[StringBuilder]
+    private final def finalStr = sbRef.gets { sb =>
+        val s = sb.toString
+        sb.clear()
+        s
+    }
 
     private def stringLiteral(valid: Parsley[StringBuilder] => Parsley[StringBuilder],
                               openLabel: (Boolean, Boolean) => LabelWithExplainConfig, closeLabel: (Boolean, Boolean) => LabelConfig) = {
-        choice(ends.view.map(makeStringParser(valid, openLabel, closeLabel)).toSeq: _*) ~> sbReg.gets(_.toString)
+        ends.view.map(makeStringParser(sbRef, valid, openLabel, closeLabel)).toList match {
+            case Nil => empty
+            case str0 :: strs => strings(stringStart(openLabel, _), str0, strs*) ~> finalStr
+        }
     }
     override lazy val fullUtf16: Parsley[String] = stringLiteral(identity, err.labelStringUtf16, err.labelStringUtf16End)
     override lazy val ascii: Parsley[String] = stringLiteral(StringParsers.ensureAscii(err), err.labelStringAscii, err.labelStringAsciiEnd)
     override lazy val latin1: Parsley[String] = stringLiteral(StringParsers.ensureExtendedAscii(err), err.labelStringLatin1, err.labelStringLatin1End)
 
-    private val sbReg = parsley.state.Ref.make[StringBuilder]
+    private def stringStart(openLabel: (Boolean, Boolean) => LabelWithExplainConfig, end: String) =
+        openLabel(allowsAllSpace, stringChar.isRaw)(string(end)).ut()
 
-    private def makeStringParser(valid: Parsley[StringBuilder] => Parsley[StringBuilder],
+    private def makeStringParser(sbRef: Ref[StringBuilder], valid: Parsley[StringBuilder] => Parsley[StringBuilder],
                                  openLabel: (Boolean, Boolean) => LabelWithExplainConfig, closeLabel: (Boolean, Boolean) => LabelConfig)
                                 (terminalStr: (String, String)) = {
+        // NOTE: begin is consumed by the caller of this function
         val (begin, end) = terminalStr
         val terminalInit = end.charAt(0)
         val strChar = stringChar(CharacterParsers.letter(terminalInit, allowsAllSpace, isGraphic))
@@ -38,12 +50,13 @@ private [token] final class ConcreteString(ends: Set[(String, String)], stringCh
         }
         // `content` is in a dropped position, so needs the unsafe to avoid the mutation
         // TODO: this could be fixed better with registers and skipMany?
-        val content = valid(parsley.expr.infix.secretLeft1((sbReg.get, strChar).zipped(pf), strChar, pure(pf), null).impure)
-        // open should be first, to allow for a jump table on the main choice
-        openLabel(allowsAllSpace, stringChar.isRaw)(string(begin)) ~>
-        // then only one string builder needs allocation
-        sbReg.set(fresh(new StringBuilder)) ~>
-        skipManyUntil(sbReg.update(char(terminalInit).hide.as((sb: StringBuilder) => sb += terminalInit)) <|> content,
-                      closeLabel(allowsAllSpace, stringChar.isRaw)(atomic(string(end)))) // atomic needed because ambiguity with init
+        val content = valid(parsley.expr.infix.secretLeft1((sbRef.get, strChar).zipped(pf), strChar, pure(pf), name = null).impure)
+        val p =
+            // only one string builder needs allocation
+            sbRef.set(fresh(new StringBuilder)) ~>
+            // FIXME: could this remove the atomic by factoring the start of the string out?
+            skipManyUntil(sbRef.update(char(terminalInit).hide.as((sb: StringBuilder) => sb += terminalInit)) | content,
+                          closeLabel(allowsAllSpace, stringChar.isRaw)(atomic(string(end)))) // atomic needed because ambiguity with init
+        (begin, p)
     }
 }

--- a/parsley/shared/src/main/scala/parsley/token/text/ConcreteString.scala
+++ b/parsley/shared/src/main/scala/parsley/token/text/ConcreteString.scala
@@ -13,43 +13,56 @@ import parsley.state.Ref
 import parsley.syntax.zipped.*
 import parsley.token.errors.{ErrorConfig, LabelConfig, LabelWithExplainConfig}
 import parsley.token.CharPred
+import parsley.token.text.ConcreteStringImpl.{addCodepoint, endParsers}
 
-private [token] final class ConcreteString(ends: Set[(String, String)], stringChar: StringCharacter, isGraphic: CharPred,
-                                           allowsAllSpace: Boolean, err: ErrorConfig) extends StringParsers {
-    private lazy val sbRef = Ref.make[StringBuilder]
+private [text] sealed abstract class ConcreteStringImpl(stringChar: StringCharacter, err: ErrorConfig) extends StringParsers {
+    override final lazy val fullUtf16: Parsley[String] = stringLiteral(identity, err.labelStringUtf16, err.labelStringUtf16End)
+    override final lazy val ascii: Parsley[String] = stringLiteral(StringParsers.ensureAscii(err), err.labelStringAscii, err.labelStringAsciiEnd)
+    override final lazy val latin1: Parsley[String] = stringLiteral(StringParsers.ensureExtendedAscii(err), err.labelStringLatin1, err.labelStringLatin1End)
+
+    protected def stringLiteral(valid: Parsley[StringBuilder] => Parsley[StringBuilder],
+                                openLabel: (Boolean, Boolean) => LabelWithExplainConfig, closeLabel: (Boolean, Boolean) => LabelConfig): Parsley[String]
+
+    protected final lazy val sbRef = Ref.make[StringBuilder]
+    protected final def literals(parsers: List[(String, Parsley[Unit])], openLabel: (Boolean, Boolean) => LabelWithExplainConfig, allowsAllSpace: Boolean) = parsers match {
+        case Nil => empty
+        case str0 :: strs => strings(stringStart(openLabel, allowsAllSpace, _), str0, strs*) ~> finalStr
+    }
+
     private final def finalStr = sbRef.gets { sb =>
         val s = sb.toString
         sb.clear()
         s
     }
-
-    private def stringLiteral(valid: Parsley[StringBuilder] => Parsley[StringBuilder],
-                              openLabel: (Boolean, Boolean) => LabelWithExplainConfig, closeLabel: (Boolean, Boolean) => LabelConfig) = {
-        ends.view.map(makeStringParser(sbRef, valid, closeLabel)).toList match {
-            case Nil => empty
-            case str0 :: strs => strings(stringStart(openLabel, _), str0, strs*) ~> finalStr
-        }
-    }
-    override lazy val fullUtf16: Parsley[String] = stringLiteral(identity, err.labelStringUtf16, err.labelStringUtf16End)
-    override lazy val ascii: Parsley[String] = stringLiteral(StringParsers.ensureAscii(err), err.labelStringAscii, err.labelStringAsciiEnd)
-    override lazy val latin1: Parsley[String] = stringLiteral(StringParsers.ensureExtendedAscii(err), err.labelStringLatin1, err.labelStringLatin1End)
-
-    private def stringStart(openLabel: (Boolean, Boolean) => LabelWithExplainConfig, end: String) =
+    private final def stringStart(openLabel: (Boolean, Boolean) => LabelWithExplainConfig, allowsAllSpace: Boolean, end: String) =
         openLabel(allowsAllSpace, stringChar.isRaw)(string(end)).ut()
+}
+private [text] object ConcreteStringImpl {
+    def endParsers(ends: Set[(String, String)], impl: ConcreteString, sbRef: Ref[StringBuilder], valid: Parsley[StringBuilder] => Parsley[StringBuilder], closeLabel: (Boolean, Boolean) => LabelConfig) = {
+        ends.view.map(impl.makeStringParser(sbRef, valid, closeLabel)).toList
+    }
+    val addCodepoint = (sb: StringBuilder, cpo: Option[Int]) => {
+        for (cp <- cpo) parsley.unicode.addCodepoint(sb, cp)
+        sb
+    }
+}
 
-    private def makeStringParser(sbRef: Ref[StringBuilder], valid: Parsley[StringBuilder] => Parsley[StringBuilder], closeLabel: (Boolean, Boolean) => LabelConfig)
-                                (terminalStr: (String, String)) = {
+private [token] final class ConcreteString(ends: Set[(String, String)], stringChar: StringCharacter, isGraphic: CharPred, allowsAllSpace: Boolean, err: ErrorConfig)
+    extends ConcreteStringImpl(stringChar, err) {
+    protected def stringLiteral(valid: Parsley[StringBuilder] => Parsley[StringBuilder],
+                                openLabel: (Boolean, Boolean) => LabelWithExplainConfig, closeLabel: (Boolean, Boolean) => LabelConfig) = {
+        literals(endParsers(ends, this, sbRef, valid, closeLabel), openLabel, allowsAllSpace)
+    }
+
+    private [text] def makeStringParser(sbRef: Ref[StringBuilder], valid: Parsley[StringBuilder] => Parsley[StringBuilder], closeLabel: (Boolean, Boolean) => LabelConfig)
+                                       (terminalStr: (String, String)) = {
         // NOTE: begin is consumed by the caller of this function
         val (begin, end) = terminalStr
         val terminalInit = end.charAt(0)
         val strChar = stringChar(CharacterParsers.letter(terminalInit, allowsAllSpace, isGraphic))
-        val pf = (sb: StringBuilder, cpo: Option[Int]) => {
-            for (cp <- cpo) parsley.unicode.addCodepoint(sb, cp)
-            sb
-        }
-        // `content` is in a dropped position, so needs the unsafe to avoid the mutation
-        // TODO: this could be fixed better with registers and skipMany?
-        val content = valid(parsley.expr.infix.secretLeft1((sbRef.get, strChar).zipped(pf), strChar, pure(pf), name = null).impure)
+        // `content` is in a dropped position, so needs the impure to avoid losing the mutation
+        // TODO: this could be fixed better with references and skipMany?
+        val content = valid(parsley.expr.infix.secretLeft1((sbRef.get, strChar).zipped(addCodepoint), strChar, pure(addCodepoint), name = null).impure)
         val p =
             // only one string builder needs allocation
             sbRef.set(fresh(new StringBuilder)) ~>
@@ -57,5 +70,15 @@ private [token] final class ConcreteString(ends: Set[(String, String)], stringCh
             skipManyUntil(sbRef.update(char(terminalInit).hide.as((sb: StringBuilder) => sb += terminalInit)) | content,
                           closeLabel(allowsAllSpace, stringChar.isRaw)(atomic(string(end)))) // atomic needed because ambiguity with init
         (begin, p)
+    }
+}
+
+private [token] final class CombinedStrings(singleEnds: Set[(String, String)], multiEnds: Set[(String, String)],
+                                            single: ConcreteString, multi: ConcreteString,
+                                            stringChar: StringCharacter, err: ErrorConfig) extends ConcreteStringImpl(stringChar, err) {
+    protected def stringLiteral(valid: Parsley[StringBuilder] => Parsley[StringBuilder],
+                                openLabel: (Boolean, Boolean) => LabelWithExplainConfig, closeLabel: (Boolean, Boolean) => LabelConfig) = {
+        val parsers = endParsers(singleEnds, single, sbRef, valid, closeLabel) ::: endParsers(multiEnds, multi, sbRef, valid, closeLabel)
+        literals(parsers, openLabel, allowsAllSpace = false)
     }
 }

--- a/parsley/shared/src/main/scala/parsley/token/text/ConcreteString.scala
+++ b/parsley/shared/src/main/scala/parsley/token/text/ConcreteString.scala
@@ -25,7 +25,7 @@ private [token] final class ConcreteString(ends: Set[(String, String)], stringCh
 
     private def stringLiteral(valid: Parsley[StringBuilder] => Parsley[StringBuilder],
                               openLabel: (Boolean, Boolean) => LabelWithExplainConfig, closeLabel: (Boolean, Boolean) => LabelConfig) = {
-        ends.view.map(makeStringParser(sbRef, valid, openLabel, closeLabel)).toList match {
+        ends.view.map(makeStringParser(sbRef, valid, closeLabel)).toList match {
             case Nil => empty
             case str0 :: strs => strings(stringStart(openLabel, _), str0, strs*) ~> finalStr
         }
@@ -37,8 +37,7 @@ private [token] final class ConcreteString(ends: Set[(String, String)], stringCh
     private def stringStart(openLabel: (Boolean, Boolean) => LabelWithExplainConfig, end: String) =
         openLabel(allowsAllSpace, stringChar.isRaw)(string(end)).ut()
 
-    private def makeStringParser(sbRef: Ref[StringBuilder], valid: Parsley[StringBuilder] => Parsley[StringBuilder],
-                                 openLabel: (Boolean, Boolean) => LabelWithExplainConfig, closeLabel: (Boolean, Boolean) => LabelConfig)
+    private def makeStringParser(sbRef: Ref[StringBuilder], valid: Parsley[StringBuilder] => Parsley[StringBuilder], closeLabel: (Boolean, Boolean) => LabelConfig)
                                 (terminalStr: (String, String)) = {
         // NOTE: begin is consumed by the caller of this function
         val (begin, end) = terminalStr

--- a/parsley/shared/src/main/scala/parsley/token/text/ConcreteString.scala
+++ b/parsley/shared/src/main/scala/parsley/token/text/ConcreteString.scala
@@ -13,45 +13,24 @@ import parsley.state.Ref
 import parsley.syntax.zipped.*
 import parsley.token.errors.{ErrorConfig, LabelConfig, LabelWithExplainConfig}
 import parsley.token.CharPred
-import parsley.token.text.ConcreteStringImpl.{addCodepoint, endParsers}
+import parsley.token.text.ConcreteStringTemplate.*
 
-private [text] sealed abstract class ConcreteStringImpl(stringChar: StringCharacter, err: ErrorConfig) extends StringParsers {
+private [text] sealed abstract class ConcreteStringTemplate(err: ErrorConfig) extends StringParsers {
     override final lazy val fullUtf16: Parsley[String] = stringLiteral(identity, err.labelStringUtf16, err.labelStringUtf16End)
     override final lazy val ascii: Parsley[String] = stringLiteral(StringParsers.ensureAscii(err), err.labelStringAscii, err.labelStringAsciiEnd)
     override final lazy val latin1: Parsley[String] = stringLiteral(StringParsers.ensureExtendedAscii(err), err.labelStringLatin1, err.labelStringLatin1End)
 
     protected def stringLiteral(valid: Parsley[StringBuilder] => Parsley[StringBuilder],
                                 openLabel: (Boolean, Boolean) => LabelWithExplainConfig, closeLabel: (Boolean, Boolean) => LabelConfig): Parsley[String]
-
-    protected final lazy val sbRef = Ref.make[StringBuilder]
-    protected final def literals(parsers: List[(String, Parsley[Unit])], openLabel: (Boolean, Boolean) => LabelWithExplainConfig, allowsAllSpace: Boolean) = parsers match {
-        case Nil => empty
-        case str0 :: strs => strings(stringStart(openLabel, allowsAllSpace, _), str0, strs*) ~> finalStr
-    }
-
-    private final def finalStr = sbRef.gets { sb =>
-        val s = sb.toString
-        sb.clear()
-        s
-    }
-    private final def stringStart(openLabel: (Boolean, Boolean) => LabelWithExplainConfig, allowsAllSpace: Boolean, end: String) =
-        openLabel(allowsAllSpace, stringChar.isRaw)(string(end)).ut()
-}
-private [text] object ConcreteStringImpl {
-    def endParsers(ends: Set[(String, String)], impl: ConcreteString, sbRef: Ref[StringBuilder], valid: Parsley[StringBuilder] => Parsley[StringBuilder], closeLabel: (Boolean, Boolean) => LabelConfig) = {
-        ends.view.map(impl.makeStringParser(sbRef, valid, closeLabel)).toList
-    }
-    val addCodepoint = (sb: StringBuilder, cpo: Option[Int]) => {
-        for (cp <- cpo) parsley.unicode.addCodepoint(sb, cp)
-        sb
-    }
 }
 
 private [token] final class ConcreteString(ends: Set[(String, String)], stringChar: StringCharacter, isGraphic: CharPred, allowsAllSpace: Boolean, err: ErrorConfig)
-    extends ConcreteStringImpl(stringChar, err) {
+    extends ConcreteStringTemplate(err) {
+    private lazy val sbRef = Ref.make[StringBuilder]
+
     protected def stringLiteral(valid: Parsley[StringBuilder] => Parsley[StringBuilder],
                                 openLabel: (Boolean, Boolean) => LabelWithExplainConfig, closeLabel: (Boolean, Boolean) => LabelConfig) = {
-        literals(endParsers(ends, this, sbRef, valid, closeLabel), openLabel, allowsAllSpace)
+        literals(endParsers(ends, this, sbRef, valid, closeLabel), sbRef, stringStart(openLabel, stringChar, allowsAllSpace, _))
     }
 
     private [text] def makeStringParser(sbRef: Ref[StringBuilder], valid: Parsley[StringBuilder] => Parsley[StringBuilder], closeLabel: (Boolean, Boolean) => LabelConfig)
@@ -75,10 +54,36 @@ private [token] final class ConcreteString(ends: Set[(String, String)], stringCh
 
 private [token] final class CombinedStrings(singleEnds: Set[(String, String)], multiEnds: Set[(String, String)],
                                             single: ConcreteString, multi: ConcreteString,
-                                            stringChar: StringCharacter, err: ErrorConfig) extends ConcreteStringImpl(stringChar, err) {
+                                            stringChar: StringCharacter, err: ErrorConfig) extends ConcreteStringTemplate(err) {
+    private lazy val sbRef = Ref.make[StringBuilder]
+
     protected def stringLiteral(valid: Parsley[StringBuilder] => Parsley[StringBuilder],
                                 openLabel: (Boolean, Boolean) => LabelWithExplainConfig, closeLabel: (Boolean, Boolean) => LabelConfig) = {
         val parsers = endParsers(singleEnds, single, sbRef, valid, closeLabel) ::: endParsers(multiEnds, multi, sbRef, valid, closeLabel)
-        literals(parsers, openLabel, allowsAllSpace = false)
+        literals(parsers, sbRef, stringStart(openLabel, stringChar, allowsAllSpace = false, _))
+    }
+}
+
+private [text] object ConcreteStringTemplate {
+    def endParsers(ends: Set[(String, String)], impl: ConcreteString, sbRef: Ref[StringBuilder], valid: Parsley[StringBuilder] => Parsley[StringBuilder], closeLabel: (Boolean, Boolean) => LabelConfig) = {
+        ends.view.map(impl.makeStringParser(sbRef, valid, closeLabel)).toList
+    }
+    val addCodepoint = (sb: StringBuilder, cpo: Option[Int]) => {
+        for (cp <- cpo) parsley.unicode.addCodepoint(sb, cp)
+        sb
+    }
+
+    def stringStart(openLabel: (Boolean, Boolean) => LabelWithExplainConfig, stringChar: StringCharacter, allowsAllSpace: Boolean, end: String) =
+        openLabel(allowsAllSpace, stringChar.isRaw)(string(end)).ut()
+
+    def literals(parsers: List[(String, Parsley[Unit])], sbRef: Ref[StringBuilder], string: String => Parsley[String]) = parsers match {
+        case Nil => empty
+        case str0 :: strs => strings(string, str0, strs*) ~> finalStr(sbRef)
+    }
+
+    private def finalStr(sbRef: Ref[StringBuilder]) = sbRef.gets { sb =>
+        val s = sb.toString
+        sb.clear()
+        s
     }
 }

--- a/parsley/shared/src/test/scala/parsley/token/text/StringTests.scala
+++ b/parsley/shared/src/test/scala/parsley/token/text/StringTests.scala
@@ -28,6 +28,12 @@ class StringTests extends ParsleyTest {
         makeString(desc, new RawCharacter(errConfig), false)
     private def makeRawMultiString(desc: TextDesc): StringParsers =
         makeString(desc, new RawCharacter(errConfig), true)
+    private def makeCombinedString(desc: TextDesc): StringParsers = {
+        val char = new EscapableCharacter(desc.escapeSequences, new Escape(desc.escapeSequences, errConfig, generic), space, errConfig)
+        val single = new ConcreteString(desc.stringEnds, char, desc.graphicCharacter, allowsAllSpace = false, errConfig)
+        val multi = new ConcreteString(desc.multiStringEnds, char, desc.graphicCharacter, allowsAllSpace = true, errConfig)
+        new CombinedStrings(desc.stringEnds, desc.multiStringEnds, single, multi, char, errConfig)
+    }
 
     def unicodeCases(str: StringParsers)(tests: (String, Option[String], Position)*): Unit = cases(str.fullUtf16)(tests: _*)
     def asciiCases(str: StringParsers)(tests: (String, Option[String], Position)*): Unit = cases(str.ascii)(tests: _*)
@@ -160,4 +166,11 @@ class StringTests extends ParsleyTest {
         "\"abc\nc\"" -> Some("abc\nc"),
         "\"d\"" -> None,
     )
+
+    "combined strings" should "allow for for either string with no ambiguity" in {
+        asciiCases(makeCombinedString(plain.copy(stringEnds = Set(("\"", "\"")), multiStringEnds = Set(("\"\"\"", "\"\"\"")))))(
+            "\"abc\"" -> Some("abc"),
+            "\"\"\"abc\n\"\"\"" -> Some("abc\n"),
+        )
+    }
 }


### PR DESCRIPTION
fixes #276 for 5.0 only: introduces `combinedString` variants that allow for efficient parsing of ambiguous single-line and multi-line  strings together. Also improves efficiency of parsing alternatives in the string ends.