### PR TITLE
Fixed covariant `enum` case bridges

### DIFF
--- a/parsley/shared/src/main/scala-3/parsley/macros/macro.scala
+++ b/parsley/shared/src/main/scala-3/parsley/macros/macro.scala
@@ -33,7 +33,10 @@ private class BridgeImpl(using Quotes) {
         val tyArgs = tyRepr.typeArgs
         tyRepr match {
             // there must be the same number of type arguments as type params, or this is a higher-kinded T (oops!)
-            case Bridgeable(cls, tyParams, bridgeParams, otherParams) if tyArgs.lengthCompare(tyParams) == 0 =>
+            // NOTE: this was changed from == 0 to <= 0, as covariant enums with a Nothing-based case will have fewer arguments
+            // compared to their type (as singletons are encoded to vals not object). If HKTs become an issue, then
+            // we'll have to find a different way to rule them out (it may be that these would result in > 0, I can't remember the exact case)
+            case Bridgeable(cls, tyParams, bridgeParams, otherParams) if tyArgs.lengthCompare(tyParams) <= 0 =>
                 def contextualise(ty: TypeRepr) = ty.substituteTypes(tyParams, tyArgs)
                 val categorisedArgs = categoriseArgs(cls, bridgeParams :: otherParams, 1, primary = true, mutable.ListBuffer.empty, contextualise)
                 // Used for the types of the lambda passed to combinator

--- a/parsley/shared/src/test/scala-3/BridgeMacro.scala
+++ b/parsley/shared/src/test/scala-3/BridgeMacro.scala
@@ -45,6 +45,9 @@ type Unital[T[_]] = T[Unit]
 
 val fooUnit = bridge[Unital[Foo]]
 
+class UnitalC[T[_]](val x: T[Int])
+val fooUnitC = bridge[UnitalC[List]]
+
 case class Empty()
 val empty = bridge[Empty]
 
@@ -60,3 +63,8 @@ val zero = bridge[Nat.Zero.type]
 
 case class EmptyT[T]()
 val emptyInt = bridge[EmptyT[Int]]
+
+enum Co[+A] {
+    case Single
+}
+val CoSingle = bridge[Co.Single.type]


### PR DESCRIPTION
When an enum is of the form:

```scala
enum Co[+A] {
  case X
}
```

An attempt to bridge `Co.X` would fail as the number of type parameters of `Co.X.type` (which isn't really real) does not match `Co` itself. By lifting the equal length arguments check, this case is admitted, but may let higher-kinded types (for which the restriction was put in place to prevent) slip through the net.