### PR TITLE
Multiple `isMeta` annotations on bridge constructor

### DIFF
--- a/parsley/shared/src/main/scala-3/parsley/generic/experimental/macro.scala
+++ b/parsley/shared/src/main/scala-3/parsley/generic/experimental/macro.scala
@@ -41,18 +41,18 @@ private class BridgeImpl(using Quotes) {
                 val bridgePrimaryArgs = bridgeParams.collect {
                     case sym if !hasMeta(sym) => (sym.name, contextualise(tyRepr.memberType(sym)))
                 }
-                val existsUniqueMeta = categorisedArgs.flatten.foldLeft(Option.empty[MetaImpl[?]]) {
-                    case (None, BridgeArg.Meta(impl)) => Some(impl)
-                    // FIXME: lift this, we need a whole list of them!
-                    case (Some(_), BridgeArg.Meta(_)) => report.errorAndAbort("When `ParsableMeta` appears in a bridged type, it must be unique")
-                    case (meta, _)                    => meta
+                val metaImpls = categorisedArgs.flatten.collect {
+                    case BridgeArg.Meta(impl) => impl
                 }
-                lazy val con = constructor[T](cls, bridgePrimaryArgs, tyArgs, categorisedArgs, existsUniqueMeta.map(_.tyRepr))
-                val lift = synthesiseLift[S](existsUniqueMeta, bridgePrimaryArgs.map(_._2), con, _)
+                // FIXME: lift this
+                if (metaImpls.length >= 2) report.errorAndAbort("When `ParsableMeta` appears in a bridged type, it must be unique")
+                val metaReprs = metaImpls.map(_.tyRepr)
+                lazy val con = constructor[T](cls, bridgePrimaryArgs, tyArgs, categorisedArgs, metaReprs)
+                val lift = synthesiseLift[S](metaImpls.headOption, bridgePrimaryArgs.map(_._2), con, _)
                 val from = [Fn] => { (fnTy: Type[Fn]) =>
                     given Type[Fn] = fnTy
-                    val curriedCon = curriedConstructor[Fn, T](cls, bridgePrimaryArgs, tyArgs, categorisedArgs, existsUniqueMeta.map(_.tyRepr))
-                    synthesiseSingle[Fn](existsUniqueMeta, curriedCon)
+                    val curriedCon = curriedConstructor[Fn, T](cls, bridgePrimaryArgs, tyArgs, categorisedArgs, metaReprs)
+                    synthesiseSingle[Fn](metaImpls.headOption, curriedCon)
                 }
                 // TODO: ensure validation if Err is encountered (report separately, but then abort if failed (Option))
                 synthesiseBridge[S](tyRepr.typeSymbol.name, bridgePrimaryArgs.map(_._2.asType), lift, from, labels, reason)
@@ -104,19 +104,16 @@ private class BridgeImpl(using Quotes) {
       * @param lamArgs the arguments for the lambda (without positions or defaulted)
       * @param clsTyArgs the type parameters provided to the constructor
       * @param otherArgs any remaining non-primary arguments
-      * @param posRepr the position
+      * @param metaReprs the position
       * @return a lambda of the form `(lamArgs..) => cls[clsTyArgs](..)(otherArgs)`
       */
-    private def constructor[R: Type](cls: Symbol, lamArgs: List[(String, TypeRepr)], clsTyArgs: List[TypeRepr], otherArgs: List[List[BridgeArg]], posRepr: Option[TypeRepr]): Term = {
-        val requiresPosition = posRepr.isDefined
-        val (paramNames, lamTys) = (posRepr.map("pos" -> _) ++: lamArgs).unzip
+    private def constructor[R: Type](cls: Symbol, lamArgs: List[(String, TypeRepr)], clsTyArgs: List[TypeRepr], otherArgs: List[List[BridgeArg]], metaReprs: List[TypeRepr]): Term = {
+        val (paramNames, lamTys) = (metaReprs.zipWithIndex.map((ty, i) => s"meta$i" -> ty) ++: lamArgs).unzip
         // grrrrrrrr why has Scala given me Tree and not Term?!
         Lambda(Symbol.spliceOwner, MethodType(paramNames)(_ => lamTys, _ => TypeRepr.of[R]), { (lamSym, params) =>
-            val paramTerms = params.map(_.asExpr.asTerm)
-            val (posParam, paramTermsWithoutPos) = paramTerms match
-                case posParam :: paramTerms if requiresPosition => (Some(posParam), paramTerms)
-                case paramTerms => (None, paramTerms)
-            appliedCon(cls, lamSym, paramTermsWithoutPos.toVector, clsTyArgs, otherArgs, posParam)
+            val paramTerms = params.map(_.asExpr.asTerm).toVector
+            val (metaParams, paramTermsWithoutPos) = paramTerms.splitAt(metaReprs.length)
+            appliedCon(cls, lamSym, paramTermsWithoutPos, clsTyArgs, otherArgs, metaParams)
         })
     }
 
@@ -129,27 +126,29 @@ private class BridgeImpl(using Quotes) {
       * @param posRepr the position
       * @return a lambda of the form `pos => (lamArgs..) => cls[clsTyArgs](..)(otherArgs)`
       */
-    private def curriedConstructor[Fn: Type, R: Type](cls: Symbol, lamArgs: List[(String, TypeRepr)], clsTyArgs: List[TypeRepr], otherArgs: List[List[BridgeArg]], metaRepr: Option[TypeRepr]): Term = {
+    private def curriedConstructor[Fn: Type, R: Type](cls: Symbol, lamArgs: List[(String, TypeRepr)], clsTyArgs: List[TypeRepr], otherArgs: List[List[BridgeArg]], metaReprs: List[TypeRepr]): Term = {
         val (paramNames, lamTys) = lamArgs.unzip
-        // grrrrrrrr why has Scala given me Tree and not Term?!
-        def inner(owner: Symbol, posParam: Option[Term]): Term = {
+        def inner(owner: Symbol, metaParams: Vector[Term]): Term = {
             // this is a singleton type
-            if (paramNames.isEmpty && posParam.isEmpty) Ident(cls.companionModule.termRef)
-            else if (paramNames.isEmpty) appliedCon(cls, owner, Vector.empty, clsTyArgs, otherArgs, posParam)
+            if (paramNames.isEmpty && metaParams.isEmpty) Ident(cls.companionModule.termRef)
+            else if (paramNames.isEmpty) appliedCon(cls, owner, Vector.empty, clsTyArgs, otherArgs, metaParams)
             else Lambda(owner, MethodType(paramNames)(_ => lamTys, _ => TypeRepr.of[R]), { (lamSym, params) =>
-                val paramTerms = params.map(_.asExpr.asTerm)
-                appliedCon(cls, lamSym, paramTerms.toVector, clsTyArgs, otherArgs, posParam)
+                // grrrrrrrr why has Scala given me Tree and not Term?!
+                appliedCon(cls, lamSym, params.map(_.asExpr.asTerm).toVector, clsTyArgs, otherArgs, metaParams)
             })
         }
-        metaRepr.fold(inner(Symbol.spliceOwner, None)) { metaRepr =>
-            Lambda(Symbol.spliceOwner, MethodType(List("pos"))(_ => List(metaRepr), _ => TypeRepr.of[Fn]), { (outerLamSym, metaParam) =>
-                // grrrrrrrr why has Scala given me Tree and not Term?!
-                inner(outerLamSym, metaParam.map(_.asExpr.asTerm).headOption)
-            })
+        metaReprs match {
+            case Nil => inner(Symbol.spliceOwner, Vector.empty)
+            case ms =>
+                val names = List.tabulate(ms.length)(i => s"meta$i")
+                Lambda(Symbol.spliceOwner, MethodType(names)(_ => ms, _ => TypeRepr.of[Fn]), { (outerLamSym, metaParam) =>
+                    // grrrrrrrr why has Scala given me Tree and not Term?!
+                    inner(outerLamSym, metaParam.map(_.asExpr.asTerm).toVector)
+                })
         }
     }
 
-    private def appliedCon(cls: Symbol, owner: Symbol, lamParams: IndexedSeq[Term], clsTyArgs: List[TypeRepr], otherArgs: List[List[BridgeArg]], metaParam: Option[Term]): Term = {
+    private def appliedCon(cls: Symbol, owner: Symbol, lamParams: IndexedSeq[Term], clsTyArgs: List[TypeRepr], otherArgs: List[List[BridgeArg]], metaParams: IndexedSeq[Term]): Term = {
         val tys: List[TypeTree] = clsTyArgs.map(tyRep => TypeTree.of(using tyRep.asType))
         val objTy = if tys.nonEmpty then New(Applied(TypeTree.ref(cls), tys)) else New(TypeTree.ref(cls))
         val con = objTy.select(cls.primaryConstructor).appliedToTypes(clsTyArgs)
@@ -165,8 +164,12 @@ private class BridgeImpl(using Quotes) {
             case params :: paramss =>
                 val mySeeds = seeds.toList
                 var i = 0 // FIXME: get rid of this
+                var j = 0 // FIXME: get rid of this
                 val terms = params.map {
-                    case BridgeArg.Meta(_) => metaParam.get
+                    case BridgeArg.Meta(_) =>
+                        val p = metaParams(j)
+                        j += 1
+                        p
                     case BridgeArg.Default(n, sym) =>
                         Ident(cls.companionModule.termRef).select(sym).appliedToTypes(clsTyArgs).appliedToArgss(mySeeds)
                     case BridgeArg.Err(name, pos) =>
@@ -191,6 +194,7 @@ private class BridgeImpl(using Quotes) {
         val tys = argTys :+ TypeRepr.of[R]
         val arity = argTys.size + existsUniquePosition.size
         TypeRepr.of[parsley.lift.type].typeSymbol.methodMember(s"lift$arity").headOption.map('{parsley.lift}.asTerm.select) match {
+            // FIXME: generalise
             case Some(lift) => existsUniquePosition match {
                 case Some(impl@MetaImpl(_, given Type[metaTy])) =>
                     val metaTyRepr = TypeRepr.of[metaTy]
@@ -207,6 +211,7 @@ private class BridgeImpl(using Quotes) {
     }
 
     private def synthesiseSingle[R: Type](existsUniquePosition: Option[MetaImpl[?]], con: Term): Expr[Parsley[R]] = existsUniquePosition match {
+        // FIXME: generalise
         case Some(impl@MetaImpl(_, given Type[metaTy])) => '{${impl.parser}.map[R](${con.asExprOf[metaTy => R]})}
         case None => '{Parsley.pure[R](${con.asExprOf[R]})}
     }

--- a/parsley/shared/src/main/scala-3/parsley/generic/experimental/macro.scala
+++ b/parsley/shared/src/main/scala-3/parsley/generic/experimental/macro.scala
@@ -48,7 +48,7 @@ private class BridgeImpl(using Quotes) {
                 if (metaImpls.length >= 2) report.errorAndAbort("When `ParsableMeta` appears in a bridged type, it must be unique")
                 val metaReprs = metaImpls.map(_.tyRepr)
                 lazy val con = constructor[T](cls, bridgePrimaryArgs, tyArgs, categorisedArgs, metaReprs)
-                val lift = synthesiseLift[S](metaImpls.headOption, bridgePrimaryArgs.map(_._2), con, _)
+                val lift = synthesiseLift[S](metaImpls, bridgePrimaryArgs.map(_._2), con, _)
                 val from = [Fn] => { (fnTy: Type[Fn]) =>
                     given Type[Fn] = fnTy
                     val curriedCon = curriedConstructor[Fn, T](cls, bridgePrimaryArgs, tyArgs, categorisedArgs, metaReprs)
@@ -108,7 +108,7 @@ private class BridgeImpl(using Quotes) {
       * @return a lambda of the form `(lamArgs..) => cls[clsTyArgs](..)(otherArgs)`
       */
     private def constructor[R: Type](cls: Symbol, lamArgs: List[(String, TypeRepr)], clsTyArgs: List[TypeRepr], otherArgs: List[List[BridgeArg]], metaReprs: List[TypeRepr]): Term = {
-        val (paramNames, lamTys) = (metaReprs.zipWithIndex.map((ty, i) => s"meta$i" -> ty) ++: lamArgs).unzip
+        val (paramNames, lamTys) = (metaReprs.zipWithIndex.map((ty, i) => s"meta$i" -> ty) ::: lamArgs).unzip
         // grrrrrrrr why has Scala given me Tree and not Term?!
         Lambda(Symbol.spliceOwner, MethodType(paramNames)(_ => lamTys, _ => TypeRepr.of[R]), { (lamSym, params) =>
             val paramTerms = params.map(_.asExpr.asTerm).toVector
@@ -190,22 +190,15 @@ private class BridgeImpl(using Quotes) {
         saturated
     }
 
-    private def synthesiseLift[R: Type](existsUniquePosition: Option[MetaImpl[?]], argTys: List[TypeRepr], con: Term, args: List[Term]): Expr[Parsley[R]] = {
+    private def synthesiseLift[R: Type](metaImpls: List[MetaImpl[?]], argTys: List[TypeRepr], con: Term, args: List[Term]): Expr[Parsley[R]] = {
         val tys = argTys :+ TypeRepr.of[R]
-        val arity = argTys.size + existsUniquePosition.size
+        val arity = argTys.size + metaImpls.size
         TypeRepr.of[parsley.lift.type].typeSymbol.methodMember(s"lift$arity").headOption.map('{parsley.lift}.asTerm.select) match {
-            // FIXME: generalise
-            case Some(lift) => existsUniquePosition match {
-                case Some(impl@MetaImpl(_, given Type[metaTy])) =>
-                    val metaTyRepr = TypeRepr.of[metaTy]
-                    lift.appliedToTypes(metaTyRepr :: tys)
-                        .appliedToArgs(con :: impl.parser.asTerm :: args)
-                        .asExprOf[Parsley[R]]
-                case None =>
-                    lift.appliedToTypes(tys)
-                        .appliedToArgs(con :: args)
-                        .asExprOf[Parsley[R]]
-            }
+            case Some(lift) =>
+                val (metaTerms, metaReprs) = metaImpls.map(impl => (impl.parser.asTerm, impl.tyRepr)).unzip
+                lift.appliedToTypes(metaReprs ::: tys)
+                    .appliedToArgs(con :: metaTerms ::: args)
+                    .asExprOf[Parsley[R]]
             case None => report.errorAndAbort(s"No `lift` available for arity $arity")
         }
     }

--- a/parsley/shared/src/main/scala-3/parsley/generic/experimental/macro.scala
+++ b/parsley/shared/src/main/scala-3/parsley/generic/experimental/macro.scala
@@ -44,15 +44,13 @@ private class BridgeImpl(using Quotes) {
                 val metaImpls = categorisedArgs.flatten.collect {
                     case BridgeArg.Meta(impl) => impl
                 }
-                // FIXME: lift this
-                if (metaImpls.length >= 2) report.errorAndAbort("When `ParsableMeta` appears in a bridged type, it must be unique")
                 val metaReprs = metaImpls.map(_.tyRepr)
                 lazy val con = constructor[T](cls, bridgePrimaryArgs, tyArgs, categorisedArgs, metaReprs)
                 val lift = synthesiseLift[S](metaImpls, bridgePrimaryArgs.map(_._2), con, _)
                 val from = [Fn] => { (fnTy: Type[Fn]) =>
                     given Type[Fn] = fnTy
                     val curriedCon = curriedConstructor[Fn, T](cls, bridgePrimaryArgs, tyArgs, categorisedArgs, metaReprs)
-                    synthesiseSingle[Fn](metaImpls.headOption, curriedCon)
+                    synthesiseSingle[Fn](metaImpls, curriedCon)
                 }
                 // TODO: ensure validation if Err is encountered (report separately, but then abort if failed (Option))
                 synthesiseBridge[S](tyRepr.typeSymbol.name, bridgePrimaryArgs.map(_._2.asType), lift, from, labels, reason)
@@ -195,6 +193,7 @@ private class BridgeImpl(using Quotes) {
         val arity = argTys.size + metaImpls.size
         TypeRepr.of[parsley.lift.type].typeSymbol.methodMember(s"lift$arity").headOption.map('{parsley.lift}.asTerm.select) match {
             case Some(lift) =>
+                // TODO: factor this out and merge into argTys and args
                 val (metaTerms, metaReprs) = metaImpls.map(impl => (impl.parser.asTerm, impl.tyRepr)).unzip
                 lift.appliedToTypes(metaReprs ::: tys)
                     .appliedToArgs(con :: metaTerms ::: args)
@@ -203,10 +202,13 @@ private class BridgeImpl(using Quotes) {
         }
     }
 
-    private def synthesiseSingle[R: Type](existsUniquePosition: Option[MetaImpl[?]], con: Term): Expr[Parsley[R]] = existsUniquePosition match {
-        // FIXME: generalise
-        case Some(impl@MetaImpl(_, given Type[metaTy])) => '{${impl.parser}.map[R](${con.asExprOf[metaTy => R]})}
-        case None => '{Parsley.pure[R](${con.asExprOf[R]})}
+    private def synthesiseSingle[R: Type](metaImpls: List[MetaImpl[?]], con: Term): Expr[Parsley[R]] = {
+        if (metaImpls.isEmpty) '{Parsley.pure[R](${con.asExprOf[R]})}
+        else {
+            // TODO: factor this out
+            val (metaTerms, metaReprs) = metaImpls.map(impl => (impl.parser.asTerm, impl.tyRepr)).unzip
+            synthesiseLift[R](Nil, metaReprs, con, metaTerms)
+        }
     }
 
     private def synthesiseBridge[R: Type](n: String, argTys: List[Type[?]], lift: List[Term] => Expr[Parsley[R]], single: [T] => Type[T] => Expr[Parsley[T]], errLabels: Expr[List[String]], errReason: Expr[Option[String]]): Expr[ErrorBridge] = (argTys.size: @switch) match {

--- a/parsley/shared/src/main/scala-3/parsley/generic/experimental/macro.scala
+++ b/parsley/shared/src/main/scala-3/parsley/generic/experimental/macro.scala
@@ -41,16 +41,15 @@ private class BridgeImpl(using Quotes) {
                 val bridgePrimaryArgs = bridgeParams.collect {
                     case sym if !hasMeta(sym) => (sym.name, contextualise(tyRepr.memberType(sym)))
                 }
-                val metaImpls = categorisedArgs.flatten.collect {
-                    case BridgeArg.Meta(impl) => impl
-                }
-                val metaReprs = metaImpls.map(_.tyRepr)
+                val (metaTerms, metaReprs) = categorisedArgs.flatten.collect {
+                    case BridgeArg.Meta(impl) => (impl.parser.asTerm, impl.tyRepr)
+                }.unzip
                 lazy val con = constructor[T](cls, bridgePrimaryArgs, tyArgs, categorisedArgs, metaReprs)
-                val lift = synthesiseLift[S](metaImpls, bridgePrimaryArgs.map(_._2), con, _)
+                val lift = (terms: List[Term]) => synthesiseLift[S](metaReprs ::: bridgePrimaryArgs.map(_._2), con, metaTerms ::: terms)
                 val from = [Fn] => { (fnTy: Type[Fn]) =>
                     given Type[Fn] = fnTy
                     val curriedCon = curriedConstructor[Fn, T](cls, bridgePrimaryArgs, tyArgs, categorisedArgs, metaReprs)
-                    synthesiseSingle[Fn](metaImpls, curriedCon)
+                    synthesiseSingle[Fn](metaReprs, metaTerms, curriedCon)
                 }
                 // TODO: ensure validation if Err is encountered (report separately, but then abort if failed (Option))
                 synthesiseBridge[S](tyRepr.typeSymbol.name, bridgePrimaryArgs.map(_._2.asType), lift, from, labels, reason)
@@ -188,27 +187,21 @@ private class BridgeImpl(using Quotes) {
         saturated
     }
 
-    private def synthesiseLift[R: Type](metaImpls: List[MetaImpl[?]], argTys: List[TypeRepr], con: Term, args: List[Term]): Expr[Parsley[R]] = {
+    private def synthesiseLift[R: Type](argTys: List[TypeRepr], con: Term, args: List[Term]): Expr[Parsley[R]] = {
         val tys = argTys :+ TypeRepr.of[R]
-        val arity = argTys.size + metaImpls.size
+        val arity = argTys.size
         TypeRepr.of[parsley.lift.type].typeSymbol.methodMember(s"lift$arity").headOption.map('{parsley.lift}.asTerm.select) match {
             case Some(lift) =>
-                // TODO: factor this out and merge into argTys and args
-                val (metaTerms, metaReprs) = metaImpls.map(impl => (impl.parser.asTerm, impl.tyRepr)).unzip
-                lift.appliedToTypes(metaReprs ::: tys)
-                    .appliedToArgs(con :: metaTerms ::: args)
+                lift.appliedToTypes(tys)
+                    .appliedToArgs(con :: args)
                     .asExprOf[Parsley[R]]
             case None => report.errorAndAbort(s"No `lift` available for arity $arity")
         }
     }
 
-    private def synthesiseSingle[R: Type](metaImpls: List[MetaImpl[?]], con: Term): Expr[Parsley[R]] = {
-        if (metaImpls.isEmpty) '{Parsley.pure[R](${con.asExprOf[R]})}
-        else {
-            // TODO: factor this out
-            val (metaTerms, metaReprs) = metaImpls.map(impl => (impl.parser.asTerm, impl.tyRepr)).unzip
-            synthesiseLift[R](Nil, metaReprs, con, metaTerms)
-        }
+    private def synthesiseSingle[R: Type](metaReprs: List[TypeRepr], metaTerms: List[Term], con: Term): Expr[Parsley[R]] = {
+        if (metaTerms.isEmpty) '{Parsley.pure[R](${con.asExprOf[R]})}
+        else synthesiseLift[R](metaReprs, con, metaTerms)
     }
 
     private def synthesiseBridge[R: Type](n: String, argTys: List[Type[?]], lift: List[Term] => Expr[Parsley[R]], single: [T] => Type[T] => Expr[Parsley[T]], errLabels: Expr[List[String]], errReason: Expr[Option[String]]): Expr[ErrorBridge] = (argTys.size: @switch) match {

--- a/parsley/shared/src/main/scala-3/parsley/generic/experimental/macro.scala
+++ b/parsley/shared/src/main/scala-3/parsley/generic/experimental/macro.scala
@@ -49,7 +49,7 @@ private class BridgeImpl(using Quotes) {
                 val from = [Fn] => { (fnTy: Type[Fn]) =>
                     given Type[Fn] = fnTy
                     val curriedCon = curriedConstructor[Fn, T](cls, bridgePrimaryArgs, tyArgs, categorisedArgs, metaReprs)
-                    synthesiseSingle[Fn](metaReprs, metaTerms, curriedCon)
+                    synthesiseLift[Fn](metaReprs, curriedCon, metaTerms)
                 }
                 // TODO: ensure validation if Err is encountered (report separately, but then abort if failed (Option))
                 synthesiseBridge[S](tyRepr.typeSymbol.name, bridgePrimaryArgs.map(_._2.asType), lift, from, labels, reason)
@@ -187,6 +187,7 @@ private class BridgeImpl(using Quotes) {
         saturated
     }
 
+    // note that `lift0 = pure`, so this handles even for pure constructs
     private def synthesiseLift[R: Type](argTys: List[TypeRepr], con: Term, args: List[Term]): Expr[Parsley[R]] = {
         val tys = argTys :+ TypeRepr.of[R]
         val arity = argTys.size
@@ -197,11 +198,6 @@ private class BridgeImpl(using Quotes) {
                     .asExprOf[Parsley[R]]
             case None => report.errorAndAbort(s"No `lift` available for arity $arity")
         }
-    }
-
-    private def synthesiseSingle[R: Type](metaReprs: List[TypeRepr], metaTerms: List[Term], con: Term): Expr[Parsley[R]] = {
-        if (metaTerms.isEmpty) '{Parsley.pure[R](${con.asExprOf[R]})}
-        else synthesiseLift[R](metaReprs, con, metaTerms)
     }
 
     private def synthesiseBridge[R: Type](n: String, argTys: List[Type[?]], lift: List[Term] => Expr[Parsley[R]], single: [T] => Type[T] => Expr[Parsley[T]], errLabels: Expr[List[String]], errReason: Expr[Option[String]]): Expr[ErrorBridge] = (argTys.size: @switch) match {

--- a/parsley/shared/src/main/scala/parsley/lift.scala
+++ b/parsley/shared/src/main/scala/parsley/lift.scala
@@ -45,6 +45,12 @@ import parsley.internal.deepembedding.frontend
 object lift extends lift
 private [parsley] trait lift {
     // scalastyle:off parameter.number ensure.single.space.after.token
+    /** Effectively alias for `pure`, to be consistent with the other `lift` variants.
+      *
+      * @param x the value to return
+      * @return a parser that returns `x`.
+      */
+    final def lift0[R](x: R): Parsley[R] = pure(x).uo("lift0")
     /** This combinator allows the result of a given parser to be changed using a given function.
       *
       * Effectively alias for `map`, to be consistent with the other `lift` variants.

--- a/parsley/shared/src/test/scala-3/BridgeMacro.scala
+++ b/parsley/shared/src/test/scala-3/BridgeMacro.scala
@@ -24,7 +24,7 @@ case class A22[A](x1: A, x2: A, x3: A, x4: A, x5: A, x6: A, x7: A, x8: A, x9: A,
 case class A23[A](x1: A, x2: A, x3: A, x4: A, x5: A, x6: A, x7: A, x8: A, x9: A, x10: A, x11: A, x12: A, x13: A, x14: A, x15: A, x16: A, x17: A, x18: A, x19: A, x20: A, x21: A, x22: A, x23: A)
 
 object Single
-case class SinglePos()(@isMeta val p: Pos)
+case class SinglePos()(@isMeta val p: Pos, @isMeta val lc: (Int, Int))
 
 /*enum Baz[A] {
     case Add(x: Baz[A], y: Baz[A])


### PR DESCRIPTION
Lifts the restriction that an `isMeta` annotation can only be used once per constructor. Instead, this will now handle an arbitrary number of them.